### PR TITLE
feat(sender): support v-model value

### DIFF
--- a/packages/x/components/sender/Sender.tsx
+++ b/packages/x/components/sender/Sender.tsx
@@ -154,7 +154,8 @@ export default defineComponent({
       default: undefined,
     },
   },
-  setup(props, { expose, slots }) {
+  emits: ["update:value"],
+  setup(props, { expose, slots, emit }) {
     const attrs = useAttrs();
     const configCtx = useConfig();
     const contextConfig = useXComponentConfig("sender");
@@ -186,6 +187,7 @@ export default defineComponent({
       skill?: SkillType,
     ) => {
       innerValue.value = nextValue;
+      emit("update:value", nextValue);
       props.onChange?.(nextValue, event, slotConfig, skill);
     };
 

--- a/packages/x/components/sender/__tests__/index.test.tsx
+++ b/packages/x/components/sender/__tests__/index.test.tsx
@@ -43,6 +43,15 @@ describe("Sender", () => {
     expect(args[1]).toBeDefined();
   });
 
+  it("emits update:value when value changes", async () => {
+    const wrapper = mount(Sender);
+
+    const textarea = wrapper.find("textarea");
+    await textarea.setValue("hello");
+
+    expect(wrapper.emitted("update:value")).toEqual([["hello"]]);
+  });
+
   it("should support controlled value", async () => {
     const wrapper = mount(Sender, {
       props: { value: "controlled" },


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](./PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

Refs #85

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

Sender exposes a `value` state, but consumers could not use Vue's `v-model:value` convention to receive value updates.

This PR emits `update:value` when Sender value changes and adds regression coverage for `v-model:value`.

Tested with:

- `vp test packages/x/components/sender/__tests__/index.test.tsx`

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Sender now supports `v-model:value` for syncing input value changes. |
| 🇨🇳 Chinese | Sender 现在支持通过 `v-model:value` 同步输入值变化。 |