### PR TITLE
fix(sender): remove slot before cursor when backspacing at editor boundary

### DIFF
--- a/packages/x/components/sender/__tests__/index.test.tsx
+++ b/packages/x/components/sender/__tests__/index.test.tsx
@@ -294,6 +294,56 @@ describe("Sender", () => {
     );
   });
 
+  it("should remove the slot before cursor when backspacing at the editor boundary", async () => {
+    const onChange = vi.fn();
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const wrapper = mount(Sender, {
+      attachTo: host,
+      props: {
+        slotConfig: [
+          {
+            type: "tag",
+            key: "assistant1",
+            props: { label: "@Travel Planner1", value: "travel1" },
+          },
+          {
+            type: "tag",
+            key: "assistant2",
+            props: { label: "@Travel Planner2", value: "travel2" },
+          },
+          {
+            type: "tag",
+            key: "assistant3",
+            props: { label: "@Travel Planner3", value: "travel3" },
+          },
+        ],
+        onChange,
+      },
+    });
+    await wrapper.vm.$nextTick();
+    onChange.mockClear();
+
+    const editable = wrapper.find(".antd-sender-input-slot");
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.setStart(editable.element, editable.element.childNodes.length);
+    range.collapse(true);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    await editable.trigger("keydown", { key: "Backspace" });
+
+    const lastChange = onChange.mock.calls[onChange.mock.calls.length - 1]!;
+    expect(lastChange[2].map((item: SlotConfigType) => item.key)).toEqual([
+      "assistant1",
+      "assistant2",
+    ]);
+
+    wrapper.unmount();
+    host.remove();
+  });
+
   it("should keep user input when typing after removing content slot with skill", async () => {
     const onChange = vi.fn();
     const skill = {

--- a/packages/x/components/sender/components/SlotTextArea.tsx
+++ b/packages/x/components/sender/components/SlotTextArea.tsx
@@ -756,31 +756,29 @@ export default defineComponent({
       const editable = editableRef.value;
       if (!editable) return false;
 
-      let anchorNode = selection.anchorNode;
-      let offset = selection.anchorOffset;
+      const anchorNode = selection.anchorNode;
+      const offset = selection.anchorOffset;
 
       if (!anchorNode || !editable.contains(anchorNode)) {
         return false;
       }
 
-      if (anchorNode === editable && offset > 0) {
-        anchorNode = editable.childNodes[offset - 1] ?? anchorNode;
-        offset = 0;
+      let previous: Node | null | undefined;
+      if (anchorNode === editable) {
+        if (offset <= 0) return false;
+        previous = editable.childNodes[offset - 1];
+      } else {
+        if (anchorNode.nodeType === Node.TEXT_NODE && offset > 0) {
+          return false;
+        }
+
+        const target =
+          anchorNode.nodeType === Node.TEXT_NODE
+            ? (anchorNode.parentNode as HTMLElement | null)
+            : (anchorNode as HTMLElement);
+
+        previous = target?.previousSibling;
       }
-
-      if (anchorNode.nodeType === Node.TEXT_NODE && offset > 0) {
-        return false;
-      }
-
-      const target =
-        anchorNode.nodeType === Node.TEXT_NODE
-          ? (anchorNode.parentNode as HTMLElement | null)
-          : (anchorNode as HTMLElement);
-
-      const previous =
-        target === editable
-          ? editable.childNodes[Math.max(0, selection.anchorOffset - 1)]
-          : target?.previousSibling;
 
       if (!(previous instanceof HTMLElement)) {
         return false;


### PR DESCRIPTION

<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

[中文版模板 / Chinese template](./PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> None — discovered during development.

### 💡 Background and Solution

When the cursor sits directly on the editable container (anchorNode === editable) and the user presses Backspace at a slot boundary, the previous logic traversed childNodes with an offset adjustment that could skip the intended slot and fail to remove it.

**Solution:** Refactored the `handleBackspaceAtSlotBoundary` handler in `SlotTextArea.tsx`:

1. Added a direct path for `anchorNode === editable` — simply grabs the previous sibling via `childNodes[offset - 1]`, returning early if offset <= 0.
2. The text-node handling path now only runs when anchorNode is not the editable container, using `previousSibling` directly.

A test case was added: places three slots in the editor, positions the cursor at the end, presses Backspace, and verifies only the last slot is removed.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fixed slot not removed when backspacing at the editor container boundary |
| 🇨🇳 Chinese | 修复在编辑器容器边界退格时 slot 未被移除的问题 |