### PR TITLE
feat(sources): support v-model expanded

### DIFF
--- a/packages/x/components/sources/Sources.tsx
+++ b/packages/x/components/sources/Sources.tsx
@@ -84,7 +84,7 @@ export const XSources = defineComponent({
       default: undefined,
     },
   },
-  emits: ["expand"],
+  emits: ["update:expanded", "expand"],
   setup(props, { slots, expose, emit }) {
     const configCtx = useConfig();
     const attrs = useAttrs();
@@ -115,6 +115,7 @@ export const XSources = defineComponent({
     const toggleExpand = () => {
       const newExpand = !isExpand.value;
       if (props.expanded === undefined) innerExpanded.value = newExpand;
+      emit("update:expanded", newExpand);
       emit("expand", newExpand);
     };
 

--- a/packages/x/components/sources/__tests__/index.test.tsx
+++ b/packages/x/components/sources/__tests__/index.test.tsx
@@ -68,6 +68,21 @@ describe("Sources", () => {
     expect(wrapper.findAll(".slot-description")[0]?.text()).toBe("desc-1");
   });
 
+  it("emits update:expanded when title is clicked", async () => {
+    const wrapper = mount(Sources, {
+      props: {
+        title: "Used 2 sources",
+        items,
+        defaultExpanded: true,
+      },
+    });
+
+    await wrapper.find(".antdx-sources-title-wrapper").trigger("click");
+
+    expect(wrapper.emitted("update:expanded")).toEqual([[false]]);
+    expect(wrapper.emitted("expand")).toEqual([[false]]);
+  });
+
   it("supports item slots in carousel card", () => {
     const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](./PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

Refs #85

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

Sources exposes an expanded state, but consumers could not sync expand and collapse changes through Vue's `v-model:expanded` convention.

This PR emits `update:expanded` when Sources expand state changes and adds regression coverage for `v-model:expanded`.

Tested with:

- `vp test packages/x/components/sources/__tests__/index.test.tsx`

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Sources now supports `v-model:expanded` for syncing expand state changes. |
| 🇨🇳 Chinese | Sources 现在支持通过 `v-model:expanded` 同步展开状态变化。 |