### PR TITLE
feat(code-highlighter): support custom header via scoped slot

### DIFF
--- a/packages/docs/src/pages/components/code-highlighter/demo/custom-header.vue
+++ b/packages/docs/src/pages/components/code-highlighter/demo/custom-header.vue
@@ -1,0 +1,48 @@
+<script setup lang="ts">
+const code = `import { createApp } from "vue";
+import App from "./App.vue";
+
+createApp(App).mount("#app");`;
+</script>
+
+<template>
+  <ax-code-highlighter :content="code" language="typescript">
+    <template #header="{ language, copied, copy, theme, toggleTheme }">
+      <div class="custom-header">
+        <span class="custom-title">{{ language }}</span>
+        <a-space>
+          <a-button size="small" @click="toggleTheme">
+            {{ theme === "light" ? "🌙 Dark" : "☀️ Light" }}
+          </a-button>
+          <a-button type="primary" size="small" @click="copy">
+            {{ copied ? "已复制" : "复制" }}
+          </a-button>
+        </a-space>
+      </div>
+    </template>
+  </ax-code-highlighter>
+</template>
+
+<style scoped>
+.custom-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  background: var(--ant-color-fill-secondary, #fafafa);
+  border-bottom: 1px solid var(--ant-color-border, #d9d9d9);
+}
+
+.custom-title {
+  font-weight: 500;
+  text-transform: uppercase;
+}
+</style>
+
+<docs lang="zh-CN">
+通过 `header` 插槽自定义头部内容。插槽作用域提供 `language`、`theme`、`copied` 状态以及 `copy`、`toggleTheme` 方法，可在自定义头部中复用复制与主题切换能力。
+</docs>
+
+<docs lang="en-US">
+Customize header content via the `header` slot. The slot scope exposes the `language`, `theme`, and `copied` state along with the `copy` and `toggleTheme` methods, so you can reuse the copy and theme-toggle capabilities inside your custom header.
+</docs>

--- a/packages/docs/src/pages/components/code-highlighter/index.en-US.md
+++ b/packages/docs/src/pages/components/code-highlighter/index.en-US.md
@@ -20,6 +20,8 @@ description: Display code blocks in AI conversation scenarios with syntax highli
 
 <demo src="./demo/copyable.vue">Copy Functionality</demo>
 
+<demo src="./demo/custom-header.vue">Custom Header</demo>
+
 ## API
 
 ### Props
@@ -43,6 +45,24 @@ description: Display code blocks in AI conversation scenarios with syntax highli
 | ------------ | ---------------------------- | ------------------------------------ |
 | copy         | Callback when code is copied | `(content: string) => void`          |
 | update:theme | Emitted when theme changes   | `(theme: 'light' \| 'dark') => void` |
+
+### Slots
+
+| Slot     | Description                                                        | Type                                     |
+| -------- | ------------------------------------------------------------------ | ---------------------------------------- |
+| `header` | Custom header area, exposing language, theme and copy capabilities | `(scope: HeaderSlotScope) => VNodeChild` |
+
+`header` slot scope `HeaderSlotScope`:
+
+| Parameter     | Description                 | Type                |
+| ------------- | --------------------------- | ------------------- |
+| `language`    | Current code language       | `string`            |
+| `theme`       | Current theme mode          | `'light' \| 'dark'` |
+| `copied`      | Whether in the copied state | `boolean`           |
+| `copy`        | Copy the code content       | `() => void`        |
+| `toggleTheme` | Toggle the theme mode       | `() => void`        |
+
+When the `header` slot is provided, it fully replaces the default header (language label, theme toggle and copy button).
 
 ### Ref
 

--- a/packages/docs/src/pages/components/code-highlighter/index.zh-CN.md
+++ b/packages/docs/src/pages/components/code-highlighter/index.zh-CN.md
@@ -20,6 +20,8 @@ description: 用于 AI 对话场景中展示代码块，提供语法高亮、行
 
 <demo src="./demo/copyable.vue">复制功能</demo>
 
+<demo src="./demo/custom-header.vue">自定义 Header</demo>
+
 ## API
 
 ### 属性
@@ -43,6 +45,24 @@ description: 用于 AI 对话场景中展示代码块，提供语法高亮、行
 | ------------ | -------------- | ------------------------------------ |
 | copy         | 复制成功回调   | `(content: string) => void`          |
 | update:theme | 主题切换时触发 | `(theme: 'light' \| 'dark') => void` |
+
+### 插槽
+
+| 插槽名   | 说明                                     | 类型                                     |
+| -------- | ---------------------------------------- | ---------------------------------------- |
+| `header` | 自定义头部区，提供语言、主题及复制等能力 | `(scope: HeaderSlotScope) => VNodeChild` |
+
+`header` 插槽作用域参数 `HeaderSlotScope`：
+
+| 参数          | 说明               | 类型                |
+| ------------- | ------------------ | ------------------- |
+| `language`    | 当前代码语言       | `string`            |
+| `theme`       | 当前主题模式       | `'light' \| 'dark'` |
+| `copied`      | 是否处于已复制状态 | `boolean`           |
+| `copy`        | 复制代码内容       | `() => void`        |
+| `toggleTheme` | 切换主题模式       | `() => void`        |
+
+提供 `header` 插槽时将整体替换默认头部（语言标识、主题切换与复制按钮）。
 
 ### Ref
 

--- a/packages/x/components/code-highlighter/CodeHighlighter.tsx
+++ b/packages/x/components/code-highlighter/CodeHighlighter.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, PropType, StyleValue } from "vue";
+import type { CSSProperties, PropType, SlotsType, StyleValue } from "vue";
 
 import {
   CopyOutlined,
@@ -20,6 +20,7 @@ import type {
   CodeHighlighterProps,
   CodeHighlighterRef,
   CodeHighlighterSemanticType,
+  CodeHighlighterSlots,
 } from "./interface";
 
 import useXComponentConfig from "../_utils/hooks/use-x-component-config";
@@ -96,7 +97,8 @@ export const XCodeHighlighter = defineComponent({
     },
   },
   emits: ["update:theme"],
-  setup(props, { emit, expose }) {
+  slots: Object as SlotsType<CodeHighlighterSlots>,
+  setup(props, { emit, expose, slots }) {
     const attrs = useAttrs();
     const contextConfig = useXComponentConfig("codeHighlighter");
     const rootRef = ref<HTMLDivElement>();
@@ -181,6 +183,16 @@ export const XCodeHighlighter = defineComponent({
     };
 
     const renderHeader = () => {
+      if (slots.header) {
+        return slots.header({
+          language: props.language || "text",
+          theme: props.theme,
+          copied: copied.value,
+          copy: handleCopy,
+          toggleTheme,
+        });
+      }
+
       const hasHeaderContent =
         props.showLanguage || props.showThemeToggle || props.showCopyButton;
       if (!hasHeaderContent) return null;

--- a/packages/x/components/code-highlighter/__tests__/index.test.tsx
+++ b/packages/x/components/code-highlighter/__tests__/index.test.tsx
@@ -1,0 +1,119 @@
+import { mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
+import { nextTick } from "vue";
+
+import CodeHighlighter from "../CodeHighlighter";
+
+const shikiMock = vi.hoisted(() => ({
+  codeToHtml: vi.fn(),
+}));
+
+vi.mock("../shiki", () => ({
+  codeToHtml: (...args: any[]) => shikiMock.codeToHtml(...args),
+}));
+
+const content = "const a = 1;";
+
+function flushPromises(wait = 0) {
+  return new Promise(resolve => setTimeout(resolve, wait));
+}
+
+describe("CodeHighlighter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    shikiMock.codeToHtml.mockResolvedValue(
+      "<pre><code>const a = 1;</code></pre>",
+    );
+  });
+
+  it("renders the default header with copy button", async () => {
+    const wrapper = mount(CodeHighlighter, {
+      props: {
+        content,
+        language: "typescript",
+      },
+    });
+
+    await flushPromises();
+
+    expect(wrapper.find(".antd-code-highlighter").exists()).toBe(true);
+    expect(wrapper.find(".antd-code-highlighter-header").exists()).toBe(true);
+    expect(wrapper.find(".antd-code-highlighter-copy-btn").exists()).toBe(true);
+    expect(wrapper.find(".antd-code-highlighter-lang").text()).toBe(
+      "typescript",
+    );
+  });
+
+  it("renders the header slot and exposes the scope", async () => {
+    const wrapper = mount(CodeHighlighter, {
+      props: {
+        content,
+        language: "typescript",
+        theme: "light",
+      },
+      slots: {
+        header: (scope: any) =>
+          `${scope.language}-${scope.theme}-${scope.copied}`,
+      },
+    });
+
+    await flushPromises();
+
+    // default header is fully replaced by the slot
+    expect(wrapper.find(".antd-code-highlighter-header").exists()).toBe(false);
+    expect(wrapper.find(".antd-code-highlighter-copy-btn").exists()).toBe(
+      false,
+    );
+    expect(wrapper.text()).toContain("typescript-light-false");
+  });
+
+  it("invokes copy from the header slot scope", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, {
+      clipboard: { writeText },
+    });
+    const onCopy = vi.fn();
+
+    const wrapper = mount(CodeHighlighter, {
+      props: {
+        content,
+        onCopy,
+      },
+      slots: {
+        header: (scope: any) => (
+          <button class="slot-copy" onClick={() => scope.copy()}>
+            copy
+          </button>
+        ),
+      },
+    });
+
+    await flushPromises();
+    await wrapper.find(".slot-copy").trigger("click");
+    await nextTick();
+
+    expect(writeText).toHaveBeenCalledWith(content);
+    expect(onCopy).toHaveBeenCalledWith(content);
+  });
+
+  it("toggles theme from the header slot scope", async () => {
+    const wrapper = mount(CodeHighlighter, {
+      props: {
+        content,
+        theme: "light",
+      },
+      slots: {
+        header: (scope: any) => (
+          <button class="slot-theme" onClick={() => scope.toggleTheme()}>
+            theme
+          </button>
+        ),
+      },
+    });
+
+    await flushPromises();
+    await wrapper.find(".slot-theme").trigger("click");
+
+    expect(wrapper.emitted("update:theme")?.[0]).toEqual(["dark"]);
+  });
+});

--- a/packages/x/components/code-highlighter/index.tsx
+++ b/packages/x/components/code-highlighter/index.tsx
@@ -1,9 +1,11 @@
 import CodeHighlighter from "./CodeHighlighter";
 
 export type {
+  CodeHighlighterHeaderSlotScope,
   CodeHighlighterProps,
   CodeHighlighterRef,
   CodeHighlighterSemanticType,
+  CodeHighlighterSlots,
 } from "./interface";
 
 export default CodeHighlighter;

--- a/packages/x/components/code-highlighter/interface.ts
+++ b/packages/x/components/code-highlighter/interface.ts
@@ -1,4 +1,4 @@
-import type { CSSProperties, HTMLAttributes } from "vue";
+import type { CSSProperties, HTMLAttributes, VNodeChild } from "vue";
 
 export type CodeHighlighterSemanticType =
   | "root"
@@ -9,6 +9,36 @@ export type CodeHighlighterSemanticType =
 
 export interface CodeHighlighterRef {
   nativeElement: HTMLDivElement;
+}
+
+export interface CodeHighlighterHeaderSlotScope {
+  /**
+   * 当前代码语言
+   */
+  language: string;
+  /**
+   * 当前主题模式
+   */
+  theme: "light" | "dark";
+  /**
+   * 是否处于"已复制"状态
+   */
+  copied: boolean;
+  /**
+   * 复制代码内容
+   */
+  copy: () => void;
+  /**
+   * 切换主题模式
+   */
+  toggleTheme: () => void;
+}
+
+export interface CodeHighlighterSlots {
+  /**
+   * 自定义头部区，作用域参数提供语言、主题及复制/主题切换能力
+   */
+  header?: (scope: CodeHighlighterHeaderSlotScope) => VNodeChild;
 }
 
 export interface CodeHighlighterProps extends Omit<


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🆕 New feature

### 🔗 Related Issues

> N/A

### 💡 Background and Solution

`CodeHighlighter` 的头部（语言标识、主题切换、复制按钮）此前完全由 props 驱动、内容写死，无法自定义。

本次为 `CodeHighlighter` 新增 `header` 作用域插槽，提供该插槽时**整体替换**默认头部。作用域参数保留了原有能力，便于在自定义头部中复用：

| 参数 | 类型 | 说明 |
| --- | --- | --- |
| `language` | `string` | 当前代码语言 |
| `theme` | `'light' \| 'dark'` | 当前主题模式 |
| `copied` | `boolean` | 是否处于已复制状态 |
| `copy` | `() => void` | 复制代码内容 |
| `toggleTheme` | `() => void` | 切换主题模式 |

用法：

```vue
<ax-code-highlighter :content="code" language="typescript">
  <template #header="{ language, copied, copy, theme, toggleTheme }">
    <span>{{ language }}</span>
    <a-button size="small" @click="toggleTheme">切换主题</a-button>
    <a-button type="primary" size="small" @click="copy">
      {{ copied ? "已复制" : "复制" }}
    </a-button>
  </template>
</ax-code-highlighter>
```

同时补充了 `SlotsType` 静态类型声明、demo、中英文文档与单元测试。

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | `CodeHighlighter` now supports a scoped `header` slot to fully customize the header, exposing `language` / `theme` / `copied` state and `copy` / `toggleTheme` helpers. |
| 🇨🇳 Chinese | `CodeHighlighter` 新增作用域 `header` 插槽以完全自定义头部，作用域提供 `language` / `theme` / `copied` 状态及 `copy` / `toggleTheme` 方法。 |
