### PR TITLE
feat: 添加 playground 子包用于本地组件调试

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "type": "module",
   "scripts": {
+    "dev:play": "vp dev packages/playground",
     "docs:dev": "vp dev packages/docs",
     "docs:preview": "vp preview packages/docs",
     "docs:build": "vp run --filter @antdv-next/docs build",

--- a/packages/playground/index.html
+++ b/packages/playground/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Antdv X Playground</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "playground",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vp dev",
+    "build": "vp build",
+    "preview": "vp preview"
+  },
+  "dependencies": {
+    "@antdv-next/icons": "catalog:prod",
+    "@vueuse/core": "catalog:prod",
+    "antdv-next": "catalog:prod",
+    "dayjs": "catalog:prod",
+    "vue": "catalog:prod",
+    "vue-i18n": "catalog:prod",
+    "vue-router": "catalog:prod"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "catalog:dev",
+    "@vitejs/plugin-vue-jsx": "catalog:dev",
+    "@vue/tsconfig": "catalog:dev",
+    "typescript": "catalog:dev",
+    "vite": "catalog:",
+    "vite-plugin-tsx-resolve-types": "catalog:dev",
+    "vue-tsc": "catalog:dev"
+  }
+}

--- a/packages/playground/src/App.vue
+++ b/packages/playground/src/App.vue
@@ -1,0 +1,59 @@
+<script setup lang="ts">
+import type { BubbleItemType } from "@antdv-next/x";
+
+import { BubbleList, Sender, Welcome, XProvider } from "@antdv-next/x";
+import { ref } from "vue";
+
+const items = ref<BubbleItemType[]>([
+  {
+    key: "welcome",
+    content: "Hello! How can I help you today?",
+    placement: "start",
+    role: "assistant",
+  },
+]);
+
+const loading = ref(false);
+
+async function handleSubmit(value: string) {
+  if (!value.trim()) return;
+
+  items.value.push({
+    key: `user-${Date.now()}`,
+    content: value,
+    placement: "end",
+    role: "user",
+  });
+
+  // Simulate assistant response
+  loading.value = true;
+  await new Promise(resolve => setTimeout(resolve, 1000));
+  items.value.push({
+    key: `assistant-${Date.now()}`,
+    content: `You said: "${value}"`,
+    placement: "start",
+    role: "assistant",
+  });
+  loading.value = false;
+}
+</script>
+
+<template>
+  <XProvider>
+    <div style="max-width: 800px; margin: 0 auto; padding: 24px">
+      <Welcome
+        icon="https://mdn.alipayobjects.com/huamei_iwk9zp/afts/img/A*s5sNRo5LjfQAAAAAAAAAAAAADgCCAQ/fmt.webp"
+        title="你好，我是 Antdv Next X"
+        description="基于 Antdv Next 的 AGI 产品界面解决方案，打造更美好的智能愿景~"
+      />
+
+      <BubbleList :items="items" :auto-scroll="true" style="margin-top: 24px" />
+
+      <Sender
+        :loading="loading"
+        style="margin-top: 24px"
+        @submit="handleSubmit"
+      />
+    </div>
+  </XProvider>
+</template>

--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -1,0 +1,5 @@
+import { createApp } from "vue";
+
+import App from "./App.vue";
+
+createApp(App).mount("#app");

--- a/packages/playground/src/vite-env.d.ts
+++ b/packages/playground/src/vite-env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="vite/client" />
+
+declare module "*.vue" {
+  import type { DefineComponent } from "vue";
+  const component: DefineComponent<object, object, unknown>;
+  export default component;
+}

--- a/packages/playground/tsconfig.app.json
+++ b/packages/playground/tsconfig.app.json
@@ -1,0 +1,25 @@
+{
+  "extends": "@vue/tsconfig/tsconfig.dom.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@antdv-next/x": ["../x/components/index.ts"],
+      "@antdv-next/x/*": ["../x/components/*"],
+      "@antdv-next/x-markdown": ["../x-markdown/src/index.ts"],
+      "@antdv-next/x-markdown/*": ["../x-markdown/src/*"],
+      "@antdv-next/x-sdk": ["../x-sdk/src/index.ts"],
+      "@antdv-next/x-sdk/*": ["../x-sdk/src/*"],
+      "@antdv-next/x-card": ["../x-card/src/index.ts"],
+      "@antdv-next/x-card/*": ["../x-card/src/*"]
+    },
+    "types": ["vite/client"],
+    "strict": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue"]
+}

--- a/packages/playground/tsconfig.json
+++ b/packages/playground/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ],
+  "files": []
+}

--- a/packages/playground/tsconfig.node.json
+++ b/packages/playground/tsconfig.node.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "moduleDetection": "force",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["node"],
+    "allowImportingTsExtensions": true,
+    "strict": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noEmit": true,
+    "verbatimModuleSyntax": true,
+    "erasableSyntaxOnly": true,
+    "skipLibCheck": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/packages/playground/vite.config.ts
+++ b/packages/playground/vite.config.ts
@@ -1,0 +1,60 @@
+import vue from "@vitejs/plugin-vue";
+import vueJsx from "@vitejs/plugin-vue-jsx";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vite";
+import { tsxResolveTypes } from "vite-plugin-tsx-resolve-types";
+
+const baseUrl = fileURLToPath(new URL(".", import.meta.url));
+
+const packagesDir = path.resolve(baseUrl, "..");
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: /^@antdv-next\/x$/,
+        replacement: path.resolve(packagesDir, "x/components/index.ts"),
+      },
+      {
+        find: /^@antdv-next\/x-markdown$/,
+        replacement: path.resolve(packagesDir, "x-markdown/src/index.ts"),
+      },
+      {
+        find: /^@antdv-next\/x-sdk$/,
+        replacement: path.resolve(packagesDir, "x-sdk/src/index.ts"),
+      },
+      {
+        find: /^@antdv-next\/x-card$/,
+        replacement: path.resolve(packagesDir, "x-card/src/index.ts"),
+      },
+      {
+        find: /^@antdv-next\/x\/(.+)$/,
+        replacement: path.resolve(packagesDir, "x/components/$1"),
+      },
+      {
+        find: /^@antdv-next\/x-markdown\/(.+)$/,
+        replacement: path.resolve(packagesDir, "x-markdown/src/$1"),
+      },
+      {
+        find: /^@antdv-next\/x-sdk\/(.+)$/,
+        replacement: path.resolve(packagesDir, "x-sdk/src/$1"),
+      },
+      {
+        find: /^@antdv-next\/x-card\/(.+)$/,
+        replacement: path.resolve(packagesDir, "x-card/src/$1"),
+      },
+      {
+        find: "@",
+        replacement: path.resolve(baseUrl, "src"),
+      },
+    ],
+  },
+  plugins: [
+    tsxResolveTypes({
+      defaultPropsToUndefined: ["Boolean"],
+    }),
+    vueJsx(),
+    vue(),
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -517,6 +517,52 @@ importers:
         specifier: ^4.19.1
         version: 4.21.0
 
+  playground:
+    dependencies:
+      '@antdv-next/icons':
+        specifier: catalog:prod
+        version: 1.0.6(vue@3.5.31(typescript@5.9.3))
+      '@vueuse/core':
+        specifier: catalog:prod
+        version: 14.2.1(vue@3.5.31(typescript@5.9.3))
+      antdv-next:
+        specifier: catalog:prod
+        version: 1.2.0(vue@3.5.31(typescript@5.9.3))
+      dayjs:
+        specifier: catalog:prod
+        version: 1.11.20
+      vue:
+        specifier: catalog:prod
+        version: 3.5.31(typescript@5.9.3)
+      vue-i18n:
+        specifier: catalog:prod
+        version: 11.3.0(vue@3.5.31(typescript@5.9.3))
+      vue-router:
+        specifier: catalog:prod
+        version: 5.0.4(@vue/compiler-sfc@3.5.31)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
+    devDependencies:
+      '@vitejs/plugin-vue':
+        specifier: catalog:dev
+        version: 6.0.5(@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(vue@3.5.31(typescript@5.9.3))
+      '@vitejs/plugin-vue-jsx':
+        specifier: catalog:dev
+        version: 5.1.5(@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(vue@3.5.31(typescript@5.9.3))
+      '@vue/tsconfig':
+        specifier: catalog:dev
+        version: 0.9.1(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))
+      typescript:
+        specifier: catalog:dev
+        version: 5.9.3
+      vite:
+        specifier: npm:@voidzero-dev/vite-plus-core@latest
+        version: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)'
+      vite-plugin-tsx-resolve-types:
+        specifier: catalog:dev
+        version: 1.0.1(@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(typescript@5.9.3)
+      vue-tsc:
+        specifier: catalog:dev
+        version: 3.2.6(typescript@5.9.3)
+
 packages:
 
   '@acemir/cssom@0.9.31':
@@ -1206,11 +1252,18 @@ packages:
     resolution: {integrity: sha512-p0bQukD8OEHxzY4T9OlANBbEFGnOnjo1CYi50HES7OD36UO2yPh6T+uOJKLtlg06eclxroipRCpQGMpeH8EJ/g==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
+  '@oxc-project/runtime@0.133.0':
+    resolution: {integrity: sha512-PkvjA1Lq5++V5S1E6Patr92ZVcieE6EalDr1VJTqv4BnjZdOUC4W3p8k1wMXSd5/2aFP4b/A6N5sg2Bkzcr9vQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   '@oxc-project/types@0.115.0':
     resolution: {integrity: sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==}
 
   '@oxc-project/types@0.122.0':
     resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
+
+  '@oxc-project/types@0.133.0':
+    resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
 
   '@oxfmt/binding-android-arm-eabi@0.41.0':
     resolution: {integrity: sha512-REfrqeMKGkfMP+m/ScX4f5jJBSmVNYcpoDF8vP8f8eYPDuPGZmzp56NIUsYmx3h7f6NzC6cE3gqh8GDWrJHCKw==}
@@ -2190,6 +2243,69 @@ packages:
       typescript:
         optional: true
       unplugin-unused:
+        optional: true
+      yaml:
+        optional: true
+
+  '@voidzero-dev/vite-plus-core@0.1.24':
+    resolution: {integrity: sha512-iXPGBABnQnrDMx89H6MOCGcTZp+QW+3rY4YMVKdE6ydchSvPk2O3MI2vgaRVfOtWJ2IjnxSnf1n2yjP67ZBRFQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@arethetypeswrong/core': ^0.18.1
+      '@tsdown/css': 0.22.1
+      '@tsdown/exe': 0.22.1
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.18
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      publint: ^0.3.8
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      typescript: ^5.0.0 || ^6.0.0
+      unplugin-unused: ^0.5.0
+      unrun: '*'
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@arethetypeswrong/core':
+        optional: true
+      '@tsdown/css':
+        optional: true
+      '@tsdown/exe':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      publint:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      typescript:
+        optional: true
+      unplugin-unused:
+        optional: true
+      unrun:
         optional: true
       yaml:
         optional: true
@@ -4967,9 +5083,13 @@ snapshots:
 
   '@oxc-project/runtime@0.121.0': {}
 
+  '@oxc-project/runtime@0.133.0': {}
+
   '@oxc-project/types@0.115.0': {}
 
   '@oxc-project/types@0.122.0': {}
+
+  '@oxc-project/types@0.133.0': {}
 
   '@oxfmt/binding-android-arm-eabi@0.41.0':
     optional: true
@@ -5818,16 +5938,49 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitejs/plugin-vue-jsx@5.1.5(@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(vue@3.5.31(typescript@5.9.3))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+      '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-rc.12
+      '@vue/babel-plugin-jsx': 2.0.1(@babel/core@7.29.0)
+      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)'
+      vue: 3.5.31(typescript@5.9.3)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitejs/plugin-vue@6.0.5(@voidzero-dev/vite-plus-core@0.1.14(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.2
       vite: '@voidzero-dev/vite-plus-core@0.1.14(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)'
       vue: 3.5.31(typescript@5.9.3)
 
+  '@vitejs/plugin-vue@6.0.5(@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(vue@3.5.31(typescript@5.9.3))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.0-rc.2
+      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)'
+      vue: 3.5.31(typescript@5.9.3)
+
   '@voidzero-dev/vite-plus-core@0.1.14(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)':
     dependencies:
       '@oxc-project/runtime': 0.121.0
       '@oxc-project/types': 0.122.0
+      lightningcss: 1.32.0
+      postcss: 8.5.8
+    optionalDependencies:
+      '@types/node': 24.12.0
+      esbuild: 0.27.4
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      tsx: 4.21.0
+      typescript: 5.9.3
+      yaml: 2.9.0
+
+  '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)':
+    dependencies:
+      '@oxc-project/runtime': 0.133.0
+      '@oxc-project/types': 0.133.0
       lightningcss: 1.32.0
       postcss: 8.5.8
     optionalDependencies:
@@ -7951,6 +8104,18 @@ snapshots:
       oxc-walker: 0.7.0(oxc-parser@0.115.0)
       typescript: 5.9.3
       vite: '@voidzero-dev/vite-plus-core@0.1.14(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)'
+
+  vite-plugin-tsx-resolve-types@1.0.1(@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(typescript@5.9.3):
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@oxc-project/types': 0.115.0
+      '@v-c/resolve-types': 0.0.1(typescript@5.9.3)
+      magic-string: 0.30.21
+      oxc-parser: 0.115.0
+      oxc-walker: 0.7.0(oxc-parser@0.115.0)
+      typescript: 5.9.3
+      vite: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)'
 
   vite-plugin-vue-devtools@8.1.1(@voidzero-dev/vite-plus-core@0.1.14(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(vue@3.5.31(typescript@5.9.3)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -431,6 +431,52 @@ importers:
         specifier: catalog:docs
         version: 3.23.0
 
+  packages/playground:
+    dependencies:
+      '@antdv-next/icons':
+        specifier: catalog:prod
+        version: 1.0.6(vue@3.5.31(typescript@5.9.3))
+      '@vueuse/core':
+        specifier: catalog:prod
+        version: 14.2.1(vue@3.5.31(typescript@5.9.3))
+      antdv-next:
+        specifier: catalog:prod
+        version: 1.2.0(vue@3.5.31(typescript@5.9.3))
+      dayjs:
+        specifier: catalog:prod
+        version: 1.11.20
+      vue:
+        specifier: catalog:prod
+        version: 3.5.31(typescript@5.9.3)
+      vue-i18n:
+        specifier: catalog:prod
+        version: 11.3.0(vue@3.5.31(typescript@5.9.3))
+      vue-router:
+        specifier: catalog:prod
+        version: 5.0.4(@vue/compiler-sfc@3.5.31)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
+    devDependencies:
+      '@vitejs/plugin-vue':
+        specifier: catalog:dev
+        version: 6.0.5(@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(vue@3.5.31(typescript@5.9.3))
+      '@vitejs/plugin-vue-jsx':
+        specifier: catalog:dev
+        version: 5.1.5(@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(vue@3.5.31(typescript@5.9.3))
+      '@vue/tsconfig':
+        specifier: catalog:dev
+        version: 0.9.1(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))
+      typescript:
+        specifier: catalog:dev
+        version: 5.9.3
+      vite:
+        specifier: npm:@voidzero-dev/vite-plus-core@latest
+        version: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)'
+      vite-plugin-tsx-resolve-types:
+        specifier: catalog:dev
+        version: 1.0.1(@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(typescript@5.9.3)
+      vue-tsc:
+        specifier: catalog:dev
+        version: 3.2.6(typescript@5.9.3)
+
   packages/x:
     dependencies:
       '@ant-design/fast-color':
@@ -516,52 +562,6 @@ importers:
       tsx:
         specifier: ^4.19.1
         version: 4.21.0
-
-  playground:
-    dependencies:
-      '@antdv-next/icons':
-        specifier: catalog:prod
-        version: 1.0.6(vue@3.5.31(typescript@5.9.3))
-      '@vueuse/core':
-        specifier: catalog:prod
-        version: 14.2.1(vue@3.5.31(typescript@5.9.3))
-      antdv-next:
-        specifier: catalog:prod
-        version: 1.2.0(vue@3.5.31(typescript@5.9.3))
-      dayjs:
-        specifier: catalog:prod
-        version: 1.11.20
-      vue:
-        specifier: catalog:prod
-        version: 3.5.31(typescript@5.9.3)
-      vue-i18n:
-        specifier: catalog:prod
-        version: 11.3.0(vue@3.5.31(typescript@5.9.3))
-      vue-router:
-        specifier: catalog:prod
-        version: 5.0.4(@vue/compiler-sfc@3.5.31)(pinia@3.0.4(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3)))(vue@3.5.31(typescript@5.9.3))
-    devDependencies:
-      '@vitejs/plugin-vue':
-        specifier: catalog:dev
-        version: 6.0.5(@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(vue@3.5.31(typescript@5.9.3))
-      '@vitejs/plugin-vue-jsx':
-        specifier: catalog:dev
-        version: 5.1.5(@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(vue@3.5.31(typescript@5.9.3))
-      '@vue/tsconfig':
-        specifier: catalog:dev
-        version: 0.9.1(typescript@5.9.3)(vue@3.5.31(typescript@5.9.3))
-      typescript:
-        specifier: catalog:dev
-        version: 5.9.3
-      vite:
-        specifier: npm:@voidzero-dev/vite-plus-core@latest
-        version: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)'
-      vite-plugin-tsx-resolve-types:
-        specifier: catalog:dev
-        version: 1.0.1(@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(typescript@5.9.3)
-      vue-tsc:
-        specifier: catalog:dev
-        version: 3.2.6(typescript@5.9.3)
 
 packages:
 


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [x] 🆕 新功能

### 🔗 相关 Issue

无。

### 💡 背景与方案

在 monorepo 中新增 \`packages/playground/\` 子包，提供本地组件调试环境。

关键设计：
- **源码级 alias** — \`@antdv-next/x\` 等 workspace 包通过 vite alias 直接指向 \`packages/*/src\`，修改源码后浏览器立即 HMR 热更新，无需先构建
- **Vite+ 兼容** — 使用 \`vp dev packages/playground\` 驱动开发服务器，与项目现有工具链一致
- **与构建隔离** — 不设 build/type-check 脚本，不会被 \`vp run\` 构建任务匹配到，不影响 CI
- **外部包走 catalog** — \`vue\`、\`antdv-next\` 等通过 pnpm catalog 统一版本管理

使用方式：

```bash
pnpm dev:play
```

在 \`packages/playground/src/App.vue\` 中编写组件 demo 即可实时预览。

### 📝 变更日志

| 语言    | 变更日志 |
| ------- | -------- |
| 🇺🇸 英文 | Add playground sub-package for local component debugging with Vite+ dev server and source-level HMR |
| 🇨🇳 中文 | 新增 playground 子包，支持本地组件调试与源码级 HMR 热更新 |