### PR TITLE
fix(sender): sync controlled speech recording state

### DIFF
--- a/packages/x/components/sender/__tests__/index.test.tsx
+++ b/packages/x/components/sender/__tests__/index.test.tsx
@@ -141,6 +141,36 @@ describe("Sender", () => {
     expect(presets.classes()).toContain("ant-flex");
   });
 
+  it("should follow controlled speech recording state", async () => {
+    const onRecordingChange = vi.fn();
+    const wrapper = mount(Sender, {
+      props: {
+        allowSpeech: {
+          recording: false,
+          onRecordingChange,
+        },
+      },
+    });
+
+    await wrapper.findAll(".antd-sender-actions-btn")[0]!.trigger("click");
+    expect(onRecordingChange).toHaveBeenLastCalledWith(true);
+
+    onRecordingChange.mockClear();
+    await wrapper.setProps({
+      allowSpeech: {
+        recording: true,
+        onRecordingChange,
+      },
+    });
+
+    expect(
+      wrapper.find(".antd-sender-actions-btn-recording-icon").exists(),
+    ).toBe(true);
+
+    await wrapper.findAll(".antd-sender-actions-btn")[0]!.trigger("click");
+    expect(onRecordingChange).toHaveBeenLastCalledWith(false);
+  });
+
   it("should render loading button when loading", () => {
     const wrapper = mount(Sender, {
       props: { loading: true },

--- a/packages/x/components/sender/hooks/use-speech.ts
+++ b/packages/x/components/sender/hooks/use-speech.ts
@@ -78,6 +78,9 @@ export default function useSpeech(
         (getSpeechRecognition() && permissionState.value !== "denied")
       ),
   );
+  const mergedRecording = computed(() =>
+    isControlled.value ? !!speechConfig.value?.recording : recording.value,
+  );
 
   const ensureRecognition = () => {
     if (!mergedAllowSpeech.value || recognition) return;
@@ -102,21 +105,21 @@ export default function useSpeech(
   };
 
   const triggerSpeech = (doForceBreak: boolean) => {
-    if (doForceBreak && !recording.value) return;
+    const currentRecording = mergedRecording.value;
+    if (doForceBreak && !currentRecording) return;
 
     forceBreak = doForceBreak;
 
-    if (isControlled.value) {
-      const nextRecording = !speechConfig.value.recording;
-      recording.value = nextRecording;
-      speechConfig.value?.onRecordingChange(nextRecording);
+    const config = speechConfig.value;
+    if (typeof config?.recording === "boolean") {
+      config.onRecordingChange(!config.recording);
       return;
     }
 
     ensureRecognition();
     if (!recognition) return;
 
-    if (recording.value) {
+    if (currentRecording) {
       recognition.stop();
       speechConfig.value?.onRecordingChange?.(false);
     } else {
@@ -125,5 +128,5 @@ export default function useSpeech(
     }
   };
 
-  return [mergedAllowSpeech, triggerSpeech, recording] as const;
+  return [mergedAllowSpeech, triggerSpeech, mergedRecording] as const;
 }


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [x] 🐞 Bug 修复
- [ ] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

修复 Sender `allowSpeech` 受控模式下录音状态切换回调与外部状态不同步的问题。

### 💡 背景与方案

`Sender` 在 `allowSpeech` 使用对象配置且传入 `recording` 时，会进入受控录音模式。此前内部仍使用本地 `recording` ref 作为按钮状态与下一次回调值的来源，导致外部更新 `recording` 后，内部状态可能不同步。

本次调整新增 `mergedRecording`：

- 受控模式下直接使用 `allowSpeech.recording` 作为当前录音状态；
- 非受控模式下继续使用内部 `recording` ref；
- 触发语音按钮时基于受控配置计算下一次 `onRecordingChange` 入参；
- 补充回归测试，覆盖外部将 `recording` 从 `false` 更新到 `true` 后再次点击应回调 `false`。

### 📝 变更日志

| 语言    | 变更日志 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Sender controlled speech recording state synchronization. |
| 🇨🇳 中文 | 修复 Sender 受控语音录制状态与外部 `recording` 不同步的问题。 |
