### PR TITLE
fix(sender): preserve cursor and user input when skill slot config changes

### DIFF
--- a/packages/x/components/sender/__tests__/index.test.tsx
+++ b/packages/x/components/sender/__tests__/index.test.tsx
@@ -1,6 +1,8 @@
 import { mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { SlotConfigType } from "../interface";
+
 import Sender from "..";
 
 beforeEach(() => {
@@ -290,6 +292,89 @@ describe("Sender", () => {
         }),
       ]),
     );
+  });
+
+  it("should keep user input when typing after removing content slot with skill", async () => {
+    const onChange = vi.fn();
+    const skill = {
+      value: "test_skill",
+      title: "Test skill",
+      closable: true,
+    };
+    const wrapper = mount(Sender, {
+      props: {
+        skill,
+        slotConfig: [
+          { type: "content", key: "input", props: { placeholder: "Content" } },
+        ],
+        placeholder: "Type something...",
+        onChange,
+      },
+    });
+
+    await wrapper.vm.$nextTick();
+    await wrapper.setProps({ slotConfig: undefined });
+    await wrapper.vm.$nextTick();
+    onChange.mockClear();
+
+    const editable = wrapper.find(".antd-sender-input-slot");
+    const skillNode = wrapper.find(".antd-sender-skill");
+
+    skillNode.element.appendChild(document.createTextNode("hello"));
+    await editable.trigger("input");
+
+    expect(onChange).toHaveBeenCalled();
+    const lastChange = onChange.mock.calls[onChange.mock.calls.length - 1]!;
+    expect(lastChange[0]).toBe("hello");
+    expect((wrapper.vm as any).getValue().value).toBe("hello");
+  });
+
+  it("should keep cursor after restoring slotConfig and typing into skill placeholder", async () => {
+    const skill = {
+      value: "test_skill",
+      title: "Test skill",
+      closable: true,
+    };
+    const slotConfig: SlotConfigType[] = [
+      { type: "content", key: "input", props: { placeholder: "Content" } },
+    ];
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const wrapper = mount(Sender, {
+      attachTo: host,
+      props: {
+        skill,
+        slotConfig,
+        placeholder: "Type something...",
+      },
+    });
+
+    await wrapper.vm.$nextTick();
+    await wrapper.setProps({ slotConfig: undefined });
+    await wrapper.vm.$nextTick();
+    await wrapper.setProps({ slotConfig: [...slotConfig] });
+    await wrapper.vm.$nextTick();
+
+    const editable = wrapper.find(".antd-sender-input-slot");
+    const skillNode = wrapper.find(".antd-sender-skill");
+    const textNode = document.createTextNode("a");
+    const selection = window.getSelection();
+    const range = document.createRange();
+
+    skillNode.element.appendChild(textNode);
+    range.setStart(textNode, 1);
+    range.collapse(true);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    await editable.trigger("input");
+
+    expect((wrapper.vm as any).getValue().value).toContain("a");
+    expect(selection?.anchorNode).toBe(textNode);
+    expect(selection?.anchorOffset).toBe(1);
+
+    wrapper.unmount();
+    host.remove();
   });
 });
 

--- a/packages/x/components/sender/components/SlotTextArea.tsx
+++ b/packages/x/components/sender/components/SlotTextArea.tsx
@@ -835,8 +835,51 @@ export default defineComponent({
       senderCtx.value.onKeyUp?.(event);
     };
 
+    const normalizeSkillTextInput = () => {
+      const editable = editableRef.value;
+      const skillDom = skillDomRef.value;
+      if (!editable || !skillDom) return;
+
+      const selection = getSelection();
+      const cursorNode =
+        selection?.anchorNode && skillDom.contains(selection.anchorNode)
+          ? selection.anchorNode
+          : null;
+      const cursorOffset = selection?.anchorOffset ?? 0;
+      const wrapperCls = `${prefixCls.value}-skill-wrapper`;
+      const textNodes = Array.from(skillDom.childNodes).filter(node => {
+        if (
+          node instanceof HTMLElement &&
+          node.classList.contains(wrapperCls)
+        ) {
+          return false;
+        }
+
+        return node.textContent;
+      });
+
+      const referenceNode = skillDom.nextSibling;
+      textNodes.forEach(node => {
+        editable.insertBefore(node, referenceNode);
+      });
+
+      if (cursorNode && editable.contains(cursorNode)) {
+        const range = document.createRange();
+        const nextOffset =
+          cursorNode.nodeType === Node.TEXT_NODE
+            ? Math.min(cursorOffset, cursorNode.textContent?.length ?? 0)
+            : Math.min(cursorOffset, cursorNode.childNodes.length);
+
+        range.setStart(cursorNode, nextOffset);
+        range.collapse(true);
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+      }
+    };
+
     const onInternalInput = (event?: Event) => {
       removeSpecificBRs();
+      normalizeSkillTextInput();
       triggerValueChange(event);
     };
 


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](./PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> N/A

### 💡 Background and Solution

**Background:** When using Sender with both `skill` and `slotConfig` (e.g., a content slot), toggling `slotConfig` between defined and `undefined` causes text nodes inside the skill DOM to be lost during normalization. The cursor position also fails to restore, making user input disappear after the UI updates.

**Solution:** Added `normalizeSkillTextInput()` method that:
1. Identifies orphaned text nodes inside the skill DOM (excluding skill wrapper elements)
2. Moves them back into the editable area
3. Preserves the cursor position (anchor node & offset) after the text node relocation

The method is called at the start of `onInternalInput`, before `triggerValueChange`, ensuring input is always captured correctly.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix Sender losing user input and cursor position when skill slot config is toggled. |
| 🇨🇳 Chinese | 修复 Sender 组件在切换 skill slotConfig 时丢失用户输入和光标位置的问题。 |
