### PR TITLE
docs: add usage guides for Vite and Rsbuild

### DIFF
--- a/packages/docs/src/pages/docs/contributing.en-US.md
+++ b/packages/docs/src/pages/docs/contributing.en-US.md
@@ -1,7 +1,7 @@
 ---
 group:
   title: Other
-  order: 1
+  order: 2
 title: Contributing
 ---
 

--- a/packages/docs/src/pages/docs/contributing.zh-CN.md
+++ b/packages/docs/src/pages/docs/contributing.zh-CN.md
@@ -1,7 +1,7 @@
 ---
 group:
   title: 其他
-  order: 1
+  order: 2
 title: 贡献指南
 ---
 

--- a/packages/docs/src/pages/docs/llms.en-US.md
+++ b/packages/docs/src/pages/docs/llms.en-US.md
@@ -1,7 +1,7 @@
 ---
 group:
   title: AI
-  order: 0
+  order: 1
 order: 1
 title: LLMs.txt
 tag: New

--- a/packages/docs/src/pages/docs/llms.zh-CN.md
+++ b/packages/docs/src/pages/docs/llms.zh-CN.md
@@ -1,7 +1,7 @@
 ---
 group:
   title: AI
-  order: 0
+  order: 1
 order: 1
 title: LLMs.txt
 tag: New

--- a/packages/docs/src/pages/docs/use-with-rsbuild.en-US.md
+++ b/packages/docs/src/pages/docs/use-with-rsbuild.en-US.md
@@ -1,0 +1,81 @@
+---
+group:
+  title: How to Use
+  order: 0
+order: 5
+title: Use with Rsbuild
+---
+
+[Rsbuild](https://rsbuild.dev/) is a build tool powered by Rspack. This guide shows how to use `@antdv-next/x` in a Vue project created with Rsbuild.
+
+## Installation and Initialization
+
+Before you start, you might need to install [yarn](https://github.com/yarnpkg/yarn/), [pnpm](https://pnpm.io/), or [bun](https://bun.sh/).
+
+<InstallDependencies npm='$ npm create rsbuild antdv-next-x-demo' yarn='$ yarn create rsbuild antdv-next-x-demo' pnpm='$ pnpm create rsbuild antdv-next-x-demo' bun='$ bun create rsbuild antdv-next-x-demo'></InstallDependencies>
+
+During initialization, `create-rsbuild` provides several templates. Choose the Vue template here.
+
+The tool will automatically initialize a Vue scaffold. If you encounter network issues during the process, try configuring a proxy or using another npm registry.
+
+Next, navigate to the project directory, install dependencies, and start the development server.
+
+```bash
+$ cd antdv-next-x-demo
+$ npm install
+$ npm run dev
+```
+
+Open the local URL printed in the terminal. If you see the default Rsbuild + Vue page, the setup is ready.
+
+## Importing @antdv-next/x
+
+Now install `@antdv-next/x` and the underlying component library `antdv-next` using yarn, npm, pnpm, or bun.
+
+<InstallDependencies npm='$ npm install @antdv-next/x antdv-next --save' yarn='$ yarn add @antdv-next/x antdv-next' pnpm='$ pnpm install @antdv-next/x antdv-next --save' bun='$ bun add @antdv-next/x antdv-next'></InstallDependencies>
+
+Import styles in `src/main.ts`.
+
+```ts
+import { createApp } from "vue";
+import App from "./App.vue";
+
+import "antdv-next/dist/reset.css";
+
+createApp(App).mount("#app");
+```
+
+Update `src/App.vue` to import the `Bubble` component from `@antdv-next/x`, and wrap it with `XProvider` for the base context.
+
+```vue
+<template>
+  <XProvider>
+    <Bubble content="Hello world!" />
+  </XProvider>
+</template>
+
+<script setup lang="ts">
+import { Bubble, XProvider } from "@antdv-next/x";
+</script>
+```
+
+You should now see the `@antdv-next/x` bubble component on the page. You can continue building your application with other components. For the rest of the development workflow, refer to the [Rsbuild documentation](https://rsbuild.dev/).
+
+## Custom Theme
+
+Configure theme tokens through `XProvider`.
+
+```vue
+<template>
+  <XProvider :theme="{ token: { colorPrimary: '#00b96b' } }">
+    <MyApp />
+  </XProvider>
+</template>
+
+<script setup lang="ts">
+import { XProvider } from "@antdv-next/x";
+import MyApp from "./MyApp.vue";
+</script>
+```
+
+You have successfully run `@antdv-next/x` with Rsbuild. Start building your application!

--- a/packages/docs/src/pages/docs/use-with-rsbuild.zh-CN.md
+++ b/packages/docs/src/pages/docs/use-with-rsbuild.zh-CN.md
@@ -1,0 +1,81 @@
+---
+group:
+  title: 如何使用
+  order: 0
+order: 5
+title: 在 Rsbuild 中使用
+---
+
+[Rsbuild](https://rsbuild.dev/zh/) 是由 Rspack 驱动的构建工具，本文会介绍如何在 Rsbuild 创建的 Vue 工程中使用 `@antdv-next/x`。
+
+## 安装和初始化
+
+在开始之前，你可能需要安装 [yarn](https://github.com/yarnpkg/yarn/) 或者 [pnpm](https://pnpm.io/zh/) 或者 [bun](https://bun.sh/)。
+
+<InstallDependencies npm='$ npm create rsbuild antdv-next-x-demo' yarn='$ yarn create rsbuild antdv-next-x-demo' pnpm='$ pnpm create rsbuild antdv-next-x-demo' bun='$ bun create rsbuild antdv-next-x-demo'></InstallDependencies>
+
+在初始化的过程中，`create-rsbuild` 会提供一系列模板供我们选择，这里选择 Vue 模板。
+
+工具会自动初始化一个 Vue 脚手架，如果在过程中出现网络问题，请尝试配置代理，或使用其他 npm registry。
+
+然后进入项目，安装依赖并启动开发服务。
+
+```bash
+$ cd antdv-next-x-demo
+$ npm install
+$ npm run dev
+```
+
+此时使用浏览器访问终端输出的本地地址，看到 Rsbuild + Vue 的默认页面就算成功了。
+
+## 引入 @antdv-next/x
+
+现在从 yarn 或 npm 或 pnpm 或 bun 安装并引入 `@antdv-next/x` 和底层组件库 `antdv-next`。
+
+<InstallDependencies npm='$ npm install @antdv-next/x antdv-next --save' yarn='$ yarn add @antdv-next/x antdv-next' pnpm='$ pnpm install @antdv-next/x antdv-next --save' bun='$ bun add @antdv-next/x antdv-next'></InstallDependencies>
+
+在 `src/main.ts` 中引入样式。
+
+```ts
+import { createApp } from "vue";
+import App from "./App.vue";
+
+import "antdv-next/dist/reset.css";
+
+createApp(App).mount("#app");
+```
+
+修改 `src/App.vue`，引入 `@antdv-next/x` 的 `Bubble` 组件，并通过 `XProvider` 提供基础上下文。
+
+```vue
+<template>
+  <XProvider>
+    <Bubble content="Hello world!" />
+  </XProvider>
+</template>
+
+<script setup lang="ts">
+import { Bubble, XProvider } from "@antdv-next/x";
+</script>
+```
+
+好了，现在你应该能看到页面上已经有了 `@antdv-next/x` 的气泡组件，接下来就可以继续选用其他组件开发应用了。其他开发流程你可以参考 Rsbuild 的[官方文档](https://rsbuild.dev/zh/)。
+
+## 自定义主题
+
+可以通过 `XProvider` 配置主题 Token。
+
+```vue
+<template>
+  <XProvider :theme="{ token: { colorPrimary: '#00b96b' } }">
+    <MyApp />
+  </XProvider>
+</template>
+
+<script setup lang="ts">
+import { XProvider } from "@antdv-next/x";
+import MyApp from "./MyApp.vue";
+</script>
+```
+
+我们现在已经把 `@antdv-next/x` 组件成功使用 Rsbuild 运行起来了，开始开发你的应用吧！

--- a/packages/docs/src/pages/docs/use-with-vite.en-US.md
+++ b/packages/docs/src/pages/docs/use-with-vite.en-US.md
@@ -1,0 +1,79 @@
+---
+group:
+  title: How to Use
+  order: 0
+order: 2
+title: Use with Vite
+---
+
+[Vite](https://vite.dev/) is a modern tool for building frontend applications. This guide shows how to use `@antdv-next/x` in a Vue project created with Vite.
+
+## Installation and Initialization
+
+Before you start, you might need to install [yarn](https://github.com/yarnpkg/yarn/), [pnpm](https://pnpm.io/), or [bun](https://bun.sh/).
+
+<InstallDependencies npm='$ npm create vite antdv-next-x-demo -- --template vue-ts' yarn='$ yarn create vite antdv-next-x-demo --template vue-ts' pnpm='$ pnpm create vite antdv-next-x-demo --template vue-ts' bun='$ bun create vite antdv-next-x-demo --template vue-ts'></InstallDependencies>
+
+The tool will automatically initialize a Vue scaffold. If you encounter network issues during the process, try configuring a proxy or using another npm registry.
+
+Next, navigate to the project directory, install dependencies, and start the development server.
+
+```bash
+$ cd antdv-next-x-demo
+$ npm install
+$ npm run dev
+```
+
+Open the local URL printed in the terminal. If you see the default Vite + Vue page, the setup is ready.
+
+## Importing @antdv-next/x
+
+Now install `@antdv-next/x` and the underlying component library `antdv-next` using yarn, npm, pnpm, or bun.
+
+<InstallDependencies npm='$ npm install @antdv-next/x antdv-next --save' yarn='$ yarn add @antdv-next/x antdv-next' pnpm='$ pnpm install @antdv-next/x antdv-next --save' bun='$ bun add @antdv-next/x antdv-next'></InstallDependencies>
+
+Import styles in `src/main.ts`.
+
+```ts
+import { createApp } from "vue";
+import App from "./App.vue";
+
+import "antdv-next/dist/reset.css";
+
+createApp(App).mount("#app");
+```
+
+Update `src/App.vue` to import the `Bubble` component from `@antdv-next/x`, and wrap it with `XProvider` for the base context.
+
+```vue
+<template>
+  <XProvider>
+    <Bubble content="Hello world!" />
+  </XProvider>
+</template>
+
+<script setup lang="ts">
+import { Bubble, XProvider } from "@antdv-next/x";
+</script>
+```
+
+You should now see the `@antdv-next/x` bubble component on the page. You can continue building your application with other components. For the rest of the development workflow, refer to the [Vite documentation](https://vite.dev/).
+
+## Custom Theme
+
+Configure theme tokens through `XProvider`.
+
+```vue
+<template>
+  <XProvider :theme="{ token: { colorPrimary: '#00b96b' } }">
+    <MyApp />
+  </XProvider>
+</template>
+
+<script setup lang="ts">
+import { XProvider } from "@antdv-next/x";
+import MyApp from "./MyApp.vue";
+</script>
+```
+
+You have successfully run `@antdv-next/x` with Vite. Start building your application!

--- a/packages/docs/src/pages/docs/use-with-vite.zh-CN.md
+++ b/packages/docs/src/pages/docs/use-with-vite.zh-CN.md
@@ -1,0 +1,79 @@
+---
+group:
+  title: 如何使用
+  order: 0
+order: 2
+title: 在 Vite 中使用
+---
+
+[Vite](https://cn.vite.dev/) 是现代前端应用开发工具之一，本文会介绍如何在 Vite 创建的 Vue 工程中使用 `@antdv-next/x`。
+
+## 安装和初始化
+
+在开始之前，你可能需要安装 [yarn](https://github.com/yarnpkg/yarn/) 或者 [pnpm](https://pnpm.io/zh/) 或者 [bun](https://bun.sh/)。
+
+<InstallDependencies npm='$ npm create vite antdv-next-x-demo -- --template vue-ts' yarn='$ yarn create vite antdv-next-x-demo --template vue-ts' pnpm='$ pnpm create vite antdv-next-x-demo --template vue-ts' bun='$ bun create vite antdv-next-x-demo --template vue-ts'></InstallDependencies>
+
+工具会自动初始化一个 Vue 脚手架，如果在过程中出现网络问题，请尝试配置代理，或使用其他 npm registry。
+
+然后进入项目，安装依赖并启动开发服务。
+
+```bash
+$ cd antdv-next-x-demo
+$ npm install
+$ npm run dev
+```
+
+此时使用浏览器访问终端输出的本地地址，看到 Vite + Vue 的默认页面就算成功了。
+
+## 引入 @antdv-next/x
+
+现在从 yarn 或 npm 或 pnpm 或 bun 安装并引入 `@antdv-next/x` 和底层组件库 `antdv-next`。
+
+<InstallDependencies npm='$ npm install @antdv-next/x antdv-next --save' yarn='$ yarn add @antdv-next/x antdv-next' pnpm='$ pnpm install @antdv-next/x antdv-next --save' bun='$ bun add @antdv-next/x antdv-next'></InstallDependencies>
+
+在 `src/main.ts` 中引入样式。
+
+```ts
+import { createApp } from "vue";
+import App from "./App.vue";
+
+import "antdv-next/dist/reset.css";
+
+createApp(App).mount("#app");
+```
+
+修改 `src/App.vue`，引入 `@antdv-next/x` 的 `Bubble` 组件，并通过 `XProvider` 提供基础上下文。
+
+```vue
+<template>
+  <XProvider>
+    <Bubble content="Hello world!" />
+  </XProvider>
+</template>
+
+<script setup lang="ts">
+import { Bubble, XProvider } from "@antdv-next/x";
+</script>
+```
+
+好了，现在你应该能看到页面上已经有了 `@antdv-next/x` 的气泡组件，接下来就可以继续选用其他组件开发应用了。其他开发流程你可以参考 Vite 的[官方文档](https://cn.vite.dev/)。
+
+## 自定义主题
+
+可以通过 `XProvider` 配置主题 Token。
+
+```vue
+<template>
+  <XProvider :theme="{ token: { colorPrimary: '#00b96b' } }">
+    <MyApp />
+  </XProvider>
+</template>
+
+<script setup lang="ts">
+import { XProvider } from "@antdv-next/x";
+import MyApp from "./MyApp.vue";
+</script>
+```
+
+我们现在已经把 `@antdv-next/x` 组件成功运行起来了，开始开发你的应用吧！


### PR DESCRIPTION
[English template / 英文模板](./PULL_REQUEST_TEMPLATE.md)

### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [ ] 🐞 Bug 修复
- [x] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [x] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

无。

### 💡 背景与方案

补全文档站「如何使用」分组，新增 Vite 与 Rsbuild 场景下使用 `@antdv-next/x` 的中英文文档。

本次文档包含：

- Vite / Rsbuild 初始化项目流程
- 安装 `@antdv-next/x` 与 `antdv-next`
- 在 Vue 入口文件中引入样式
- 使用 `XProvider` 与 `Bubble` 的基础示例
- 通过 `XProvider` 配置主题 Token 的示例

同时调整研发文档侧边栏分组顺序为「如何使用 / How to Use」→「AI」→「其他 / Other」。

### 📝 变更日志

| 语言    | 变更日志                                         |
| ------- | ------------------------------------------------ |
| 🇺🇸 英文 | Add Vite and Rsbuild usage guides for Vue users. |
| 🇨🇳 中文 | 新增 Vite 与 Rsbuild 中使用 X 的文档指南。       |

### ✅ 验证

- `git diff --cached --check`：通过
- `vp check`：未通过，仅因本地忽略文件 `.claude/settings.local.json` 存在格式化问题；该文件未被 git 跟踪，也不在本 PR diff 中。
