### PR TITLE
fix: update Image component prop from class to rootClass in XFileCard

### DIFF
--- a/packages/x/components/file-card/FileCard.tsx
+++ b/packages/x/components/file-card/FileCard.tsx
@@ -368,7 +368,7 @@ export const XFileCard = defineComponent({
             style={mergedStyles.value.file}
           >
             <Image
-              class={`${props.prefixCls}-image-img`}
+              rootClass={`${props.prefixCls}-image-img`}
               width={mergedStyles.value.file?.width}
               height={mergedStyles.value.file?.height}
               alt={props.name}


### PR DESCRIPTION
[English template / 英文模板](./PULL_REQUEST_TEMPLATE.md)

### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [x] 🐞 Bug 修复
- [ ] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

close #70

### 💡 背景与方案

- 问题：FileCard 组件中 Image 组件使用了错误的 prop `class`，应该使用 `rootClass`
- 影响：图片样式无法正确应用

### 📝 变更日志

&gt; - 建议阅读 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)。
&gt; - 变更日志应描述对开发者的影响，而不是实现过程。

| 语言    | 变更日志 |
| ------- | -------- |
| 🇺🇸 英文 | fix: update Image component prop from `class` to `rootClass` in XFileCard |
| 🇨🇳 中文 | 修复：XFileCard 中 Image 组件 prop 从 `class` 更新为 `rootClass` |
