### PR TITLE
chore: add .worktrees to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 .DS_Store
+.worktrees
 dist
 dist-ssr
 coverage

--- a/packages/docs/src/assets/styles/index.css
+++ b/packages/docs/src/assets/styles/index.css
@@ -1,6 +1,8 @@
-@layer reset, preflights, default, markdown, antd, layout, common, components, utilities;
+@layer reset, preflights, default, markdown, antdx, layout, common, components, utilities;
 
 @import "antdv-next/dist/reset.css" layer(reset);
-@import "antdv-next/dist/antd.css" layer(antd);
+/* antdv-next styles must use the same layer name as the top-level @layer declaration. */
+@import "antdv-next/dist/antd.css" layer(antdx);
+/* markdown styles also keep a unified layer name with the top-level @layer declaration. */
 @import "./markdown/index.css" layer(markdown);
 @import "./common.css" layer(common);


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](./PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [x] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

N/A

### 💡 Background and Solution

Add `.worktrees` to `.gitignore` to prevent accidental commits of git worktree metadata when using `git worktree`.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add .worktrees to .gitignore to exclude git worktree metadata |
| 🇨🇳 Chinese | 在 .gitignore 中添加 .worktrees，排除 git worktree 元数据 |
