### PR TITLE
fix(sender): 修复受控模式下 onRecordingChange 始终传入 true 的问题

### DIFF
--- a/packages/x/components/sender/hooks/use-speech.ts
+++ b/packages/x/components/sender/hooks/use-speech.ts
@@ -107,7 +107,9 @@ export default function useSpeech(
     forceBreak = doForceBreak;
 
     if (isControlled.value) {
-      speechConfig.value?.onRecordingChange(!recording.value);
+      const nextRecording = !speechConfig.value.recording;
+      recording.value = nextRecording;
+      speechConfig.value?.onRecordingChange(nextRecording);
       return;
     }
 


### PR DESCRIPTION
## 问题

`Sender` 组件的 `speech-config` 中，受控模式下 `onRecordingChange` 回调传入的参数始终为 `true`，无法正确切换录音状态。

## 根因

`triggerSpeech` 在受控模式下使用 `!recording.value` 取反，但 `recording` 是内部 `ref(false)`。受控模式下 `return` 提前退出，不会触发 SpeechRecognition 的 `onstart/onend` 来更新内部状态，导致 `recording.value` 始终为 `false`，`!recording.value` 始终为 `true`。

## 修复

使用外部受控状态 `speechConfig.value.recording` 取反，并同步更新内部 `recording.value`：

```diff
  if (isControlled.value) {
-   speechConfig.value?.onRecordingChange(!recording.value);
+   const nextRecording = !speechConfig.value.recording;
+   recording.value = nextRecording;
+   speechConfig.value?.onRecordingChange(nextRecording);
    return;
  }
```