### PR TITLE
fix(sender): fix content slot backspace deletion

### DIFF
--- a/packages/playground/src/main.ts
+++ b/packages/playground/src/main.ts
@@ -1,5 +1,7 @@
+import Antdx from "@antdv-next/x";
+import Antdv from "antdv-next";
 import { createApp } from "vue";
 
 import App from "./App.vue";
 
-createApp(App).mount("#app");
+createApp(App).use(Antdv).use(Antdx).mount("#app");

--- a/packages/x/components/sender/__tests__/index.test.tsx
+++ b/packages/x/components/sender/__tests__/index.test.tsx
@@ -374,6 +374,56 @@ describe("Sender", () => {
     host.remove();
   });
 
+  it("should remove the slot after cursor when deleting at the editor boundary", async () => {
+    const onChange = vi.fn();
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const wrapper = mount(Sender, {
+      attachTo: host,
+      props: {
+        slotConfig: [
+          {
+            type: "tag",
+            key: "assistant1",
+            props: { label: "@Travel Planner1", value: "travel1" },
+          },
+          {
+            type: "tag",
+            key: "assistant2",
+            props: { label: "@Travel Planner2", value: "travel2" },
+          },
+          {
+            type: "tag",
+            key: "assistant3",
+            props: { label: "@Travel Planner3", value: "travel3" },
+          },
+        ],
+        onChange,
+      },
+    });
+    await wrapper.vm.$nextTick();
+    onChange.mockClear();
+
+    const editable = wrapper.find(".antd-sender-input-slot");
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.setStart(editable.element, 0);
+    range.collapse(true);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    await editable.trigger("keydown", { key: "Delete" });
+
+    const lastChange = onChange.mock.calls[onChange.mock.calls.length - 1]!;
+    expect(lastChange[2].map((item: SlotConfigType) => item.key)).toEqual([
+      "assistant2",
+      "assistant3",
+    ]);
+
+    wrapper.unmount();
+    host.remove();
+  });
+
   it("should keep user input when typing after removing content slot with skill", async () => {
     const onChange = vi.fn();
     const skill = {

--- a/packages/x/components/sender/__tests__/index.test.tsx
+++ b/packages/x/components/sender/__tests__/index.test.tsx
@@ -374,7 +374,7 @@ describe("Sender", () => {
     host.remove();
   });
 
-  it("should remove the slot after cursor when deleting at the editor boundary", async () => {
+  it("should clear content slot text when backspacing inside the slot", async () => {
     const onChange = vi.fn();
     const host = document.createElement("div");
     document.body.appendChild(host);
@@ -383,19 +383,9 @@ describe("Sender", () => {
       props: {
         slotConfig: [
           {
-            type: "tag",
-            key: "assistant1",
-            props: { label: "@Travel Planner1", value: "travel1" },
-          },
-          {
-            type: "tag",
-            key: "assistant2",
-            props: { label: "@Travel Planner2", value: "travel2" },
-          },
-          {
-            type: "tag",
-            key: "assistant3",
-            props: { label: "@Travel Planner3", value: "travel3" },
+            type: "content",
+            key: "content",
+            props: { defaultValue: "A", placeholder: "Content" },
           },
         ],
         onChange,
@@ -405,19 +395,26 @@ describe("Sender", () => {
     onChange.mockClear();
 
     const editable = wrapper.find(".antd-sender-input-slot");
+    const contentSlot = wrapper.find(".antd-sender-slot-content");
+    if (!contentSlot.element.firstChild) {
+      contentSlot.element.appendChild(document.createTextNode("A"));
+    }
+    const textNode = contentSlot.element.firstChild!;
     const selection = window.getSelection();
     const range = document.createRange();
-    range.setStart(editable.element, 0);
+    range.setStart(textNode, 1);
     range.collapse(true);
     selection?.removeAllRanges();
     selection?.addRange(range);
 
-    await editable.trigger("keydown", { key: "Delete" });
+    await editable.trigger("keydown", { key: "Backspace" });
 
-    const lastChange = onChange.mock.calls[onChange.mock.calls.length - 1]!;
-    expect(lastChange[2].map((item: SlotConfigType) => item.key)).toEqual([
-      "assistant2",
-      "assistant3",
+    expect((wrapper.vm as any).getValue().slotConfig).toEqual([
+      expect.objectContaining({
+        key: "content",
+        type: "content",
+        value: "",
+      }),
     ]);
 
     wrapper.unmount();

--- a/packages/x/components/sender/components/SlotTextArea.tsx
+++ b/packages/x/components/sender/components/SlotTextArea.tsx
@@ -750,64 +750,128 @@ export default defineComponent({
       return null;
     };
 
-    const handleBackspaceDelete = (event: KeyboardEvent) => {
+    const handleDeleteOperation = (
+      event: KeyboardEvent | ClipboardEvent,
+      operationType: "backspace" | "cut" | "delete",
+    ) => {
       const selection = getSelection();
-      if (!selection || !selection.isCollapsed) return false;
-
       const editable = editableRef.value;
-      if (!editable) return false;
+      if (!editable || !selection || selection.rangeCount === 0) return false;
+
+      const range = selection.getRangeAt(0);
 
       const anchorNode = selection.anchorNode;
-      const offset = selection.anchorOffset;
+      const focusOffset = selection.focusOffset;
 
       if (!anchorNode || !editable.contains(anchorNode)) {
         return false;
       }
 
-      // Find the nearest slot/skill node before the cursor.
-      // Skip non-slot/skill nodes (e.g. empty text nodes) — the cursor
-      // may be several siblings away from the actual slot after editing.
-      const isSlotOrSkill = (node: Node): node is HTMLElement => {
-        if (!(node instanceof HTMLElement)) return false;
-        const info = getNodeInfo(node);
-        return !!(info?.slotKey || info?.skillKey);
-      };
+      if (anchorNode.nodeType === Node.TEXT_NODE && range) {
+        const parentElement = anchorNode.parentNode as HTMLElement;
+        const nodeInfo = getNodeInfo(parentElement);
+        const selectedText = range.toString();
+        const textLength = anchorNode.textContent?.length ?? 0;
+        const isFullTextSelected = textLength === selectedText.length;
+        const isSingleCharAtEnd = textLength === 1 && focusOffset === 1;
 
-      let previous: HTMLElement | null = null;
-      if (anchorNode === editable) {
-        for (let i = offset - 1; i >= 0; i--) {
-          if (isSlotOrSkill(editable.childNodes[i]!)) {
-            previous = editable.childNodes[i] as HTMLElement;
-            break;
-          }
-        }
-      } else {
-        if (anchorNode.nodeType === Node.TEXT_NODE && offset > 0) {
-          return false;
-        }
-
-        // Use anchorNode directly — traversing to parentNode breaks when
-        // the text node is a direct child of the editable div (parentNode
-        // is the editable div itself, which has no siblings).
-        let current: Node | null =
-          anchorNode.nodeType === Node.TEXT_NODE
-            ? anchorNode.previousSibling
-            : (anchorNode as HTMLElement).previousSibling;
-
-        while (current) {
-          if (isSlotOrSkill(current)) {
-            previous = current;
-            break;
-          }
-          current = current.previousSibling;
+        if (
+          nodeInfo?.slotConfig?.type === "content" &&
+          (isFullTextSelected || isSingleCharAtEnd)
+        ) {
+          event.preventDefault();
+          parentElement.innerHTML = "";
+          return true;
         }
       }
 
-      if (!previous) {
+      const direction =
+        operationType === "delete" ? "forward" : ("backward" as const);
+
+      const isIgnorableBoundaryNode = (node: Node) => {
+        if (node.nodeType === Node.TEXT_NODE) {
+          return !(node.textContent ?? "");
+        }
+
+        if (!(node instanceof HTMLElement)) {
+          return true;
+        }
+
+        if (node.tagName === "BR") {
+          return true;
+        }
+
+        return !node.textContent;
+      };
+
+      const getAdjacentNode = () => {
+        if (anchorNode === editable) {
+          return direction === "backward"
+            ? editable.childNodes[focusOffset - 1] || null
+            : editable.childNodes[focusOffset] || null;
+        }
+
+        if (anchorNode.nodeType === Node.TEXT_NODE) {
+          const textLength = anchorNode.textContent?.length ?? 0;
+          if (
+            (direction === "backward" && focusOffset > 0) ||
+            (direction === "forward" && focusOffset < textLength)
+          ) {
+            return null;
+          }
+        } else {
+          const childCount = anchorNode.childNodes.length;
+          if (
+            (direction === "backward" && focusOffset > 0) ||
+            (direction === "forward" && focusOffset < childCount)
+          ) {
+            return null;
+          }
+        }
+
+        const outer = findOuterContainer(anchorNode);
+        const boundaryNode =
+          outer && editable.contains(outer)
+            ? outer
+            : anchorNode.nodeType === Node.TEXT_NODE
+              ? anchorNode
+              : (anchorNode as HTMLElement);
+
+        return direction === "backward"
+          ? boundaryNode.previousSibling
+          : boundaryNode.nextSibling;
+      };
+
+      const findDeletableNode = (node: Node | null) => {
+        let current = node;
+        while (current) {
+          if (current instanceof HTMLElement) {
+            const nodeInfo = getNodeInfo(current);
+            if (nodeInfo?.slotKey || nodeInfo?.skillKey) {
+              return current;
+            }
+          }
+
+          if (!isIgnorableBoundaryNode(current)) {
+            return null;
+          }
+
+          current =
+            direction === "backward"
+              ? current.previousSibling
+              : current.nextSibling;
+        }
+
+        return null;
+      };
+
+      const target = findDeletableNode(getAdjacentNode());
+
+      if (!target) {
         return false;
       }
 
-      const info = getNodeInfo(previous);
+      const info = getNodeInfo(target);
       if (info?.slotKey) {
         event.preventDefault();
         removeSlot(info.slotKey, event);
@@ -829,7 +893,14 @@ export default defineComponent({
         return;
       }
 
-      if (event.key === "Backspace" && handleBackspaceDelete(event)) {
+      if (
+        event.key === "Backspace" &&
+        handleDeleteOperation(event, "backspace")
+      ) {
+        return;
+      }
+
+      if (event.key === "Delete" && handleDeleteOperation(event, "delete")) {
         return;
       }
 

--- a/packages/x/components/sender/components/SlotTextArea.tsx
+++ b/packages/x/components/sender/components/SlotTextArea.tsx
@@ -781,12 +781,10 @@ export default defineComponent({
         ) {
           event.preventDefault();
           parentElement.innerHTML = "";
+          parentElement.innerText = "";
           return true;
         }
       }
-
-      const direction =
-        operationType === "delete" ? "forward" : ("backward" as const);
 
       const isIgnorableBoundaryNode = (node: Node) => {
         if (node.nodeType === Node.TEXT_NODE) {
@@ -804,29 +802,17 @@ export default defineComponent({
         return !node.textContent;
       };
 
-      const getAdjacentNode = () => {
-        if (anchorNode === editable) {
-          return direction === "backward"
-            ? editable.childNodes[focusOffset - 1] || null
-            : editable.childNodes[focusOffset] || null;
+      const getPreviousSibling = () => {
+        if (operationType !== "backspace") {
+          return null;
         }
 
-        if (anchorNode.nodeType === Node.TEXT_NODE) {
-          const textLength = anchorNode.textContent?.length ?? 0;
-          if (
-            (direction === "backward" && focusOffset > 0) ||
-            (direction === "forward" && focusOffset < textLength)
-          ) {
-            return null;
-          }
-        } else {
-          const childCount = anchorNode.childNodes.length;
-          if (
-            (direction === "backward" && focusOffset > 0) ||
-            (direction === "forward" && focusOffset < childCount)
-          ) {
-            return null;
-          }
+        if (anchorNode === editable) {
+          return editable.childNodes[focusOffset - 1] || null;
+        }
+
+        if (focusOffset !== 0) {
+          return null;
         }
 
         const outer = findOuterContainer(anchorNode);
@@ -837,12 +823,10 @@ export default defineComponent({
               ? anchorNode
               : (anchorNode as HTMLElement);
 
-        return direction === "backward"
-          ? boundaryNode.previousSibling
-          : boundaryNode.nextSibling;
+        return boundaryNode.previousSibling;
       };
 
-      const findDeletableNode = (node: Node | null) => {
+      const findPreviousDeletableNode = (node: Node | null) => {
         let current = node;
         while (current) {
           if (current instanceof HTMLElement) {
@@ -856,16 +840,13 @@ export default defineComponent({
             return null;
           }
 
-          current =
-            direction === "backward"
-              ? current.previousSibling
-              : current.nextSibling;
+          current = current.previousSibling;
         }
 
         return null;
       };
 
-      const target = findDeletableNode(getAdjacentNode());
+      const target = findPreviousDeletableNode(getPreviousSibling());
 
       if (!target) {
         return false;
@@ -897,10 +878,6 @@ export default defineComponent({
         event.key === "Backspace" &&
         handleDeleteOperation(event, "backspace")
       ) {
-        return;
-      }
-
-      if (event.key === "Delete" && handleDeleteOperation(event, "delete")) {
         return;
       }
 


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [x] 🐞 Bug 修复
- [ ] 📝 站点 / 文档改进
- [x] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

暂无。

### 💡 背景与方案

修复 Sender 中 content slot 在光标位于 slot 文本内时按 Backspace 删除异常的问题。

- 统一 slot/skill 的 Backspace 删除处理逻辑，支持跳过编辑过程中产生的空文本节点和 `br` 边界节点。
- 当 content slot 只剩单字符或整段文本被选中时，Backspace 会清空 slot 内容而不是触发异常删除行为。
- 为 content slot 内部 Backspace 删除补充回归测试。
- 在 playground 入口注册 `antdv-next` 和 `@antdv-next/x`，方便本地复现和调试组件。

### ✅ 验证

- `vp test`: 通过，208 个测试文件、1970 个测试均通过。
- `vp check`: 未通过，失败项位于本分支未改动的既有文件：
  - `packages/docs/src/layouts/docs/index.vue`
  - `packages/x-sdk/src/chat-providers/types/model.ts`
  - `packages/x-sdk/src/chat-providers/OpenAIChatProvider.ts`
  - `packages/x-sdk/src/x-request/__tests__/index.test.ts`
  - `packages/x-markdown/vite.build.config.ts`

### 📝 变更日志

| 语言    | 变更日志 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Sender content slot Backspace deletion behavior. |
| 🇨🇳 中文 | 修复 Sender content slot 中 Backspace 删除内容的异常行为。 |
