### PR TITLE
docs(file-card): Fixed an issue where the image loading style for file-card was abnormal, and resolved an error caused by the absence of `message.useMessage()` in custom descriptions.

### DIFF
--- a/packages/docs/src/pages/components/file-card/demo/custom-description.vue
+++ b/packages/docs/src/pages/components/file-card/demo/custom-description.vue
@@ -3,8 +3,6 @@ import { DownloadOutlined } from "@antdv-next/icons";
 import { App } from "antdv-next";
 const { message } = App.useApp();
 
-const [messageApi, contextHolder] = message.useMessage();
-
 const fileData = [
   {
     name: "Project Document.docx",
@@ -24,12 +22,11 @@ const fileData = [
 ];
 
 const handleDownload = (url: string, fileName: string) => {
-  messageApi.info(`Clicked download: ${fileName},${url}`);
+  message.info(`Clicked download: ${fileName},${url}`);
 };
 </script>
 
 <template>
-  <component :is="contextHolder" />
   <a-flex vertical gap="middle">
     <ax-file-card
       v-for="(file, index) in fileData"

--- a/packages/docs/src/pages/components/file-card/demo/image-loading.vue
+++ b/packages/docs/src/pages/components/file-card/demo/image-loading.vue
@@ -62,7 +62,7 @@ onBeforeUnmount(() => {
       :loading="loading"
       :styles="{
         file: {
-          width: 200,
+          width: '200px',
         },
       }"
       :spin-props="{


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> N/A

### 💡 Background and Solution

> Background
> Chinese
>> - 在文档示例 FileCard 组件[图片加载](https://x.antdv-next.com/components/file-card#file-card-demo-image-loading)的示例中 "\<ax-file-card :styles="{ file: { width: 200 } }" \/\>" 需要 width: '200px' 携带单位才能正常生效，示例才表现正常

> English
>> - In the documentation example, the FileCard component in the [Image Loading](https://x.antdv-next.com/components/file-card#file-card-demo-image-loading) example: "\ In the documentation example, the `FileCard` component in the [Image Loading](https://x.antdv-next.com/components/file-card#file-card-demo-image-loading) example—“<ax-file-card :styles=”{ file: { width: 200 } }“ \/\>”—requires the `width: ‘200px’` property to include a unit in order to function properly; only then will the example display correctly.

<img width="401" height="769" alt="image" src="https://github.com/user-attachments/assets/567e5ed6-ed94-4782-ac3f-4fcbae1e28a3" />
<br />

> Background
> Chinese
>> - 在文档示例 FileCard 组件[自定义描述](https://x.antdv-next.com/components/file-card#file-card-demo-custom-description)的示例中，由于 message.useMessage() 不存在引起报错，导致示例无法正常渲染显示问题

> English
>> - In the example for the FileCard component [Custom Description](https://x.antdv-next.com/components/file-card#file-card-demo-custom-description), an error occurs because `message.useMessage()` does not exist, preventing the example from rendering and displaying properly.

<img width="470" height="213" alt="image" src="https://github.com/user-attachments/assets/a0852f8e-f7bb-4c7b-83ca-84c50b7a24bf" />


### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.
> - Reference: https://ant.design/changelog

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed an issue where the image loading style for file-card was abnormal, and resolved an error caused by the absence of `message.useMessage()` in custom descriptions. |
| 🇨🇳 Chinese | 修复 file-card 卡片图片加载样式异常问题，自定义描述由于 message.useMessage() 不存在引起报错问题 |
