### PR TITLE
fix(sender): skip non-slot nodes when backspacing at editor boundary

### DIFF
--- a/packages/x/components/sender/__tests__/index.test.tsx
+++ b/packages/x/components/sender/__tests__/index.test.tsx
@@ -379,6 +379,82 @@ describe("Sender", () => {
     expect((wrapper.vm as any).getValue().value).toBe("hello");
   });
 
+  it("should remove slot when backspacing past empty text nodes at editor boundary", async () => {
+    const onChange = vi.fn();
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const wrapper = mount(Sender, {
+      attachTo: host,
+      props: {
+        slotConfig: [
+          {
+            type: "tag",
+            key: "a1",
+            props: { label: "@A1", value: "a1" },
+          },
+          {
+            type: "tag",
+            key: "a2",
+            props: { label: "@A2", value: "a2" },
+          },
+        ],
+        onChange,
+      },
+    });
+    await wrapper.vm.$nextTick();
+    onChange.mockClear();
+
+    const editable = wrapper.find(".antd-sender-input-slot");
+
+    // Insert empty text nodes between the last slot and the cursor
+    // to simulate DOM state after editing (browser may leave orphan text nodes)
+    editable.element.appendChild(document.createTextNode(""));
+    editable.element.appendChild(document.createTextNode(""));
+
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.setStart(editable.element, editable.element.childNodes.length);
+    range.collapse(true);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    await editable.trigger("keydown", { key: "Backspace" });
+
+    const lastChange = onChange.mock.calls[onChange.mock.calls.length - 1]!;
+    expect(lastChange[2].map((item: SlotConfigType) => item.key)).toEqual([
+      "a1",
+    ]);
+
+    wrapper.unmount();
+    host.remove();
+  });
+
+  it("should not show empty placeholder when skill has child nodes", async () => {
+    const skill = {
+      value: "test_skill",
+      title: "Test skill",
+      closable: true,
+    };
+    const wrapper = mount(Sender, {
+      props: {
+        skill,
+        placeholder: "Type something...",
+      },
+    });
+    await wrapper.vm.$nextTick();
+
+    const skillNode = wrapper.find(".antd-sender-skill");
+    // Simulate user typing into the skill area
+    skillNode.element.appendChild(document.createTextNode("hello"));
+
+    const editable = wrapper.find(".antd-sender-input-slot");
+    await editable.trigger("input");
+    await wrapper.vm.$nextTick();
+
+    // The empty class should NOT be applied since the skill has child nodes
+    expect(skillNode.classes()).not.toContain("antd-sender-skill-empty");
+  });
+
   it("should keep cursor after restoring slotConfig and typing into skill placeholder", async () => {
     const skill = {
       value: "test_skill",

--- a/packages/x/components/sender/components/SlotTextArea.tsx
+++ b/packages/x/components/sender/components/SlotTextArea.tsx
@@ -672,7 +672,8 @@ export default defineComponent({
       const isEmpty =
         !value.value &&
         value.slotConfig.length === 0 &&
-        !!senderCtx.value.placeholder;
+        !!senderCtx.value.placeholder &&
+        !skillDom.hasChildNodes();
 
       if (isEmpty) {
         skillDom.setAttribute("contenteditable", "true");
@@ -763,24 +764,46 @@ export default defineComponent({
         return false;
       }
 
-      let previous: Node | null | undefined;
+      // Find the nearest slot/skill node before the cursor.
+      // Skip non-slot/skill nodes (e.g. empty text nodes) — the cursor
+      // may be several siblings away from the actual slot after editing.
+      const isSlotOrSkill = (node: Node): node is HTMLElement => {
+        if (!(node instanceof HTMLElement)) return false;
+        const info = getNodeInfo(node);
+        return !!(info?.slotKey || info?.skillKey);
+      };
+
+      let previous: HTMLElement | null = null;
       if (anchorNode === editable) {
-        if (offset <= 0) return false;
-        previous = editable.childNodes[offset - 1];
+        for (let i = offset - 1; i >= 0; i--) {
+          if (isSlotOrSkill(editable.childNodes[i]!)) {
+            previous = editable.childNodes[i] as HTMLElement;
+            break;
+          }
+        }
       } else {
         if (anchorNode.nodeType === Node.TEXT_NODE && offset > 0) {
           return false;
         }
 
-        const target =
+        // Use anchorNode directly — traversing to parentNode breaks when
+        // the text node is a direct child of the editable div (parentNode
+        // is the editable div itself, which has no siblings).
+        let current: Node | null =
           anchorNode.nodeType === Node.TEXT_NODE
-            ? (anchorNode.parentNode as HTMLElement | null)
-            : (anchorNode as HTMLElement);
+            ? anchorNode.previousSibling
+            : (anchorNode as HTMLElement).previousSibling;
 
-        previous = target?.previousSibling;
+        while (current) {
+          if (isSlotOrSkill(current)) {
+            previous = current;
+            break;
+          }
+          current = current.previousSibling;
+        }
       }
 
-      if (!(previous instanceof HTMLElement)) {
+      if (!previous) {
         return false;
       }
 


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [x] 🐞 Bug 修复

### 🔗 相关 Issue

- Related: #98, #96

### 💡 背景与方案

**问题：** 在 `SlotTextArea` 编辑器中，当光标位于空文本节点或其他非 slot/skill 兄弟节点之后时，按 Backspace 无法正确找到并删除前方的 slot 节点。此外，当编辑器仍有子节点时，placeholder 会错误显示。

**方案：**
1. 在查找光标前的 slot 节点时，向后遍历兄弟节点，跳过非 slot/skill 节点（如空文本节点），直到找到最近的 slot 或 skill 节点。
2. 在 `isEmpty` 判断中增加 `!skillDom.hasChildNodes()` 检查，避免编辑器有子节点时错误显示 placeholder。

### 📝 变更日志

| 语言    | 变更日志 |
| ------- | -------- |
| 🇺🇸 英文 | fix(sender): correctly find and remove slot nodes when backspacing past non-slot siblings at editor boundary |
| 🇨🇳 中文 | fix(sender): 修复编辑器边界处 backspace 无法正确删除 slot 节点的问题 |