### PR TITLE
feat(sender): use Flex component for action presets layout

### DIFF
--- a/packages/x/components/sender/Sender.tsx
+++ b/packages/x/components/sender/Sender.tsx
@@ -1,6 +1,7 @@
 import type { PropType, StyleValue } from "vue";
 import type { CSSProperties } from "vue";
 
+import { Flex } from "antdv-next";
 import { useConfig } from "antdv-next/config-provider/context";
 import { computed, defineComponent, ref, useAttrs, watch } from "vue";
 
@@ -363,10 +364,10 @@ export default defineComponent({
       const actionListCls = `${cls}-actions-list`;
 
       const actionNode = (
-        <div class={`${actionListCls}-presets`}>
+        <Flex class={`${actionListCls}-presets`}>
           {props.allowSpeech && <SpeechButton />}
           {props.loading ? <LoadingButton /> : <SendButton />}
-        </div>
+        </Flex>
       );
 
       const suffixNode =

--- a/packages/x/components/sender/__tests__/index.test.tsx
+++ b/packages/x/components/sender/__tests__/index.test.tsx
@@ -1,7 +1,11 @@
 import { mount } from "@vue/test-utils";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import Sender from "..";
+
+beforeEach(() => {
+  document.head.innerHTML = "";
+});
 
 describe("Sender", () => {
   it("should render with default props", () => {
@@ -115,6 +119,15 @@ describe("Sender", () => {
     const wrapper = mount(Sender);
     const buttons = wrapper.findAll("button");
     expect(buttons.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("should render action presets with Flex", () => {
+    const wrapper = mount(Sender, {
+      props: { allowSpeech: true },
+    });
+
+    const presets = wrapper.find(".antd-sender-actions-list-presets");
+    expect(presets.classes()).toContain("ant-flex");
   });
 
   it("should render loading button when loading", () => {


### PR DESCRIPTION
## Summary

- Replace `<div>` with `<Flex>` for action presets layout in Sender component
- Add test to verify Flex rendering in action presets
- Add `beforeEach` cleanup for document head in tests