### PR TITLE
fix(bubble): refactor content rendering logic to support dynamic content slot

### DIFF
--- a/packages/x/components/bubble/Bubble.tsx
+++ b/packages/x/components/bubble/Bubble.tsx
@@ -163,7 +163,13 @@ export const XBubble = defineComponent({
       return rest;
     });
 
-    const memoedContent = computed(() => {
+    const fallbackContent = computed(() => {
+      return props.contentRender
+        ? props.contentRender(props.content as never, props.info)
+        : props.content;
+    });
+
+    const resolveMainContent = () => {
       if (slots.content) {
         const slotNode = slots.content({
           content: props.content,
@@ -172,10 +178,8 @@ export const XBubble = defineComponent({
         if (hasRenderableNode(slotNode)) return slotNode;
       }
 
-      return props.contentRender
-        ? props.contentRender(props.content as never, props.info)
-        : props.content;
-    });
+      return fallbackContent.value;
+    };
 
     const mergedTyping = computed(() => {
       if (typeof props.typing === "function")
@@ -185,22 +189,22 @@ export const XBubble = defineComponent({
 
     const usingInnerAnimation = computed(() => {
       return (
-        Boolean(mergedTyping.value) && typeof memoedContent.value === "string"
+        Boolean(mergedTyping.value) && typeof fallbackContent.value === "string"
       );
     });
 
     watch(
       () =>
         [
-          memoedContent.value,
+          fallbackContent.value,
           usingInnerAnimation.value,
           props.streaming,
         ] as const,
       () => {
         if (usingInnerAnimation.value) return;
         if (props.streaming) return;
-        if (typeof memoedContent.value === "string")
-          props.onTypingComplete?.(memoedContent.value);
+        if (typeof fallbackContent.value === "string")
+          props.onTypingComplete?.(fallbackContent.value);
       },
       { immediate: true },
     );
@@ -275,7 +279,10 @@ export const XBubble = defineComponent({
       );
     };
 
-    const renderMainContent = () => {
+    const renderMainContent = (
+      mainContent: ReturnType<typeof resolveMainContent>,
+      usingInnerAnimationInRender: boolean,
+    ) => {
       if (isEditing.value) {
         if (typeof props.content !== "string")
           throw new Error(
@@ -299,17 +306,17 @@ export const XBubble = defineComponent({
       }
 
       const defaultMainContent =
-        usingInnerAnimation.value && typeof memoedContent.value === "string" ? (
+        usingInnerAnimationInRender && typeof mainContent === "string" ? (
           <TypingContent
             prefixCls={props.prefixCls}
             streaming={props.streaming}
             typing={mergedTyping.value as true | BubbleAnimationOption}
-            content={memoedContent.value}
+            content={mainContent}
             onTyping={props.onTyping}
             onTypingComplete={props.onTypingComplete}
           />
         ) : (
-          memoedContent.value
+          mainContent
         );
 
       return defaultMainContent;
@@ -331,6 +338,10 @@ export const XBubble = defineComponent({
         return <Loading prefixCls={props.prefixCls} />;
       }
 
+      const mainContent = resolveMainContent();
+      const usingInnerAnimationInRender =
+        Boolean(mergedTyping.value) && typeof mainContent === "string";
+
       return (
         <div class={getSlotClassName("body")} style={getSlotStyle("body")}>
           {renderHeader()}
@@ -343,7 +354,7 @@ export const XBubble = defineComponent({
               props.classes?.content,
               {
                 [`${prefixCls.value}-content-string`]:
-                  typeof memoedContent.value === "string",
+                  typeof mainContent === "string",
                 [`${prefixCls.value}-content-editing`]: isEditing.value,
                 [`${prefixCls.value}-content-${props.info.status}`]:
                   props.info.status,
@@ -357,12 +368,12 @@ export const XBubble = defineComponent({
             {isFooterInner.value ? (
               <>
                 <div class={`${prefixCls.value}-content-with-footer`}>
-                  {renderMainContent()}
+                  {renderMainContent(mainContent, usingInnerAnimationInRender)}
                 </div>
                 {!isEditing.value ? renderFooter() : null}
               </>
             ) : (
-              renderMainContent()
+              renderMainContent(mainContent, usingInnerAnimationInRender)
             )}
           </div>
           {!isEditing.value && !isFooterInner.value ? renderFooter() : null}

--- a/packages/x/components/bubble/__tests__/index.test.tsx
+++ b/packages/x/components/bubble/__tests__/index.test.tsx
@@ -1,7 +1,7 @@
 import { mount } from "@vue/test-utils";
 import zhCN from "antdv-next/dist/locale/zh_CN";
 import { describe, expect, it, vi } from "vite-plus/test";
-import { h, nextTick } from "vue";
+import { h, nextTick, ref } from "vue";
 
 import XProvider from "../../x-provider";
 import Bubble from "../Bubble";
@@ -131,6 +131,92 @@ describe("Bubble", () => {
 
     expect(wrapper.find(".content-render-slot").exists()).toBe(true);
     expect(wrapper.text()).toContain("SlotContent-content-key-success");
+  });
+
+  it("refreshes content when slot turns renderable after initial empty", async () => {
+    const slotText = ref("");
+    const wrapper = mount({
+      setup() {
+        return () => (
+          <Bubble content="fallback-content">
+            {{
+              content: () =>
+                slotText.value ? (
+                  <div class="dynamic-content-slot">{slotText.value}</div>
+                ) : null,
+            }}
+          </Bubble>
+        );
+      },
+    });
+
+    expect(wrapper.text()).toContain("fallback-content");
+    expect(wrapper.find(".dynamic-content-slot").exists()).toBe(false);
+
+    slotText.value = "slot-now-visible";
+    await nextTick();
+
+    expect(wrapper.find(".dynamic-content-slot").exists()).toBe(true);
+    expect(wrapper.text()).toContain("slot-now-visible");
+    expect(wrapper.text()).not.toContain("fallback-content");
+  });
+
+  it("refreshes content when slot output changes", async () => {
+    const slotText = ref("slot-v1");
+    const wrapper = mount({
+      setup() {
+        return () => (
+          <Bubble content="fallback-content">
+            {{
+              content: () => (
+                <div class="dynamic-content-slot">{slotText.value}</div>
+              ),
+            }}
+          </Bubble>
+        );
+      },
+    });
+
+    expect(wrapper.text()).toContain("slot-v1");
+
+    slotText.value = "slot-v2";
+    await nextTick();
+
+    expect(wrapper.text()).toContain("slot-v2");
+    expect(wrapper.text()).not.toContain("slot-v1");
+  });
+
+  it("falls back to contentRender when content slot becomes empty", async () => {
+    const showSlot = ref(true);
+    const wrapper = mount({
+      setup() {
+        return () => (
+          <Bubble
+            content="source-content"
+            contentRender={content => (
+              <div class="content-render-fallback">{`render-${content}`}</div>
+            )}
+          >
+            {{
+              content: () =>
+                showSlot.value ? (
+                  <div class="dynamic-content-slot">slot-render</div>
+                ) : null,
+            }}
+          </Bubble>
+        );
+      },
+    });
+
+    expect(wrapper.text()).toContain("slot-render");
+    expect(wrapper.find(".content-render-fallback").exists()).toBe(false);
+
+    showSlot.value = false;
+    await nextTick();
+
+    expect(wrapper.find(".dynamic-content-slot").exists()).toBe(false);
+    expect(wrapper.find(".content-render-fallback").exists()).toBe(true);
+    expect(wrapper.text()).toContain("render-source-content");
   });
 
   it("supports contentRender prop", () => {


### PR DESCRIPTION

### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [x] 🐞 Bug 修复
- [ ] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [x] ⭐️ 功能增强
- [ ] 🌐 国际化
- [x] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

&gt; - 修复 content slot 动态变化时无法正确更新的问题

### 💡 背景与方案

**问题：** 
- 当 content slot 从空变为有内容（或反之）时，Bubble 组件无法正确响应更新
- 原因是使用 computed 缓存了 content，导致 slot 变化时不会重新计算

**方案：**
- 将 `memoedContent` 拆分为 `fallbackContent` (computed) 和 `resolveMainContent()` (函数)
- `resolveMainContent()` 在每次渲染时调用，确保 slot 变化能被正确检测
- `renderMainContent()` 接收参数而非依赖闭包，避免状态不一致
- 添加完整的测试用例覆盖动态 slot 场景

### 📝 变更日志

| 语言    | 变更日志 |
| ------- | -------- |
| 🇺🇸 英文 | fix(bubble): refactor content rendering logic to support dynamic content slot |
| 🇨🇳 中文 | fix(bubble): 重构内容渲染逻辑以支持动态 content slot |
