### PR TITLE
docs: add version tag display in sidebar navigation

### DIFF
--- a/packages/docs/src/components/component-overview/data.ts
+++ b/packages/docs/src/components/component-overview/data.ts
@@ -10,6 +10,7 @@ export interface ComponentOverviewItem {
   groupOrder: number;
   cover: string;
   coverDark: string;
+  tag?: string;
 }
 
 export const componentOverviewItems: ComponentOverviewItem[] = [

--- a/packages/docs/src/layouts/docs/index.vue
+++ b/packages/docs/src/layouts/docs/index.vue
@@ -148,6 +148,7 @@ interface ParsedPageMeta {
   groupTitle?: string;
   groupOrder?: number;
   hidden?: boolean;
+  tag?: string;
 }
 
 const docsRawPageLoaders = import.meta.glob("../../pages/**/*.md", {
@@ -191,6 +192,8 @@ function parseFrontmatterMeta(markdown: string): ParsedPageMeta {
   const order = toOptionalNumber(frontmatter.match(/^order:\s*(.+)$/m)?.[1]);
   const hidden = toOptionalBoolean(frontmatter.match(/^hidden:\s*(.+)$/m)?.[1]);
 
+  const tag = toOptionalText(frontmatter.match(/^tag:\s*(.+)$/m)?.[1]);
+
   const groupBlock = frontmatter.match(/^group:\s*\n((?:[ \t].*\n?)*)/m)?.[1];
   const groupTitle = toOptionalText(
     groupBlock?.match(/^[ \t]+title:\s*(.+)$/m)?.[1],
@@ -202,6 +205,7 @@ function parseFrontmatterMeta(markdown: string): ParsedPageMeta {
   return {
     title,
     subtitle,
+    tag,
     order,
     groupTitle,
     groupOrder,
@@ -229,6 +233,7 @@ function getFallbackPageMeta(
     title: meta.title,
     groupTitle: meta.group[localeKey],
     groupOrder: meta.groupOrder,
+    tag: meta.tag,
   };
 }
 
@@ -249,6 +254,7 @@ function createGroupedSiderItems(
     isSectionIndex: boolean;
     groupTitle?: string;
     groupOrder: number;
+    tag?: string;
   }>,
 ) {
   const visibleItems = items.filter(item => !item.hidden);
@@ -258,7 +264,10 @@ function createGroupedSiderItems(
   const ungroupedItems = contentItems
     .filter(item => !item.groupTitle)
     .sort(sortSiderEntries)
-    .map(({ key, label }) => ({ key, label }));
+    .map(
+      ({ key, label, tag }) =>
+        ({ key, label, tag }) as MenuItemType & { tag?: string },
+    );
 
   const groups = new Map<
     string,
@@ -266,7 +275,13 @@ function createGroupedSiderItems(
       key: string;
       label: string;
       order: number;
-      children: Array<{ key: string; label: string; order: number }>;
+      tag?: string;
+      children: Array<{
+        key: string;
+        label: string;
+        order: number;
+        tag?: string;
+      }>;
     }
   >();
 
@@ -289,6 +304,7 @@ function createGroupedSiderItems(
         key: item.key,
         label: item.label,
         order: item.order,
+        tag: item.tag,
       });
     });
 
@@ -300,12 +316,21 @@ function createGroupedSiderItems(
       label: group.label,
       children: group.children
         .sort(sortSiderEntries)
-        .map(({ key, label }) => ({ key, label })),
+        .map(
+          ({ key, label, tag }) =>
+            ({ key, label, tag }) as MenuItemType & { tag?: string },
+        ),
     }));
 
   return [
     ...(overviewItem
-      ? [{ key: overviewItem.key, label: overviewItem.label }]
+      ? [
+          {
+            key: overviewItem.key,
+            label: overviewItem.label,
+            tag: overviewItem.tag,
+          } as MenuItemType & { tag?: string },
+        ]
       : []),
     ...ungroupedItems,
     ...groupedItems,
@@ -322,6 +347,28 @@ function toOptionalText(value?: string) {
   if (!value) return undefined;
   return value.trim().replace(/^['"]|['"]$/g, "");
 }
+
+// ============ Tag helpers (ref: Ant Design X) ============
+function isVersionNumber(value?: string) {
+  return value && /^\d+\.\d+\.\d+$/.test(value);
+}
+
+function getTagColor(val?: string) {
+  if (isVersionNumber(val)) {
+    return "success";
+  }
+  if (val?.toUpperCase() === "NEW") {
+    return "success";
+  }
+  if (val?.toUpperCase() === "UPDATED") {
+    return "processing";
+  }
+  if (val?.toUpperCase() === "DEPRECATED") {
+    return "red";
+  }
+  return "success";
+}
+// ======================================================
 
 const normalizedCurrentPath = computed(() => normalizePath(route.path));
 const currentPathWithoutLocale = computed(() =>
@@ -424,6 +471,7 @@ const siderItems = computed<MenuItemType[]>(() => {
         pageMeta?.groupOrder ??
         fallbackMeta.groupOrder ??
         Number.MAX_SAFE_INTEGER,
+      tag: pageMeta?.tag ?? fallbackMeta.tag,
       label: [
         pageMeta?.title ||
           fallbackMeta.title ||
@@ -469,16 +517,31 @@ const editGithubUrl = computed(() => {
           mode="inline"
           @click="handleSiderMenuClick"
         >
-          <template #labelRender="{ type, key, label }">
+          <template #labelRender="item">
             <a
-              v-if="type !== 'group'"
+              v-if="item.type !== 'group'"
               class="text-inherit transition-0!"
-              :href="typeof key === 'string' ? key : '#'"
+              :href="typeof item.key === 'string' ? item.key : '#'"
               @click.prevent
+              style="
+                display: flex;
+                align-items: center;
+                justify-content: space-between;
+                gap: 8px;
+              "
             >
-              {{ label }}
+              <span>{{ item.label }}</span>
+              <a-tag
+                v-if="item.tag"
+                variant="filled"
+                size="small"
+                :color="getTagColor(item.tag)"
+                style="margin-inline-end: 0; flex-shrink: 0"
+              >
+                {{ item.tag }}
+              </a-tag>
             </a>
-            <span v-else>{{ label }}</span>
+            <span v-else>{{ item.label }}</span>
           </template>
         </a-menu>
       </aside>

--- a/packages/docs/src/pages/components/folder/demo/searchable.vue
+++ b/packages/docs/src/pages/components/folder/demo/searchable.vue
@@ -133,7 +133,8 @@ function filterTreeData(
     if (titleMatch || filteredChildren.length > 0) {
       acc.push({
         ...item,
-        children: filteredChildren.length > 0 ? filteredChildren : item.children,
+        children:
+          filteredChildren.length > 0 ? filteredChildren : item.children,
       });
     }
 
@@ -157,12 +158,13 @@ function onSelectedFileChange(info: SelectedFileInfo) {
 </script>
 
 <template>
-  <div style="padding: 24px; height: 600px">
-    <a-space direction="vertical" style="width: 100%; margin-bottom: 16px">
+  <div class="p-[24px] h-[600px] flex flex-col">
+    <div class="mb-[16px] flex-shrink-0">
       <a-input-search
         v-model:value="searchValue"
         placeholder="Search files or folders..."
         allow-clear
+        class="mb-[8px]"
       />
       <a-space>
         <a-tag color="blue">Total Files: {{ countFiles(treeData) }}</a-tag>
@@ -170,30 +172,24 @@ function onSelectedFileChange(info: SelectedFileInfo) {
           Matching Results: {{ countFiles(filteredTreeData) }}
         </a-tag>
       </a-space>
-    </a-space>
-    <ax-folder
-      :tree-data="filteredTreeData"
-      :selected-file="selectedFile"
-      @selected-file-change="onSelectedFileChange"
-    >
-      <template #directoryTitle>
-        <div
-          style="
-            white-space: nowrap;
-            padding: 12px;
-            border-bottom: 1px solid #f0f0f0;
-          "
-        >
-          <strong>Project File Browser</strong>
-          <div
-            v-if="searchValue"
-            style="font-size: 12px; color: #666; margin-top: 4px"
-          >
-            Search: "{{ searchValue }}"
+    </div>
+
+    <div class="flex-1 min-h-0">
+      <ax-folder
+        :tree-data="filteredTreeData"
+        :selected-file="selectedFile"
+        @selected-file-change="onSelectedFileChange"
+      >
+        <template #directoryTitle>
+          <div class="whitespace-nowrap p-[12px] border-b border-[#f0f0f0]">
+            <strong>Project File Browser</strong>
+            <div v-if="searchValue" class="text-xs text-[#666] mt-[4px]">
+              Search: "{{ searchValue }}"
+            </div>
           </div>
-        </div>
-      </template>
-    </ax-folder>
+        </template>
+      </ax-folder>
+    </div>
   </div>
 </template>
 

--- a/packages/docs/src/pages/components/folder/index.en-US.md
+++ b/packages/docs/src/pages/components/folder/index.en-US.md
@@ -1,6 +1,7 @@
 ---
 title: Folder
 description: File tree component for displaying hierarchical file structure.
+tag: 1.1.0
 ---
 
 ## When To Use

--- a/packages/docs/src/pages/components/folder/index.zh-CN.md
+++ b/packages/docs/src/pages/components/folder/index.zh-CN.md
@@ -2,6 +2,7 @@
 title: Folder
 subtitle: 文件树
 description: 用于展示层级文件结构的文件树组件。
+tag: 1.1.0
 ---
 
 ## 何时使用


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
-->

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 💡 Background and Solution

在左侧侧边栏导航中，在每个页面标题旁显示一个带颜色的版本标签（如 `1.1.0`、`New`、`Updated`），让用户直观了解该功能/文档首次发布或最近更新的版本。

方案参考 Ant Design X 的做法：
- 在 Markdown 前置元数据中通过 `tag` 字段声明版本信息
- 颜色语义：版本号/New→绿色，Updated→蓝色，Deprecated→红色
- 通过 antdv-next Menu 的 `labelRender` slot 渲染 `a-tag` 组件

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Display version/status tags in sidebar navigation for documentation pages |
| 🇨🇳 Chinese | 在文档侧边栏导航中显示版本/状态标签 |
