### PR TITLE
docs(markdown): optimize streaming-format demo styles

### DIFF
--- a/packages/docs/src/pages/markdown/demo/streaming-format.vue
+++ b/packages/docs/src/pages/markdown/demo/streaming-format.vue
@@ -351,8 +351,15 @@ const handleDemoChange = (value: string | number) => {
       <Card
         title="Rendered Output"
         size="small"
-        class="flex flex-1 flex-col min-w-0"
-        :bodyStyle="{ flex: 1, minHeight: 0 }"
+        style="flex: 1; display: flex; flex-direction: column; min-width: 0"
+        :styles="{
+          body: {
+            flex: 1,
+            minHeight: 0,
+            display: 'flex',
+            flexDirection: 'column',
+          },
+        }"
       >
         <template #extra>
           <Button size="small" @click="rerender">Re-Render</Button>

--- a/packages/docs/src/pages/markdown/demo/streaming-format.vue
+++ b/packages/docs/src/pages/markdown/demo/streaming-format.vue
@@ -221,7 +221,7 @@ const IncompleteEmphasis = defineComponent({
       if (!match || !match[2]) return null;
 
       const [, symbols, content] = match;
-      const level = symbols.length;
+      const level = symbols?.length;
 
       if (level === 1) return h("em", content);
       if (level === 2) return h("strong", content);
@@ -329,8 +329,15 @@ const handleDemoChange = (value: string | number) => {
       <Card
         title="Markdown Source"
         size="small"
-        class="flex flex-1 flex-col min-w-0"
-        :bodyStyle="{ flex: 1, minHeight: 0 }"
+        style="flex: 1; display: flex; flex-direction: column; min-width: 0"
+        :styles="{
+          body: {
+            flex: 1,
+            minHeight: 0,
+            display: 'flex',
+            flexDirection: 'column',
+          },
+        }"
       >
         <div
           ref="sourceRef"


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 📽️ Demo improvement

### 🔗 Related Issues

> N/A

### 💡 Background and Solution

The Markdown streaming-format demo relied on Tailwind utility classes (`flex flex-1 flex-col min-w-0`) plus a `:bodyStyle` prop to lay out the "Markdown Source" card. This made the demo depend on Tailwind being present and used the deprecated `bodyStyle` prop. The layout is now expressed with plain inline `style` + the `:styles="{ body: ... }"` API so the demo renders correctly standalone. Also hardened the incomplete-emphasis parser with optional chaining (`symbols?.length`).

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Improve the Markdown streaming-format demo: replace Tailwind classes with inline styles and use the `styles` API instead of the deprecated `bodyStyle`. |
| 🇨🇳 Chinese | 优化 Markdown streaming-format 示例：使用内联样式替换 Tailwind 类，并以 `styles` API 取代已废弃的 `bodyStyle`。 |
