### PR TITLE
docs(sender): align demos with upstream ant-design-x

### DIFF
--- a/packages/docs/src/pages/components/sender/demo/agent.vue
+++ b/packages/docs/src/pages/components/sender/demo/agent.vue
@@ -1,41 +1,172 @@
 <script setup lang="ts">
+import type { SenderProps } from "@antdv-next/x";
 import type { MenuProps } from "antdv-next";
 
 import {
+  AntDesignOutlined,
   ApiOutlined,
   CodeOutlined,
   EditOutlined,
+  FileImageOutlined,
   OpenAIOutlined,
   PaperClipOutlined,
+  ProfileOutlined,
   SearchOutlined,
 } from "@antdv-next/icons";
 import { App } from "antdv-next";
-import { ref, watch } from "vue";
+import { h, ref, watch } from "vue";
 const { message } = App.useApp();
 
-interface AgentItem {
+interface AgentInfoItem {
   icon: any;
   label: string;
+  zh_label: string;
+  skill: SenderProps["skill"];
+  zh_skill: SenderProps["skill"];
+  slotConfig: SenderProps["slotConfig"];
+  zh_slotConfig: SenderProps["slotConfig"];
 }
 
-const agentMap: Record<string, AgentItem> = {
-  deep_search: { icon: SearchOutlined, label: "深度搜索" },
-  ai_code: { icon: CodeOutlined, label: "写代码" },
-  ai_writing: { icon: EditOutlined, label: "帮我写作" },
+const AgentInfo: Record<string, AgentInfoItem> = {
+  deep_search: {
+    icon: SearchOutlined,
+    label: "Deep Search",
+    zh_label: "深度搜索",
+    skill: {
+      value: "deepSearch",
+      title: "Deep Search",
+      closable: true,
+    },
+    zh_skill: {
+      value: "deepSearch",
+      title: "深度搜索",
+      closable: true,
+    },
+    slotConfig: [
+      { type: "text", value: "Please help me search for news about " },
+      {
+        type: "select",
+        key: "search_type",
+        props: {
+          options: ["AI", "Technology", "Entertainment"],
+          placeholder: "Please select a category",
+        },
+      },
+      { type: "text", key: "", value: "Please help me search for news about " },
+    ],
+    zh_slotConfig: [
+      { type: "text", value: "请帮我搜索关于" },
+      {
+        type: "select",
+        key: "search_type",
+        props: {
+          options: ["AI", "技术", "娱乐"],
+          placeholder: "请选择一个类别",
+        },
+      },
+      { type: "text", key: "", value: "的新闻。" },
+    ],
+  },
+  ai_code: {
+    icon: CodeOutlined,
+    label: "AI Code",
+    zh_label: "写代码",
+    skill: {
+      value: "aiCode",
+      title: "Code Assistant",
+      closable: true,
+    },
+    zh_skill: {
+      value: "aiCode",
+      title: "代码助手",
+      closable: true,
+    },
+    slotConfig: [
+      { type: "text", value: "Please use " },
+      {
+        type: "select",
+        key: "code_lang",
+        props: {
+          options: ["JS", "C++", "Java"],
+          placeholder: "Please select a programming language",
+        },
+      },
+      { type: "text", value: " to write a mini game." },
+    ],
+    zh_slotConfig: [
+      { type: "text", value: "请使用" },
+      {
+        type: "select",
+        key: "code_lang",
+        props: {
+          options: ["JS", "C++", "Java"],
+          placeholder: "请选择一个编程语言",
+        },
+      },
+      { type: "text", value: "写一个小游戏。" },
+    ],
+  },
+  ai_writing: {
+    icon: EditOutlined,
+    label: "Writing",
+    zh_label: "帮我写作",
+    skill: {
+      value: "writing",
+      title: "Writing Assistant",
+      closable: true,
+    },
+    zh_skill: {
+      value: "writing",
+      title: "写作助手",
+      closable: true,
+    },
+    slotConfig: [
+      { type: "text", value: "Please write an article about " },
+      {
+        type: "select",
+        key: "writing_type",
+        props: {
+          options: ["Campus", "Travel", "Reading"],
+          placeholder: "Please enter a topic",
+        },
+      },
+      { type: "text", value: ". The requirement is " },
+      {
+        type: "content",
+        key: "writing_num",
+        props: {
+          defaultValue: "800",
+          placeholder: "[Please enter the number of words]",
+        },
+      },
+      { type: "text", value: " words." },
+    ],
+    zh_slotConfig: [
+      { type: "text", value: "请帮我写一篇关于" },
+      {
+        type: "select",
+        key: "writing_type",
+        props: {
+          options: ["校园", "旅行", "阅读"],
+          placeholder: "请输入主题",
+        },
+      },
+      { type: "text", value: "的文章。要求是" },
+      {
+        type: "content",
+        key: "writing_num",
+        props: {
+          defaultValue: "800",
+          placeholder: "[请输入字数]",
+        },
+      },
+      { type: "text", value: "字。" },
+    ],
+  },
 };
 
-const loading = ref(false);
-const deepThink = ref(true);
-const activeAgentKey = ref("ai_writing");
-
-const agentItems = Object.entries(agentMap).map(([key, { icon, label }]) => ({
-  key,
-  label,
-  icon,
-}));
-
-const agentItemClick: MenuProps["onClick"] = item => {
-  activeAgentKey.value = item.key as string;
+const IconStyle = {
+  fontSize: "16px",
 };
 
 const SwitchTextStyle = {
@@ -45,100 +176,291 @@ const SwitchTextStyle = {
   alignItems: "center",
 };
 
-const IconStyle = { fontSize: "16px" };
+interface FileInfoItem {
+  icon: any;
+  label: string;
+  zh_label: string;
+}
 
+const FileInfo: Record<string, FileInfoItem> = {
+  file_image: {
+    icon: FileImageOutlined,
+    label: "x-image",
+    zh_label: "x-图片",
+  },
+};
+
+const loading = ref(false);
+const deepThink = ref(true);
+const activeAgentKey = ref("ai_writing");
+const slotConfig = ref<AgentInfoItem>(AgentInfo[activeAgentKey.value]);
+
+// ======================== sender en ========================
+const senderRef = useTemplateRef("senderRef");
+
+const agentItems = Object.keys(AgentInfo).map(agent => {
+  const { icon, label } = AgentInfo[agent];
+  return { key: agent, icon, label };
+});
+
+const zhAgentItems = Object.keys(AgentInfo).map(agent => {
+  const { icon, zh_label } = AgentInfo[agent];
+  return { key: agent, icon, label: zh_label };
+});
+
+const fileItems = Object.keys(FileInfo).map(file => {
+  const { icon, label } = FileInfo[file];
+  return { key: file, icon, label };
+});
+
+const zhFileItems = Object.keys(FileInfo).map(file => {
+  const { icon, zh_label } = FileInfo[file];
+  return { key: file, icon, label: zh_label };
+});
+
+const agentItemClick: MenuProps["onClick"] = item => {
+  activeAgentKey.value = item.key as string;
+  try {
+    // deep clone
+    slotConfig.value = JSON.parse(
+      JSON.stringify(AgentInfo[item.key as string]),
+    );
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+// ======================== sender zh ========================
+const senderZhRef = useTemplateRef("senderZhRef");
+
+const fileItemClick = (item: { key: string }, type?: string) => {
+  const { icon, label } = FileInfo[item.key];
+  const sender = type !== "zh" ? senderRef.value : senderZhRef.value;
+  sender?.insert?.([
+    {
+      type: "tag",
+      key: `${item.key}_${Date.now()}`,
+      props: {
+        label: h("div", { style: { display: "flex", gap: "8px" } }, [
+          h(icon),
+          label,
+        ]),
+        value: item.key,
+      },
+    },
+  ]);
+};
+
+// Mock send message
 watch(loading, val => {
   if (val) {
     const timer = setTimeout(() => {
       loading.value = false;
-      message.success("发送成功！");
-      clearTimeout(timer);
+      message.success("Send message successfully!");
     }, 3000);
+    return () => {
+      clearTimeout(timer);
+    };
   }
 });
 
-const onSubmit = (v: string) => {
+const onSubmit: SenderProps["onSubmit"] = (v, _, skill) => {
   loading.value = true;
-  message.info(`发送消息: ${activeAgentKey.value} | ${v}`);
+  message.info(`Send message: ${skill?.value} | ${v}`);
+  senderRef.value?.clear?.();
+};
+
+const onSubmitZh: SenderProps["onSubmit"] = (v, _, skill) => {
+  loading.value = true;
+  message.info(`Send message: ${skill?.value} | ${v}`);
+  senderZhRef.value?.clear?.();
 };
 
 const onCancel = () => {
   loading.value = false;
-  message.error("取消发送！");
+  message.error("Cancel sending!");
 };
 </script>
 
 <template>
-  <ax-sender
-    :loading="loading"
-    placeholder="按 Enter 发送消息"
-    :suffix="false"
-    :auto-size="{ minRows: 3, maxRows: 6 }"
-    :on-submit="onSubmit"
-    :on-cancel="onCancel"
-  >
-    <template #footer="{ components }">
-      <a-flex justify="space-between" align="center">
-        <a-flex gap="small" align="center">
-          <a-button :style="IconStyle" type="text">
-            <template #icon>
-              <PaperClipOutlined />
-            </template>
-          </a-button>
-          <ax-sender-switch
-            :value="deepThink"
-            :on-change="(checked: boolean) => (deepThink = checked)"
-          >
-            <template #icon>
-              <OpenAIOutlined />
-            </template>
-            <template #checkedChildren>
-              <div>
-                深度搜索：
-                <span :style="SwitchTextStyle">开启</span>
-              </div>
-            </template>
-            <template #unCheckedChildren>
-              <div>
-                深度搜索：
-                <span :style="SwitchTextStyle">关闭</span>
-              </div>
-            </template>
-          </ax-sender-switch>
-          <a-dropdown
-            :menu="{
-              selectedKeys: [activeAgentKey],
-              onClick: agentItemClick,
-              items: agentItems,
-            }"
-          >
-            <template #iconRender="{ key }">
-              <SearchOutlined v-if="key === 'deep_search'" />
-              <CodeOutlined v-else-if="key === 'ai_code'" />
-              <EditOutlined v-else-if="key === 'ai_writing'" />
-            </template>
-            <ax-sender-switch :value="false">
+  <a-flex vertical gap="middle">
+    <ax-sender
+      ref="senderRef"
+      :loading="loading"
+      :skill="slotConfig.skill"
+      placeholder="Press Enter to send message"
+      :suffix="false"
+      :slot-config="slotConfig.slotConfig"
+      :auto-size="{ minRows: 3, maxRows: 6 }"
+      :on-submit="onSubmit"
+      :on-cancel="onCancel"
+    >
+      <template #footer="{ defaultNode }">
+        <a-flex justify="space-between" align="center">
+          <a-flex gap="small" align="center">
+            <a-button :style="IconStyle" type="text">
               <template #icon>
-                <SearchOutlined />
+                <PaperClipOutlined />
               </template>
-              功能应用
+            </a-button>
+            <ax-sender-switch
+              :value="deepThink"
+              :on-change="(checked: boolean) => (deepThink = checked)"
+            >
+              <template #icon>
+                <OpenAIOutlined />
+              </template>
+              <template #checkedChildren>
+                <div>
+                  Deep Think:
+                  <span :style="SwitchTextStyle">on</span>
+                </div>
+              </template>
+              <template #unCheckedChildren>
+                <div>
+                  Deep Think:
+                  <span :style="SwitchTextStyle">off</span>
+                </div>
+              </template>
             </ax-sender-switch>
-          </a-dropdown>
+            <a-dropdown
+              :menu="{
+                selectedKeys: [activeAgentKey],
+                onClick: agentItemClick,
+                items: agentItems,
+              }"
+            >
+              <template #iconRender="{ key }">
+                <SearchOutlined v-if="key === 'deep_search'" />
+                <CodeOutlined v-else-if="key === 'ai_code'" />
+                <EditOutlined v-else-if="key === 'ai_writing'" />
+              </template>
+              <ax-sender-switch :value="false">
+                <template #icon>
+                  <AntDesignOutlined />
+                </template>
+                Agent
+              </ax-sender-switch>
+            </a-dropdown>
+            <a-dropdown
+              v-if="fileItems.length"
+              :menu="{
+                onClick: fileItemClick,
+                items: fileItems,
+              }"
+            >
+              <template #iconRender="{ key }">
+                <FileImageOutlined v-if="key === 'file_image'" />
+              </template>
+              <ax-sender-switch :value="false">
+                <template #icon>
+                  <ProfileOutlined />
+                </template>
+                Files
+              </ax-sender-switch>
+            </a-dropdown>
+          </a-flex>
+          <a-flex align="center">
+            <a-button type="text" :style="IconStyle">
+              <template #icon>
+                <ApiOutlined />
+              </template>
+            </a-button>
+            <a-divider type="vertical" />
+            <component :is="defaultNode" />
+          </a-flex>
         </a-flex>
-        <a-flex align="center">
-          <a-button type="text" :style="IconStyle">
-            <template #icon>
-              <ApiOutlined />
-            </template>
-          </a-button>
-          <a-divider type="vertical" />
-          <component
-            :is="loading ? components.LoadingButton : components.SendButton"
-          />
+      </template>
+    </ax-sender>
+    <ax-sender
+      ref="senderZhRef"
+      :loading="loading"
+      :skill="slotConfig.zh_skill"
+      placeholder=""
+      :suffix="false"
+      :slot-config="slotConfig.zh_slotConfig"
+      :auto-size="{ minRows: 3, maxRows: 6 }"
+      :on-submit="onSubmitZh"
+      :on-cancel="onCancel"
+    >
+      <template #footer="{ defaultNode }">
+        <a-flex justify="space-between" align="center">
+          <a-flex gap="small" align="center">
+            <a-button :style="IconStyle" type="text">
+              <template #icon>
+                <PaperClipOutlined />
+              </template>
+            </a-button>
+            <ax-sender-switch
+              :value="deepThink"
+              :on-change="(checked: boolean) => (deepThink = checked)"
+            >
+              <template #icon>
+                <OpenAIOutlined />
+              </template>
+              <template #checkedChildren>
+                <div>
+                  深度搜索：
+                  <span :style="SwitchTextStyle">开启</span>
+                </div>
+              </template>
+              <template #unCheckedChildren>
+                <div>
+                  深度搜索：
+                  <span :style="SwitchTextStyle">关闭</span>
+                </div>
+              </template>
+            </ax-sender-switch>
+            <a-dropdown
+              :menu="{
+                selectedKeys: [activeAgentKey],
+                onClick: agentItemClick,
+                items: zhAgentItems,
+              }"
+            >
+              <template #iconRender="{ key }">
+                <SearchOutlined v-if="key === 'deep_search'" />
+                <CodeOutlined v-else-if="key === 'ai_code'" />
+                <EditOutlined v-else-if="key === 'ai_writing'" />
+              </template>
+              <ax-sender-switch :value="false">
+                <template #icon>
+                  <AntDesignOutlined />
+                </template>
+                功能应用
+              </ax-sender-switch>
+            </a-dropdown>
+            <a-dropdown
+              v-if="fileItems.length"
+              :menu="{
+                onClick: (item: { key: string }) => fileItemClick(item, 'zh'),
+                items: zhFileItems,
+              }"
+            >
+              <template #iconRender="{ key }">
+                <FileImageOutlined v-if="key === 'file_image'" />
+              </template>
+              <ax-sender-switch :value="false">
+                <template #icon>
+                  <ProfileOutlined />
+                </template>
+                文件引用
+              </ax-sender-switch>
+            </a-dropdown>
+          </a-flex>
+          <a-flex align="center">
+            <a-button type="text" :style="IconStyle">
+              <template #icon>
+                <ApiOutlined />
+              </template>
+            </a-button>
+            <a-divider type="vertical" />
+            <component :is="defaultNode" />
+          </a-flex>
         </a-flex>
-      </a-flex>
-    </template>
-  </ax-sender>
+      </template>
+    </ax-sender>
+  </a-flex>
 </template>
 
 <docs lang="zh-CN">

--- a/packages/docs/src/pages/components/sender/demo/disable-ctrl-slot.vue
+++ b/packages/docs/src/pages/components/sender/demo/disable-ctrl-slot.vue
@@ -7,7 +7,7 @@ import type {
 } from "@antdv-next/x";
 
 import { CloudUploadOutlined, PaperClipOutlined } from "@antdv-next/icons";
-import { computed, onBeforeUnmount, ref } from "vue";
+import { computed, onBeforeUnmount, ref, shallowRef } from "vue";
 
 type Attachment = Exclude<AttachmentsProps["items"], undefined>[number];
 
@@ -56,10 +56,12 @@ const onChange = ({
       file.status !== "removed" &&
       item.originFileObj
     ) {
+      // clear URL
       if (item.url?.startsWith("blob:")) {
         URL.revokeObjectURL(item.url);
       }
 
+      // create new preview URL
       return {
         ...item,
         url: URL.createObjectURL(item.originFileObj),
@@ -101,7 +103,7 @@ const onSubmit = () => {
           value = v;
         }
       "
-      placeholder="按 Enter 发送消息"
+      placeholder="Enter to send message"
       :on-submit="onSubmit"
     >
       <template #header>
@@ -128,14 +130,7 @@ const onSubmit = () => {
 
       <template #prefix>
         <a-badge :dot="items.length > 0 && !open">
-          <a-button
-            type="text"
-            @click="
-              open
-                ? (open = false)
-                : attachmentsRef?.select({ multiple: true }) || (open = true)
-            "
-          >
+          <a-button type="text" @click="open = !open">
             <template #icon>
               <PaperClipOutlined :style="{ fontSize: '16px' }" />
             </template>
@@ -144,7 +139,7 @@ const onSubmit = () => {
       </template>
 
       <template #suffix="{ components }">
-        <a-tooltip v-if="loading" title="点击取消">
+        <a-tooltip v-if="loading" title="Click to cancel">
           <component :is="components.LoadingButton" />
         </a-tooltip>
         <component

--- a/packages/docs/src/pages/components/sender/demo/disable-ctrl.vue
+++ b/packages/docs/src/pages/components/sender/demo/disable-ctrl.vue
@@ -1,9 +1,5 @@
 <script setup lang="ts">
-import type {
-  AttachmentsProps,
-  AttachmentsRef,
-  SenderRef,
-} from "@antdv-next/x";
+import type { AttachmentsProps, SenderRef } from "@antdv-next/x";
 
 import { CloudUploadOutlined, PaperClipOutlined } from "@antdv-next/icons";
 import { computed, onBeforeUnmount, ref } from "vue";
@@ -14,7 +10,6 @@ const open = ref(false);
 const value = ref("");
 const items = shallowRef<Attachment[]>([]);
 const senderRef = ref<SenderRef>();
-const attachmentsRef = ref<AttachmentsRef>();
 
 const submitDisabled = computed(
   () => items.value.length === 0 && !value.value && !loading.value,
@@ -86,7 +81,7 @@ const onSubmit = () => {
           value = v;
         }
       "
-      placeholder="按 Enter 发送消息"
+      placeholder="Enter to send message"
       :on-submit="onSubmit"
     >
       <template #header>
@@ -97,7 +92,6 @@ const onSubmit = () => {
           :styles="{ content: { padding: 0 } }"
         >
           <ax-attachments
-            ref="attachmentsRef"
             :before-upload="() => false"
             :items="items"
             @change="onChange"
@@ -113,14 +107,7 @@ const onSubmit = () => {
 
       <template #prefix>
         <a-badge :dot="items.length > 0 && !open">
-          <a-button
-            type="text"
-            @click="
-              open
-                ? (open = false)
-                : attachmentsRef?.select({ multiple: true }) || (open = true)
-            "
-          >
+          <a-button type="text" @click="open = !open">
             <template #icon>
               <PaperClipOutlined :style="{ fontSize: '16px' }" />
             </template>
@@ -129,7 +116,7 @@ const onSubmit = () => {
       </template>
 
       <template #suffix="{ components }">
-        <a-tooltip v-if="loading" title="点击取消">
+        <a-tooltip v-if="loading" title="Click to cancel">
           <component :is="components.LoadingButton" />
         </a-tooltip>
         <component

--- a/packages/docs/src/pages/components/sender/demo/footer.vue
+++ b/packages/docs/src/pages/components/sender/demo/footer.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { ApiOutlined, LinkOutlined, SearchOutlined } from "@antdv-next/icons";
-import { onBeforeUnmount, ref, watch } from "vue";
+import { theme } from "antdv-next";
+import { computed, onBeforeUnmount, ref, watch } from "vue";
+
+const { token } = theme.useToken();
 
 const loading = ref(false);
 const value = ref("");
@@ -21,7 +24,10 @@ onBeforeUnmount(() => {
   if (timer) clearTimeout(timer);
 });
 
-const iconStyle = { fontSize: "18px" };
+const iconStyle = computed(() => ({
+  fontSize: "18px",
+  color: token.value.colorText,
+}));
 </script>
 
 <template>

--- a/packages/docs/src/pages/components/sender/demo/header-fixed.vue
+++ b/packages/docs/src/pages/components/sender/demo/header-fixed.vue
@@ -29,7 +29,7 @@ function handleSubmit() {
             <a-space>
               <EnterOutlined />
               <a-typography-text type="secondary">
-                "Tell more about Antdv Next X"
+                "Tell more about Ant Design X"
               </a-typography-text>
             </a-space>
           </template>

--- a/packages/docs/src/pages/components/sender/demo/paste-image.vue
+++ b/packages/docs/src/pages/components/sender/demo/paste-image.vue
@@ -6,7 +6,7 @@ import type {
 } from "@antdv-next/x";
 
 import { CloudUploadOutlined, PaperClipOutlined } from "@antdv-next/icons";
-import { onBeforeUnmount, ref } from "vue";
+import { ref } from "vue";
 
 type Attachment = Exclude<AttachmentsProps["items"], undefined>[number];
 
@@ -17,14 +17,6 @@ const items = shallowRef<Attachment[]>([]);
 const senderRef = ref<SenderRef>();
 const attachmentsRef = ref<AttachmentsRef>();
 
-onBeforeUnmount(() => {
-  items.value.forEach(item => {
-    if (item.url?.startsWith("blob:")) {
-      URL.revokeObjectURL(item.url);
-    }
-  });
-});
-
 const onPasteFile = (files: FileList) => {
   for (const file of files) {
     attachmentsRef.value?.upload(file);
@@ -32,31 +24,8 @@ const onPasteFile = (files: FileList) => {
   open.value = true;
 };
 
-const onChange = ({
-  file,
-  fileList,
-}: {
-  file: Attachment;
-  fileList: Attachment[];
-}) => {
-  items.value = fileList.map(item => {
-    if (
-      item.uid === file.uid &&
-      file.status !== "removed" &&
-      item.originFileObj
-    ) {
-      if (item.url?.startsWith("blob:")) {
-        URL.revokeObjectURL(item.url);
-      }
-
-      return {
-        ...item,
-        url: URL.createObjectURL(item.originFileObj),
-      };
-    }
-
-    return item;
-  });
+const onChange = ({ fileList }: { fileList: Attachment[] }) => {
+  items.value = fileList;
 };
 
 const placeholder = (type: "inline" | "drop") =>
@@ -65,8 +34,8 @@ const placeholder = (type: "inline" | "drop") =>
         title: "Drop file here",
       }
     : {
-        title: "Paste or upload files",
-        description: "Paste files into the input box or click to select files",
+        title: "Upload files",
+        description: "Click or drag files to this area to upload",
       };
 
 const onSubmit = () => {
@@ -92,6 +61,7 @@ const onSubmit = () => {
         <ax-sender-header
           title="Attachments"
           :open="open"
+          force-render
           :on-open-change="
             (val: boolean) => {
               open = val;
@@ -117,9 +87,7 @@ const onSubmit = () => {
         <a-button
           type="text"
           :style="{ fontSize: '16px' }"
-          @click="
-            open ? (open = false) : attachmentsRef?.select({ multiple: true })
-          "
+          @click="open = !open"
         >
           <template #icon>
             <PaperClipOutlined />

--- a/packages/docs/src/pages/components/sender/demo/ref-action.vue
+++ b/packages/docs/src/pages/components/sender/demo/ref-action.vue
@@ -3,34 +3,31 @@ const senderRef = useTemplateRef("senderRef");
 </script>
 
 <template>
-  <a-flex vertical gap="middle">
-    <a-flex gap="middle" wrap>
-      <a-button @click="senderRef?.insert('Hello ', 'start')">
-        Insert at Start
-      </a-button>
-      <a-button @click="senderRef?.insert(' World', 'end')">
-        Insert at End
-      </a-button>
-      <a-button @click="senderRef?.insert('🐛 ', 'cursor')">
-        Insert at Cursor
-      </a-button>
-      <a-button @click="senderRef?.focus()"> Focus </a-button>
-      <a-button @click="senderRef?.focus({ cursor: 'start' })">
-        Focus at Start
-      </a-button>
-      <a-button @click="senderRef?.focus({ cursor: 'end' })">
-        Focus at End
-      </a-button>
-      <a-button @click="senderRef?.focus({ cursor: 'all' })">
-        Select All
-      </a-button>
-      <a-button @click="senderRef?.focus({ preventScroll: true })">
-        Focus (Prevent Scroll)
-      </a-button>
-      <a-button @click="senderRef?.blur()"> Blur </a-button>
-      <a-button @click="senderRef?.clear()"> Clear </a-button>
-    </a-flex>
-    <ax-sender ref="senderRef" />
+  <a-flex wrap :gap="12">
+    <a-button @click="senderRef?.insert('some text')"> Insert Text </a-button>
+    <a-button @click="senderRef?.insert('some text', 'end')">
+      Insert Text End
+    </a-button>
+    <a-button @click="senderRef?.insert('some text', 'start')">
+      Insert Text Start
+    </a-button>
+    <a-button @click="senderRef?.focus({ cursor: 'start' })">
+      Focus at first
+    </a-button>
+    <a-button @click="senderRef?.focus({ cursor: 'end' })">
+      Focus at last
+    </a-button>
+    <a-button @click="senderRef?.focus({ cursor: 'all' })">
+      Focus to select all
+    </a-button>
+    <a-button @click="senderRef?.focus({ preventScroll: true })">
+      Focus prevent scroll
+    </a-button>
+    <a-button @click="senderRef?.blur()"> Blur </a-button>
+    <ax-sender
+      ref="senderRef"
+      default-value="Hello, welcome to use Ant Design X!"
+    />
   </a-flex>
 </template>
 

--- a/packages/docs/src/pages/components/sender/demo/send-style.vue
+++ b/packages/docs/src/pages/components/sender/demo/send-style.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-import type { ButtonProps } from "antdv-next";
+import type { ButtonProps, CSSProperties } from "antdv-next";
 
 import { SendOutlined } from "@antdv-next/icons";
 import { App } from "antdv-next";
 import { onBeforeUnmount, ref, watch } from "vue";
+
 const { message } = App.useApp();
 
 const value = ref("Ask something?");
@@ -11,9 +12,10 @@ const loading = ref(false);
 
 interface SenderConfig {
   key: string;
-  placeholder: string;
+  placeholder?: string;
   ignoreLoading?: boolean;
   showIcon?: boolean;
+  buttonStyle?: CSSProperties;
   buttonProps: Partial<ButtonProps>;
 }
 
@@ -23,8 +25,8 @@ const senderConfigs: SenderConfig[] = [
     placeholder: "Change button border radius",
     buttonProps: {
       shape: "default",
-      styles: "border-radius: 12px",
     },
+    buttonStyle: { borderRadius: "12px" },
   },
   {
     key: "icon",
@@ -88,7 +90,11 @@ const onSubmit = (msg: string) => {
           v-else-if="!config.ignoreLoading"
           :title="value ? 'Send ↵' : 'Please type something'"
         >
-          <component :is="components.SendButton" v-bind="config.buttonProps">
+          <component
+            :is="components.SendButton"
+            v-bind="config.buttonProps"
+            :style="config.buttonStyle"
+          >
             <template v-if="config.showIcon" #icon>
               <SendOutlined />
             </template>
@@ -98,6 +104,7 @@ const onSubmit = (msg: string) => {
           v-else
           :is="components.SendButton"
           v-bind="config.buttonProps"
+          :style="config.buttonStyle"
         >
           <template v-if="config.showIcon" #icon>
             <SendOutlined />

--- a/packages/docs/src/pages/components/sender/demo/slot-filling.vue
+++ b/packages/docs/src/pages/components/sender/demo/slot-filling.vue
@@ -1,166 +1,306 @@
 <script setup lang="ts">
-import type { SenderProps } from "@antdv-next/x";
+import type { SenderProps, SenderRef } from "@antdv-next/x";
 
-import { Sender } from "@antdv-next/x";
-import { Button, Flex, message } from "antdv-next";
-import { ref } from "vue";
+import { App } from "antdv-next";
+import { h, ref } from "vue";
 
-const senderRef = ref<InstanceType<typeof Sender>>();
-const value = ref("");
-const slotValue = ref("");
-const skillValue = ref("");
+type SlotConfig = SenderProps["slotConfig"];
 
-const slotConfigMap = {
-  travel: [
-    { type: "text", value: "I want to travel to " },
-    {
-      type: "content",
-      key: "location",
-      props: {
-        defaultValue: "Beijing",
-        placeholder: "[Please enter location]",
-      },
+const otherSlotConfig: SlotConfig = [
+  { type: "text", value: "I want to travel to " },
+  {
+    type: "content",
+    key: "location",
+    props: {
+      defaultValue: "Beijing",
+      placeholder: "[Please enter the location]",
     },
-    { type: "text", value: " by " },
-    {
-      type: "select",
-      key: "transportation",
-      props: {
-        defaultValue: "airplane",
-        options: ["airplane", "high-speed rail", "ship"],
-        placeholder: "Please choose a mode of transportation",
-      },
+  },
+  { type: "text", value: "by" },
+  {
+    type: "select",
+    key: "transportation",
+    props: {
+      defaultValue: "airplane",
+      options: ["airplane", "high-speed rail", "cruise ship"],
+      placeholder: "Please choose a mode of transportation",
     },
-    { type: "text", value: " and budget is " },
-    {
-      type: "input",
-      key: "budget",
-      props: { placeholder: "Please enter budget" },
+  },
+  {
+    type: "text",
+    value: "with a group of 3 people, and each person has a budget of",
+  },
+  {
+    type: "custom",
+    key: "priceRange",
+    props: {
+      defaultValue: [3000, 6000],
     },
-    { type: "text", value: ". " },
-    {
-      type: "tag",
-      key: "assistant",
-      props: { label: "@Travel Planner", value: "travel" },
+    customRender: (value: any, onChange: (value: any) => void, props) => {
+      return h(
+        "div",
+        {
+          style: {
+            width: "200px",
+            paddingInline: "20px",
+            display: "inline-block",
+            alignItems: "center",
+          },
+        },
+        [
+          h("a-slider", {
+            ...props,
+            max: 8000,
+            min: 1000,
+            style: { margin: 0 },
+            range: true,
+            value,
+            onChange,
+          }),
+        ],
+      );
     },
-  ] as NonNullable<SenderProps["slotConfig"]>,
-  meeting: [
-    { type: "text", value: "Please schedule a meeting with " },
-    {
-      type: "input",
-      key: "person",
-      props: { placeholder: "name" },
+    formatResult: (value: any) => {
+      return `between ${value[0]} and ${value[1]} RMB.`;
     },
-    { type: "text", value: " at " },
-    {
-      type: "content",
-      key: "time",
-      props: { defaultValue: "10:00", placeholder: "time" },
+  },
+  { type: "text", value: "Please" },
+  {
+    type: "tag",
+    key: "tag",
+    props: { label: "@Travel Planner ", value: "travelTool" },
+  },
+  { type: "text", value: "help me create a travel itinerary,Use account " },
+  {
+    type: "input",
+    key: "account",
+    props: {
+      placeholder: "Please enter a account",
     },
-    { type: "text", value: "." },
-  ] as NonNullable<SenderProps["slotConfig"]>,
+  },
+  { type: "text", value: "." },
+];
+
+const altSlotConfig: SlotConfig = [
+  { type: "text", value: "My favorite city is " },
+  {
+    type: "select",
+    key: "city",
+    props: {
+      defaultValue: "London",
+      options: ["London", "Paris", "New York"],
+      placeholder: "Select a city",
+    },
+  },
+  { type: "text", value: ", and I want to travel with " },
+  { type: "input", key: "partner", props: { placeholder: "Enter a name" } },
+];
+
+const slotConfig = {
+  otherSlotConfig,
+  altSlotConfig,
 };
 
-const slotConfigKey = ref<keyof typeof slotConfigMap>("travel");
-const skill = ref<SenderProps["skill"]>({
-  value: "travel_skill",
+const skillConfig = {
+  value: "travelId",
   title: "Travel Planner",
-  toolTip: { title: "Travel Skill" },
-  closable: true,
-});
+  toolTip: {
+    title: "Travel Skill",
+  },
+  closable: {
+    onClose: () => {
+      console.log("close");
+    },
+  },
+};
 
-const onSubmit: SenderProps["onSubmit"] = (
+const { message } = App.useApp();
+
+const slotConfigKey = ref<keyof typeof slotConfig | false>("otherSlotConfig");
+const senderRef = ref<SenderRef>();
+const value = ref("");
+const skill = ref<SenderProps["skill"]>(skillConfig);
+const skillValue = ref("");
+const slotValue = ref("");
+
+const onSubmit: SenderProps["onSubmit"] = nextValue => {
+  value.value = nextValue;
+  slotConfigKey.value = false;
+  message.open({
+    type: "success",
+    content: `Send message success: ${nextValue}`,
+  });
+  senderRef.value?.clear?.();
+};
+
+const onChange: SenderProps["onChange"] = (
   nextValue,
+  event,
   nextSlotConfig,
   nextSkill,
 ) => {
-  value.value = nextValue;
-  slotValue.value = JSON.stringify(nextSlotConfig ?? []);
-  skillValue.value = nextSkill?.value ?? "";
-  message.success(`Send message success: ${nextValue}`);
-  senderRef.value?.clear();
+  console.log(nextValue, event, nextSlotConfig, nextSkill);
+  if (!nextSkill) {
+    skill.value = undefined;
+  }
 };
 
 const onGetValue = () => {
-  const val = senderRef.value?.getValue();
-  value.value = val?.value ?? "";
-  slotValue.value = JSON.stringify(val?.slotConfig ?? []);
-  skillValue.value = val?.skill?.value ?? "";
+  const val = senderRef.value?.getValue?.();
+  if (val?.skill) {
+    skillValue.value = val?.skill?.value;
+  }
+  value.value = val?.value ? val.value : "No value";
+  slotValue.value = val?.slotConfig
+    ? JSON.stringify(val.slotConfig)
+    : "No value";
 };
 
 const toggleSlotConfig = () => {
-  slotConfigKey.value = slotConfigKey.value === "travel" ? "meeting" : "travel";
+  slotConfigKey.value =
+    slotConfigKey.value === "otherSlotConfig"
+      ? "altSlotConfig"
+      : "otherSlotConfig";
 };
 
-const toggleSkill = () => {
-  skill.value =
-    skill.value?.value === "travel_skill"
-      ? {
-          value: "meeting_skill",
-          title: "Meeting Planner",
-          toolTip: { title: "Meeting Skill" },
-          closable: true,
-        }
-      : {
-          value: "travel_skill",
-          title: "Travel Planner",
-          toolTip: { title: "Travel Skill" },
-          closable: true,
-        };
+const changeSkill = () => {
+  skill.value = {
+    value: "travelId_1",
+    title: "Travel Planner2",
+    toolTip: {
+      title: "Travel Skill2",
+    },
+    closable: {
+      onClose: () => {
+        console.log("close");
+      },
+    },
+  };
+};
+
+const xProviderTheme = {
+  components: {
+    Sender: {
+      fontSize: 16,
+    },
+  },
 };
 </script>
 
 <template>
-  <Flex vertical :gap="16">
-    <Flex wrap :gap="8">
-      <Button @click="senderRef?.clear()"> Clear </Button>
-      <Button @click="onGetValue"> Get Value </Button>
-      <Button @click="senderRef?.insert(' some text ', 'cursor')">
+  <a-flex vertical :gap="16">
+    <!-- 操作按钮区 -->
+    <a-flex wrap :gap="8">
+      <a-button @click="senderRef?.clear?.()"> Clear </a-button>
+      <a-button @click="onGetValue"> Get Value </a-button>
+      <a-button
+        @click="senderRef?.insert?.([{ type: 'text', value: ' some text A' }])"
+      >
         Insert Text
-      </Button>
-      <Button
+      </a-button>
+      <a-button
         @click="
-          senderRef?.insert([
+          senderRef?.insert?.([
+            { type: 'text', value: ' some text B' },
             {
-              type: 'input',
-              key: `name_${Date.now()}`,
-              props: { placeholder: 'Enter a name' },
+              type: 'content',
+              key: `partner_3_${Date.now()}`,
+              props: { defaultValue: '11' },
+            },
+          ])
+        "
+      >
+        Insert Slots
+      </a-button>
+      <a-button
+        @click="
+          senderRef?.insert?.([
+            {
+              type: 'content',
+              key: `partner_1_${Date.now()}`,
+              props: { defaultValue: 'NingNing', placeholder: 'Enter a name' },
             },
           ])
         "
       >
         Insert Slot
-      </Button>
-      <Button @click="toggleSlotConfig"> Change SlotConfig </Button>
-      <Button @click="senderRef?.focus()"> Focus </Button>
-      <Button @click="senderRef?.focus({ cursor: 'start' })">
-        Focus Start
-      </Button>
-      <Button @click="senderRef?.focus({ cursor: 'end' })"> Focus End </Button>
-      <Button @click="senderRef?.focus({ cursor: 'slot' })">
-        Focus Slot
-      </Button>
-      <Button @click="senderRef?.focus({ cursor: 'slot', key: 'budget' })">
-        Focus Slot By Key
-      </Button>
-      <Button @click="toggleSkill"> Change Skill </Button>
-    </Flex>
+      </a-button>
+      <a-button
+        @click="
+          senderRef?.insert?.(
+            [
+              {
+                type: 'input',
+                key: `partner_2_${Date.now()}`,
+                props: { placeholder: 'Enter a name' },
+              },
+            ],
+            'start',
+          )
+        "
+      >
+        Insert Slot Start
+      </a-button>
+      <a-button
+        @click="
+          senderRef?.insert?.(
+            [
+              {
+                type: 'input',
+                key: `partner_3_${Date.now()}`,
+                props: { placeholder: 'Enter a name' },
+              },
+            ],
+            'end',
+          )
+        "
+      >
+        Insert Slot End
+      </a-button>
+      <a-button @click="toggleSlotConfig"> Change SlotConfig </a-button>
+      <a-button @click="senderRef?.focus()"> Focus </a-button>
+      <a-button @click="senderRef?.focus({ cursor: 'start' })">
+        Focus at first
+      </a-button>
+      <a-button @click="senderRef?.focus({ cursor: 'end' })">
+        Focus at last
+      </a-button>
+      <a-button @click="senderRef?.focus({ cursor: 'slot' })">
+        Focus at slot
+      </a-button>
+      <a-button @click="senderRef?.focus({ cursor: 'slot', key: 'account' })">
+        Focus at slot with key
+      </a-button>
+      <a-button @click="senderRef?.focus({ cursor: 'all' })">
+        Focus to select all
+      </a-button>
+      <a-button @click="senderRef?.focus({ preventScroll: true })">
+        Focus prevent scroll
+      </a-button>
+      <a-button @click="senderRef?.blur()"> Blur </a-button>
+      <a-button @click="changeSkill"> Change Skill </a-button>
+    </a-flex>
 
-    <Sender
-      ref="senderRef"
-      :slot-config="slotConfigMap[slotConfigKey]"
-      :skill="skill"
-      :auto-size="{ minRows: 3, maxRows: 4 }"
-      placeholder="Enter to send message"
-      :on-submit="onSubmit"
-    />
+    <!-- Sender 词槽填空示例 -->
+    <ax-x-provider :theme="xProviderTheme">
+      <ax-sender
+        ref="senderRef"
+        :skill="skill"
+        allow-speech
+        :auto-size="{ minRows: 3, maxRows: 4 }"
+        placeholder="Enter to send message"
+        :slot-config="slotConfigKey ? slotConfig?.[slotConfigKey] : []"
+        :on-submit="onSubmit"
+        :on-change="onChange"
+      />
+    </ax-x-provider>
 
-    <Flex vertical gap="small">
-      <div v-if="value">value: {{ value }}</div>
-      <div v-if="slotValue">slotConfig: {{ slotValue }}</div>
-      <div v-if="skillValue">skill: {{ skillValue }}</div>
-    </Flex>
-  </Flex>
+    <a-flex vertical gap="middle">
+      <div>{{ skillValue ? `skill:${skillValue}` : null }}</div>
+      <div>{{ value ? `value:${value}` : null }}</div>
+      <div>{{ slotValue ? `slotValue:${slotValue}` : null }}</div>
+    </a-flex>
+  </a-flex>
 </template>
 
 <docs lang="zh-CN">

--- a/packages/docs/src/pages/components/sender/demo/slot-with-suggestion.vue
+++ b/packages/docs/src/pages/components/sender/demo/slot-with-suggestion.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { SuggestionItem } from "@antdv-next/x";
+import type { SenderProps, SuggestionItem } from "@antdv-next/x";
 import type { MenuProps } from "antdv-next";
 
 import {
@@ -15,17 +15,87 @@ import {
   SearchOutlined,
 } from "@antdv-next/icons";
 import { App } from "antdv-next";
-import { nextTick, onBeforeUnmount, ref } from "vue";
+import { h, onBeforeUnmount, ref, watch } from "vue";
+
 const { message } = App.useApp();
 
-const agentMap: Record<string, { icon: any; label: string }> = {
-  deep_search: { icon: SearchOutlined, label: "Deep Search" },
-  ai_code: { icon: CodeOutlined, label: "AI Code" },
-  ai_writing: { icon: EditOutlined, label: "Writing" },
+interface AgentInfoItem {
+  icon: any;
+  label: string;
+  slotConfig: SenderProps["slotConfig"];
+}
+
+const AgentInfo: Record<string, AgentInfoItem> = {
+  deep_search: {
+    icon: SearchOutlined,
+    label: "Deep Search",
+    slotConfig: [
+      { type: "text", value: "Please help me search for news about " },
+      {
+        type: "select",
+        key: "search_type",
+        props: {
+          options: ["AI", "Technology", "Entertainment"],
+          placeholder: "Please select a category",
+        },
+      },
+      { type: "text", value: " and summarize it into a list." },
+    ],
+  },
+  ai_code: {
+    icon: CodeOutlined,
+    label: "AI Code",
+    slotConfig: [
+      { type: "text", value: "Please use " },
+      {
+        type: "select",
+        key: "code_lang",
+        props: {
+          options: ["JS", "C++", "Java"],
+          placeholder: "Please select a programming language",
+        },
+      },
+      { type: "text", value: " to write a mini game." },
+    ],
+  },
+  ai_writing: {
+    icon: EditOutlined,
+    label: "Writing",
+    slotConfig: [
+      { type: "text", value: "Please write an article about " },
+      {
+        type: "select",
+        key: "writing_type",
+        props: {
+          options: ["Campus", "Travel", "Reading"],
+          placeholder: "Please enter a topic",
+        },
+      },
+      { type: "text", value: ". The requirement is " },
+      {
+        type: "input",
+        key: "writing_num",
+        props: {
+          defaultValue: "800",
+          placeholder: "Please enter the number of words.",
+        },
+      },
+      { type: "text", value: " words." },
+    ],
+  },
 };
 
-const fileMap: Record<string, { icon: any; label: string }> = {
+const FileInfo: Record<string, { icon: any; label: string }> = {
   file_image: { icon: FileImageOutlined, label: "x-image" },
+};
+
+const iconStyle = { fontSize: "16px" };
+
+const switchTextStyle = {
+  display: "inline-flex",
+  width: "28px",
+  justifyContent: "center",
+  alignItems: "center",
 };
 
 const suggestions: SuggestionItem[] = [
@@ -34,6 +104,7 @@ const suggestions: SuggestionItem[] = [
   {
     label: "Check some knowledge",
     value: "knowledge",
+    icon: h(OpenAIFilled),
     children: [
       { label: "About React", value: "react" },
       { label: "About Ant Design", value: "antd" },
@@ -44,59 +115,67 @@ const suggestions: SuggestionItem[] = [
 const loading = ref(false);
 const deepThink = ref(true);
 const activeAgentKey = ref("deep_search");
-const value = ref("");
 
 const senderRef = useTemplateRef("senderRef");
 
-const agentItems = Object.entries(agentMap).map(([key, { icon, label }]) => ({
-  key,
-  label,
-  icon,
-}));
+const agentItems = Object.keys(AgentInfo).map(agent => {
+  const { icon, label } = AgentInfo[agent];
+  return { key: agent, icon: h(icon), label };
+});
 
-const fileItems = Object.entries(fileMap).map(([key, { icon, label }]) => ({
-  key,
-  label,
-  icon,
-}));
+const fileItems = Object.keys(FileInfo).map(file => {
+  const { icon, label } = FileInfo[file];
+  return { key: file, icon: h(icon), label };
+});
 
 const agentItemClick: MenuProps["onClick"] = item => {
   activeAgentKey.value = item.key as string;
 };
 
 const fileItemClick: MenuProps["onClick"] = item => {
-  const file = fileMap[item.key as string];
-  if (!file) return;
-  senderRef.value?.insert(` [${file.label}] `, "cursor");
+  const { icon, label } = FileInfo[item.key as string];
+  senderRef.value?.insert?.([
+    {
+      type: "tag",
+      key: `${item.key}_${Date.now()}`,
+      props: {
+        label: h("div", { style: { display: "flex", gap: "8px" } }, [
+          h(icon),
+          label,
+        ]),
+        value: item.key as string,
+      },
+    },
+  ]);
 };
 
-const switchTextStyle = {
-  display: "inline-flex",
-  width: "28px",
-  justifyContent: "center",
-  alignItems: "center",
-};
-
-const iconStyle = { fontSize: "16px" };
-
+// Mock send message
 let timer: ReturnType<typeof setTimeout> | undefined;
+watch(loading, val => {
+  if (val) {
+    timer = setTimeout(() => {
+      loading.value = false;
+      message.success("Send message successfully!");
+    }, 3000);
+  }
+});
 
 onBeforeUnmount(() => {
   if (timer) clearTimeout(timer);
 });
 
 const onSelectSuggestion = () => {
-  if (value.value.endsWith("@")) {
-    value.value = value.value.slice(0, -1);
-  }
-
-  nextTick(() => {
-    senderRef.value?.insert("[Enter a name] ", "cursor");
-  });
-};
-
-const onSenderChange = (nextValue: string) => {
-  value.value = nextValue;
+  senderRef.value?.insert?.(
+    [
+      {
+        type: "content",
+        key: `partner_2_${Date.now()}`,
+        props: { placeholder: "Enter a name" },
+      },
+    ],
+    "cursor",
+    "@",
+  );
 };
 
 const onSenderKeyDown = (
@@ -107,23 +186,16 @@ const onSenderKeyDown = (
   if (event.key === "@") {
     onTrigger();
   }
-
   return onSuggestionKeyDown(event);
 };
 
 const onSubmit = (content: string) => {
   loading.value = true;
   message.info(`Send message: ${content}`);
-  senderRef.value?.clear();
-  if (timer) clearTimeout(timer);
-  timer = setTimeout(() => {
-    loading.value = false;
-    message.success("Send message successfully!");
-  }, 3000);
+  senderRef.value?.clear?.();
 };
 
 const onCancel = () => {
-  if (timer) clearTimeout(timer);
   loading.value = false;
   message.error("Cancel sending!");
 };
@@ -136,11 +208,10 @@ const onCancel = () => {
         <ax-sender
           ref="senderRef"
           :loading="loading"
-          :value="value"
           placeholder="Press Enter to send message"
           :suffix="false"
           :auto-size="{ minRows: 3, maxRows: 6 }"
-          :on-change="onSenderChange"
+          :slot-config="AgentInfo[activeAgentKey].slotConfig"
           :on-key-down="
             (event: KeyboardEvent) =>
               onSenderKeyDown(event, onTrigger, onKeyDown)
@@ -148,7 +219,7 @@ const onCancel = () => {
           :on-submit="onSubmit"
           :on-cancel="onCancel"
         >
-          <template #footer="{ components }">
+          <template #footer="{ defaultNode }">
             <a-flex justify="space-between" align="center">
               <a-flex gap="small" align="center">
                 <a-button :style="iconStyle" type="text">
@@ -165,14 +236,12 @@ const onCancel = () => {
                   </template>
                   <template #checkedChildren>
                     <div>
-                      Deep Think:
-                      <span :style="switchTextStyle">on</span>
+                      Deep Think:<span :style="switchTextStyle">on</span>
                     </div>
                   </template>
                   <template #unCheckedChildren>
                     <div>
-                      Deep Think:
-                      <span :style="switchTextStyle">off</span>
+                      Deep Think:<span :style="switchTextStyle">off</span>
                     </div>
                   </template>
                 </ax-sender-switch>
@@ -183,11 +252,6 @@ const onCancel = () => {
                     items: agentItems,
                   }"
                 >
-                  <template #iconRender="{ key }">
-                    <SearchOutlined v-if="key === 'deep_search'" />
-                    <CodeOutlined v-else-if="key === 'ai_code'" />
-                    <EditOutlined v-else-if="key === 'ai_writing'" />
-                  </template>
                   <ax-sender-switch :value="false">
                     <template #icon>
                       <AntDesignOutlined />
@@ -202,9 +266,6 @@ const onCancel = () => {
                     items: fileItems,
                   }"
                 >
-                  <template #iconRender="{ key }">
-                    <FileImageOutlined v-if="key === 'file_image'" />
-                  </template>
                   <ax-sender-switch :value="false">
                     <template #icon>
                       <ProfileOutlined />
@@ -220,21 +281,11 @@ const onCancel = () => {
                   </template>
                 </a-button>
                 <a-divider type="vertical" />
-                <component :is="components.SpeechButton" />
-                <a-divider type="vertical" />
-                <component
-                  :is="
-                    loading ? components.LoadingButton : components.SendButton
-                  "
-                />
+                <component :is="defaultNode" />
               </a-flex>
             </a-flex>
           </template>
         </ax-sender>
-      </template>
-
-      <template #iconRender="{ item }">
-        <OpenAIFilled v-if="item.value === 'knowledge'" />
       </template>
     </ax-suggestion>
   </a-flex>

--- a/packages/docs/src/pages/components/sender/demo/speech-custom.vue
+++ b/packages/docs/src/pages/components/sender/demo/speech-custom.vue
@@ -1,17 +1,23 @@
 <script setup lang="ts">
+import { App } from "antdv-next";
 import { ref } from "vue";
 
+const { message } = App.useApp();
+
+// When setting `recording`, the built-in speech recognition feature will be disabled
 const recording = ref(false);
+
+function handleRecordingChange(nextRecording: boolean) {
+  message.info(`Mock Customize Recording: ${nextRecording}`);
+  recording.value = nextRecording;
+}
 </script>
 
 <template>
   <ax-sender
     :allow-speech="{
       recording,
-      onRecordingChange: (next: boolean) => {
-        recording = next;
-        console.log('Recording:', next);
-      },
+      onRecordingChange: handleRecordingChange,
     }"
   />
 </template>

--- a/packages/docs/src/pages/components/sender/demo/suffix.vue
+++ b/packages/docs/src/pages/components/sender/demo/suffix.vue
@@ -1,20 +1,28 @@
 <script setup lang="ts">
 import { OpenAIOutlined } from "@antdv-next/icons";
 import { App } from "antdv-next";
-import { ref } from "vue";
+import { onBeforeUnmount, ref, watch } from "vue";
+
 const { message } = App.useApp();
 
 const value = ref("");
 const loading = ref(false);
 
-function handleSubmit() {
-  loading.value = true;
-  setTimeout(() => {
-    loading.value = false;
-    value.value = "";
-    message.success("Send message successfully!");
-  }, 2000);
-}
+let timer: ReturnType<typeof setTimeout> | undefined;
+
+watch(loading, val => {
+  if (val) {
+    timer = setTimeout(() => {
+      loading.value = false;
+      value.value = "";
+      message.success("Send message successfully!");
+    }, 2000);
+  }
+});
+
+onBeforeUnmount(() => {
+  if (timer) clearTimeout(timer);
+});
 </script>
 
 <template>
@@ -23,7 +31,7 @@ function handleSubmit() {
     :value="value"
     :loading="loading"
     :on-change="(v: string) => (value = v)"
-    :on-submit="handleSubmit"
+    :on-submit="() => (loading = true)"
     :on-cancel="() => (loading = false)"
   >
     <template #suffix="{ components }">
@@ -34,11 +42,27 @@ function handleSubmit() {
         <component :is="components.ClearButton" />
         <component :is="components.SpeechButton" />
         <component
-          :is="loading ? components.LoadingButton : components.SendButton"
+          v-if="loading"
+          :is="components.LoadingButton"
+          type="default"
+          variant="filled"
+          disabled
+        >
+          <template #icon>
+            <a-spin
+              size="small"
+              :style="{ display: 'flex' }"
+              :styles="{ indicator: { color: '#fff' } }"
+            />
+          </template>
+        </component>
+        <component
+          v-else
+          :is="components.SendButton"
           type="primary"
           :disabled="false"
         >
-          <template v-if="!loading" #icon>
+          <template #icon>
             <OpenAIOutlined />
           </template>
         </component>

--- a/packages/docs/src/pages/components/sender/demo/switch.vue
+++ b/packages/docs/src/pages/components/sender/demo/switch.vue
@@ -17,7 +17,7 @@ const controlled = ref(false);
       </ax-sender-switch>
     </a-flex>
     <a-flex align="center" gap="small">
-      Custom checked/unchecked:
+      Custom checked/unchecked content:
       <ax-sender-switch
         checked-children="Deep Search: on"
         un-checked-children="Deep Search: off"
@@ -49,7 +49,9 @@ const controlled = ref(false);
       DefaultValue:
       <ax-sender-switch
         :default-value="true"
-        :on-change="(checked: boolean) => console.log('toggled', checked)"
+        :on-change="
+          (checked: boolean) => console.log('Switch toggled', checked)
+        "
       >
         <template #icon>
           <SearchOutlined />
@@ -58,7 +60,7 @@ const controlled = ref(false);
       </ax-sender-switch>
     </a-flex>
     <a-flex align="center" gap="small">
-      Controlled:
+      Controlled mode:
       <ax-sender-switch
         :value="controlled"
         :on-change="(v: boolean) => (controlled = v)"

--- a/packages/docs/src/pages/components/sender/index.en-US.md
+++ b/packages/docs/src/pages/components/sender/index.en-US.md
@@ -19,17 +19,17 @@ description: A chat input component for sending messages.
 <demo src="./demo/speech.vue">Voice Input</demo>
 <demo src="./demo/speech-custom.vue">Custom Voice Input</demo>
 <demo src="./demo/suffix.vue">Custom Suffix</demo>
-<demo src="./demo/layout-slots.vue">Layout Slots</demo>
 <demo src="./demo/disable-ctrl.vue">Disable Ctrl</demo>
 <demo src="./demo/disable-ctrl-slot.vue">Disable Ctrl with Slots</demo>
 <demo src="./demo/header.vue">Expand Panel</demo>
-<demo src="./demo/header-title-slot.vue">Header Title Slot</demo>
-<demo src="./demo/switch-slots.vue">Switch Slots</demo>
 <demo src="./demo/slot-with-suggestion.vue">Quick Commands</demo>
 <demo src="./demo/header-fixed.vue">References</demo>
 <demo src="./demo/footer.vue">Custom Footer Content</demo>
 <demo src="./demo/send-style.vue">Style Adjustment</demo>
 <demo src="./demo/paste-image.vue">Paste Files</demo>
+<demo src="./demo/layout-slots.vue">Layout Slots</demo>
+<demo src="./demo/header-title-slot.vue">Header Title Slot</demo>
+<demo src="./demo/switch-slots.vue">Switch Slots</demo>
 <demo src="./demo/loading.vue">Loading</demo>
 
 ## API

--- a/packages/docs/src/pages/components/sender/index.zh-CN.md
+++ b/packages/docs/src/pages/components/sender/index.zh-CN.md
@@ -19,17 +19,17 @@ description: 用于聊天的输入框组件。
 <demo src="./demo/speech.vue">语音输入</demo>
 <demo src="./demo/speech-custom.vue">自定义语音输入</demo>
 <demo src="./demo/suffix.vue">自定义后缀</demo>
-<demo src="./demo/layout-slots.vue">区域插槽</demo>
 <demo src="./demo/disable-ctrl.vue">发送控制</demo>
 <demo src="./demo/disable-ctrl-slot.vue">词槽发送控制</demo>
 <demo src="./demo/header.vue">展开面板</demo>
-<demo src="./demo/header-title-slot.vue">头部标题插槽</demo>
-<demo src="./demo/switch-slots.vue">开关插槽</demo>
 <demo src="./demo/slot-with-suggestion.vue">快捷指令</demo>
 <demo src="./demo/header-fixed.vue">引用</demo>
 <demo src="./demo/footer.vue">自定义底部内容</demo>
 <demo src="./demo/send-style.vue">调整样式</demo>
 <demo src="./demo/paste-image.vue">黏贴文件</demo>
+<demo src="./demo/layout-slots.vue">区域插槽</demo>
+<demo src="./demo/header-title-slot.vue">头部标题插槽</demo>
+<demo src="./demo/switch-slots.vue">开关插槽</demo>
 <demo src="./demo/loading.vue">加载状态</demo>
 
 ## API


### PR DESCRIPTION
## 背景

当前 Sender 组件的 demo 用例与上游 [ant-design-x](https://github.com/ant-design/x) 的 `packages/x/components/sender/demo` 差距较大：复杂示例（如 `agent`、`slot-filling`、`slot-with-suggestion`）被简化、缺少英文示例、缺失 `skill` / `slotConfig` 体系。本 PR 将 demo 严格对齐上游参考实现，**标题、描述、demo 内容**三者保持一致。

## 改动

将 17 个上游 demo 忠实移植到 Vue：

- **agent**：双语（EN/ZH）双输入框，完整 `skill` / `slotConfig` 映射（deep_search / ai_code / ai_writing）、智能体与文件下拉、Deep Think 开关、通过 ref 插入 `tag` 节点。
- **slot-filling**：完整 `slotConfig`（content / select / 自定义 slider / tag / input）、完整 ref 操作按钮集、`XProvider` 主题。
- **slot-with-suggestion**：补齐 `slotConfig` 数据，`@` 触发词槽插入（`insert(replaceCharacters)`）。
- **disable-ctrl(-slot)、suffix、send-style、footer、paste-image、switch、speech-custom、ref-action、header-fixed**：对齐文案、locale、样式与交互。
- **index 文档**：按上游顺序重排 demo 列表；Vue 专属 demo（`layout-slots`、`header-title-slot`、`switch-slots`、`loading`）保留在列表末尾。

各 demo 的 `<docs>` 描述与上游 `.md` 已一致，标题与上游 `index.*.md` 一致。

## 验证

- `pnpm docs:build` 通过（exit 0）。
- `vp lint` / pre-commit `vp check` 通过。