### PR TITLE
feat(suggestion): support v-model open

### DIFF
--- a/packages/x/components/suggestion/Suggestion.tsx
+++ b/packages/x/components/suggestion/Suggestion.tsx
@@ -57,7 +57,7 @@ const XSuggestion = defineComponent({
       default: false,
     },
   },
-  emits: ["openChange", "select"],
+  emits: ["update:open", "openChange", "select"],
   setup(props, { slots, emit }) {
     const attrs = useAttrs();
     const configCtx = useConfig();
@@ -116,6 +116,7 @@ const XSuggestion = defineComponent({
         innerOpen.value = nextOpen;
       }
 
+      emit("update:open", nextOpen);
       emit("openChange", nextOpen);
     };
 

--- a/packages/x/components/suggestion/__tests__/index.test.tsx
+++ b/packages/x/components/suggestion/__tests__/index.test.tsx
@@ -81,6 +81,28 @@ describe("Suggestion", () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
+  it("emits update:open when open state changes", async () => {
+    const wrapper = track(
+      mount(Suggestion, {
+        attachTo: document.body,
+        props: {
+          items,
+        },
+        slots: createSlot(),
+      }),
+    );
+
+    await wrapper.find(".trigger-input").trigger("keydown", { key: "@" });
+    await flush();
+
+    expect(wrapper.emitted("update:open")).toEqual([[true]]);
+
+    await wrapper.find(".trigger-input").trigger("keydown", { key: "Delete" });
+    await flush();
+
+    expect(wrapper.emitted("update:open")).toEqual([[true], [false]]);
+  });
+
   it("emits select with value and selected path", async () => {
     const onSelect = vi.fn();
     const wrapper = track(


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](./PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

Refs #85

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

Suggestion supports an `open` state, but consumers could not listen to open state changes through Vue's `v-model:open` convention.

This PR emits `update:open` when the Suggestion open state changes and adds regression coverage for `v-model:open`.

Tested with:

- `vp test packages/x/components/suggestion/__tests__/index.test.tsx`

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Suggestion now supports `v-model:open` for controlling open state. |
| 🇨🇳 Chinese | Suggestion 现在支持通过 `v-model:open` 控制展开状态。 |