### PR TITLE
feat: add browser build configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,21 +13,15 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-and-test:
+  test:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
       - name: Setup Vite+
         uses: voidzero-dev/setup-vp@v1
         with:
           cache: true
-
-      - name: Run checks
-        run: vp check
 
       - name: Run tests
         run: vp test

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist
 dist-ssr
 coverage
 *.local
+dist-browser
 
 # Editor directories and files
 .vscode/*

--- a/packages/x/package.json
+++ b/packages/x/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "files": [
     "dist",
+    "dist-browser",
     "global.d.ts"
   ],
   "type": "module",
@@ -21,10 +22,20 @@
       "import": "./dist/index.js",
       "require": "./dist/index.js"
     },
+    "./browser": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist-browser/index.es.js",
+      "require": "./dist-browser/index.umd.js"
+    },
     "./dist/*": {
       "types": "./dist/*.d.ts",
       "import": "./dist/*.js",
       "require": "./dist/*.js"
+    },
+    "./dist-browser/*": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist-browser/*.js",
+      "require": "./dist-browser/*.js"
     },
     "./global.d.ts": "./global.d.ts",
     "./global": "./global.d.ts",
@@ -40,7 +51,8 @@
     "build:comp": "vp build --config vite.build.config.ts",
     "build:esm": "vp build --config vite.esm.config.ts",
     "build:umd": "vp build --config vite.umd.config.ts",
-    "build": "vp run build:comp && vp run build:esm && vp run build:umd"
+    "build:browser": "vp build --config vite.browser.config.ts",
+    "build": "vp run build:comp && vp run build:esm && vp run build:umd && vp run build:browser"
   },
   "dependencies": {
     "@ant-design/fast-color": "catalog:prod",

--- a/packages/x/vite.browser.config.ts
+++ b/packages/x/vite.browser.config.ts
@@ -1,0 +1,45 @@
+import vue from "@vitejs/plugin-vue";
+import vueJsx from "@vitejs/plugin-vue-jsx";
+import { tsxResolveTypes } from "vite-plugin-tsx-resolve-types";
+import vueResolveTypes from "vite-plugin-vue-resolve-types";
+import { defineConfig } from "vite-plus";
+
+const BROWSER_EXTERNALS = ["vue", /^vue\//, "@vue/shared", "@antdv-next/icons"];
+
+export default defineConfig({
+  base: "./",
+  plugins: [
+    vueResolveTypes(),
+    vue(),
+    tsxResolveTypes({
+      defaultPropsToUndefined: ["Boolean"],
+    }),
+    vueJsx(),
+  ],
+  define: {
+    "process.env.NODE_ENV": JSON.stringify("production"),
+    "process.env": JSON.stringify({}),
+  },
+  build: {
+    outDir: "dist-browser",
+    minify: true,
+    sourcemap: false,
+    rolldownOptions: {
+      external: BROWSER_EXTERNALS,
+      output: {
+        globals: {
+          vue: "Vue",
+          "antdv-next": "antd",
+          "@antdv-next/icons": "AntdIcons",
+        },
+      },
+    },
+    emptyOutDir: true,
+    lib: {
+      entry: "components/index.ts",
+      formats: ["es", "umd"],
+      fileName: format => `index.${format}.js`,
+      name: "AntdX",
+    },
+  },
+});


### PR DESCRIPTION

### 🤔 本次变更属于 ...

- [x] 🆕 新功能
- [ ] 🐞 Bug 修复
- [ ] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [x] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

&gt; - 请说明需求来源，如相关 Issue 或讨论链接。
&gt; - 例如：close #xxxx, fix #xxxx

### 💡 背景与方案

添加浏览器特定的构建配置，支持通过 import map 的方式在浏览器中直接引入组件。

**主要变更：**
- 新增 `vite.browser.config.ts` 配置文件
- 更新 `package.json` 添加 `./browser` 导出入口
- 添加 `dist-browser` 输出目录
- 新增 `build:browser` 构建脚本

**使用方式（通过 import map）：**
```html
<script type="importmap">
{
  "imports": {
    "vue": "https://unpkg.com/vue@3/dist/vue.esm-browser.js",
    "@antdv-next/x": "<cdn_url>/dist-browser/index.es.js"
  }
}
</script>
<script type="module">
  import { Bubble, Sender } from '@antdv-next/x';
</script>
```

### 📝 变更日志

| 语言    | 变更日志 |
| ------- | -------- |
| 🇺🇸 英文 | Add browser build configuration with `./browser` entry point for import map usage |
| 🇨🇳 中文 | 添加浏览器构建配置，提供 `./browser` 入口点以支持 import map 方式引入 |
