### PR TITLE
feat(mermaid): add SlotsType declaration for header and custom action slots

### DIFF
--- a/packages/x/components/mermaid/Mermaid.tsx
+++ b/packages/x/components/mermaid/Mermaid.tsx
@@ -3,6 +3,7 @@ import type {
   CSSProperties,
   HTMLAttributes,
   PropType,
+  SlotsType,
   StyleValue,
   VNodeChild,
 } from "vue";
@@ -76,6 +77,21 @@ export interface MermaidCustomActionSlotInfo {
   item: ItemType;
   index: number;
   originNode: VNodeChild;
+}
+
+export interface MermaidSlots {
+  /**
+   * 自定义头部区，优先级高于 `header` 属性
+   */
+  header?: () => VNodeChild;
+  /**
+   * 自定义 `actions.customActions` 的图标
+   */
+  customActionIconRender?: (info: MermaidCustomActionSlotInfo) => VNodeChild;
+  /**
+   * 自定义 `actions.customActions` 的操作区
+   */
+  customActionRender?: (info: MermaidCustomActionSlotInfo) => VNodeChild;
 }
 
 enum RenderType {
@@ -195,6 +211,7 @@ const XMermaid = defineComponent({
     },
   },
   emits: ["update:renderType", "renderTypeChange"],
+  slots: Object as SlotsType<MermaidSlots>,
   setup(props, { emit, expose, slots }) {
     const attrs = useAttrs();
     const configCtx = useConfig();
@@ -250,8 +267,14 @@ const XMermaid = defineComponent({
 
     const getNamedSlot = (
       name: "customActionIconRender" | "customActionRender",
-    ) =>
-      slots[name] ?? slots[name.replace(/[A-Z]/g, s => `-${s.toLowerCase()}`)];
+    ) => {
+      const kebabName = name.replace(/[A-Z]/g, s => `-${s.toLowerCase()}`);
+      const slotMap = slots as Record<
+        string,
+        ((info: MermaidCustomActionSlotInfo) => VNodeChild) | undefined
+      >;
+      return slotMap[name] ?? slotMap[kebabName];
+    };
 
     const resolvedCustomActions = computed<ItemType[]>(() =>
       mergedActions.value.customActions.map((item, index) => {

--- a/packages/x/components/mermaid/index.tsx
+++ b/packages/x/components/mermaid/index.tsx
@@ -7,6 +7,7 @@ export type {
   MermaidRef,
   MermaidRenderType,
   MermaidSemanticType,
+  MermaidSlots,
 } from "./Mermaid";
 
 export default Mermaid;


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [x] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> N/A

### 💡 Background and Solution

`Mermaid` already supports `header`, `customActionIconRender`, and `customActionRender` slots at runtime, but the slot types were not declared explicitly. This means consumers can use the slots, but there was no static typing or IDE completion.

This PR adds a `MermaidSlots` interface and wires it into `defineComponent` with `SlotsType<MermaidSlots>`, then exports the slot type from the package entry.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | `Mermaid` now declares typed slots for `header`, `customActionIconRender`, and `customActionRender` via `SlotsType`, improving type safety and IDE completion. |
| 🇨🇳 Chinese | `Mermaid` 现在通过 `SlotsType` 显式声明了 `header`、`customActionIconRender` 和 `customActionRender` 插槽，提升类型安全和 IDE 补全。 |
