### PR TITLE
feat(attachments): support v-model items

### DIFF
--- a/packages/x/components/attachments/__tests__/index.test.tsx
+++ b/packages/x/components/attachments/__tests__/index.test.tsx
@@ -1,0 +1,25 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vite-plus/test";
+
+import Attachments from "../index";
+
+describe("Attachments", () => {
+  it("emits update:items when file list changes", async () => {
+    const wrapper = mount(Attachments);
+    const file = new File(["hello"], "hello.txt", { type: "text/plain" });
+    Object.defineProperty(file, "uid", {
+      value: "file-1",
+      configurable: true,
+    });
+
+    await wrapper
+      .findComponent({ name: "AUpload" })
+      .vm.$emit("change", { file, fileList: [file] });
+
+    expect(wrapper.emitted("update:items")).toEqual([[[file]]]);
+    expect(wrapper.emitted("change")?.[0]?.[0]).toMatchObject({
+      file,
+      fileList: [file],
+    });
+  });
+});

--- a/packages/x/components/attachments/index.tsx
+++ b/packages/x/components/attachments/index.tsx
@@ -201,7 +201,7 @@ const XAttachments = defineComponent({
       default: true,
     },
   },
-  emits: ["change"],
+  emits: ["update:items", "change"],
   setup(props, { attrs, emit, slots, expose }) {
     const configCtx = useConfig();
     const contextConfig = useXComponentConfig("attachments");
@@ -239,6 +239,7 @@ const XAttachments = defineComponent({
       fileList: Attachment[];
     }) => {
       fileList.value = info.fileList as FileListAttachment[];
+      emit("update:items", info.fileList);
       emit("change", info);
     };
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](./PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - Describe the source of related requirements, such as links to relevant issue discussions.
> - For example: close #xxxx, fix #xxxx

Refs #85

### 💡 Background and Solution

> - The specific problem to be addressed.
> - List the final API implementation and usage if needed.
> - If there are UI/interaction changes, consider providing screenshots or GIFs.

Attachments exposes an `items` file list, but consumers could not sync list changes through Vue's `v-model:items` convention.

This PR emits `update:items` when Attachments items change and adds regression coverage for `v-model:items`.

Tested with:

- `vp test packages/x/components/attachments/__tests__/index.test.tsx`

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Attachments now supports `v-model:items` for syncing file list changes. |
| 🇨🇳 Chinese | Attachments 现在支持通过 `v-model:items` 同步文件列表变化。 |