### PR TITLE
chore: add cross repo pr sync skill

### DIFF
--- a/.agents/skills/cross-repo-pr-sync/SKILL.md
+++ b/.agents/skills/cross-repo-pr-sync/SKILL.md
@@ -1,0 +1,574 @@
+---
+name: cross-repo-pr-sync
+description: >
+  跨仓库 PR 同步追踪技能。当用户需要追踪一个上游仓库（如 ant-design）的 fix/feature
+  变更，并同步到下游移植仓库（如 antdv-next）时使用此技能。
+  触发场景：用户给出一个起始 commit SHA，需要列出从该 commit 往后所有需要同步的 PR，
+  并生成带优先级排序的同步表格和 checklist 模板。
+  也适用于：两个仓库之间的变更追踪、上下游组件库同步分析、跨框架移植任务管理。
+  如果用户提到"同步上游"、"追踪 PR"、"从某个 commit 开始"、"移植 fix"、"同步 issue"
+  等关键词，务必使用此技能。
+  特别地：若用户只说"同步仓库"、"继续同步"、"sync"，应优先读取下游仓库根目录的
+  .sync-upstream.json 文件，从中获取上次同步位置，无需用户再次提供任何参数。
+---
+
+# Cross-Repo PR Sync Tracker
+
+## 概述
+
+本技能用于分析上游仓库（如 ant-design React 版、ant-design/x React 版）从某个 commit 起的所有变更，
+筛选出需要同步到下游移植仓库（如 antdv-next Vue3 版、antdv-next/x Vue3 版）的 PR，
+输出带优先级的同步表格和每个 PR 对应的 checklist 模板。
+
+当前仓库默认追踪 `ant-design/x`，路径映射为：
+
+- `packages/x` → `packages/x`
+- `packages/x-sdk` → `packages/x-sdk`
+- `packages/x-markdown` → `packages/x-markdown`
+- `packages/x-card` → `packages/x-card`
+- `packages/x-skill` → `packages/x-skill`
+
+支持**多 worker 并行**模式：主进程负责调度和汇总 review，
+每个 worker 独立负责一个上游仓库或子包的分析，互不阻塞。
+
+```
+主进程（调度 + 汇总）
+  ├── worker-1: ant-design          → packages/components
+  ├── worker-2: ant-design-icons    → packages/icons
+  ├── worker-3: pro-components/table → packages/pro-table
+  └── worker-4: pro-components/form  → packages/pro-form
+          ↓ 各自独立 clone/分析，结果写入 results/
+主进程：等待全部完成 → 合并 → 输出统一表格 + checklist
+```
+
+---
+
+## Step 0：读取同步状态（优先执行）
+
+在做任何事之前，先检查下游仓库根目录是否存在 `.sync-upstream.json`：
+
+```bash
+# 在下游仓库根目录执行
+cat .sync-upstream.json
+```
+
+### 情况 A：文件存在 ✅
+
+读取上次同步位置，**无需用户再次提供任何参数**。
+
+首先合并两个配置文件（若存在）：
+
+- `.sync-upstream.json` — 团队共享，提交到 git
+- `.sync-upstream.local.json` — 当前用户私有，加入 `.gitignore`，用于覆盖本地路径
+
+然后按以下优先级确定每个上游的数据源：
+
+| 优先级  | 条件                                           | 行为                       |
+| ------- | ---------------------------------------------- | -------------------------- |
+| 1️⃣ 最优 | 合并后 `local_path` 有效且目录存在             | 直接使用本地仓库，无需网络 |
+| 2️⃣ 自动 | `local_path` 为空或路径不存在，有 `remote_url` | 克隆到 tmp，用完删除       |
+| 3️⃣ 兜底 | 仅有 `repo` 字段（GitHub）                     | 使用 GitHub API            |
+
+**当触发自动克隆时**，告知用户：
+
+> 🌐 本地仓库不可用，正在从 `{remote_url}` 克隆到临时目录，分析完成后自动清理...
+
+**正常续传时**，告知用户：
+
+> 📖 读取到同步记录，上次同步到 `a1b2c3d`（2024-03-01），继续从该点往后分析...
+
+> 克隆和清理的完整流程见 `references/tmp-clone.md`
+
+### 情况 B：文件不存在 ⚠️
+
+首次使用，询问用户以下信息，然后**创建**该文件：
+
+| 需要询问             | 说明                                            |
+| -------------------- | ----------------------------------------------- |
+| 上游仓库地址         | 本地相对路径（如 `../ant-design`）或 remote URL |
+| 起始 commit SHA      | 从哪个版本开始往后追踪                          |
+| 上游仓库名称（可选） | 用于显示，默认取 URL/路径最后一段               |
+
+> `downstream.local_path` 固定写入 `"./"` 即可，无需用户提供。
+
+初始化时 Skill 同时执行：
+
+```bash
+echo ".sync-upstream.local.json" >> .gitignore
+echo ".sync-checklist-*.md" >> .gitignore
+```
+
+> 详见 `references/sync-state.md` 了解文件格式、本地覆盖机制和读写操作
+
+---
+
+## 前置准备
+
+### 模式判断（优先检查）
+
+**根据用户提供的内容自动选择模式**：
+
+| 用户提供                                        | 使用模式                                       |
+| ----------------------------------------------- | ---------------------------------------------- |
+| 本地仓库路径（`/home/...`、`~/...`、`./...`）   | 🖥️ **Local 模式**（git CLI，最快）             |
+| 任意 Git remote URL（GitHub/GitLab/Gitea/自建） | 🔄 **Auto-clone 模式**（克隆到 tmp，用完删除） |
+| 仅 GitHub `owner/repo` 名称                     | 🌐 **Remote 模式**（GitHub API，兜底方案）     |
+
+**优先级**：Local > Auto-clone > Remote API
+
+> Auto-clone 支持所有 Git 平台，只需提供一次 URL 写入 `.sync-upstream.json`，后续自动处理。详见 `references/tmp-clone.md`。
+
+---
+
+### 参数清单
+
+| 参数           | Local 模式 | Auto-clone 模式 | Remote API 模式 |
+| -------------- | ---------- | --------------- | --------------- |
+| 上游仓库       | 本地路径   | 任意 Git URL    | `owner/repo`    |
+| 下游仓库       | 本地路径   | 本地路径        | `owner/repo`    |
+| `start_commit` | commit SHA | commit SHA      | commit SHA      |
+| `github_token` | 不需要     | 不需要          | 可选，推荐      |
+| `max_prs`      | 默认 50    | 默认 50         | 默认 50         |
+
+**并行相关参数**（可写入 `.sync-upstream.json` 的 `settings` 字段）：
+
+| 参数          | 默认值                          | 说明                                                                |
+| ------------- | ------------------------------- | ------------------------------------------------------------------- |
+| `parallel`    | `true`                          | 是否启用多 worker 并行                                              |
+| `max_workers` | `4`                             | 最大并发 worker 数，超出的任务排队等待                              |
+| `results_dir` | `/tmp/sync-results-{timestamp}` | 共享结果目录，每个 worker 写 `{worker_id}.json`，主进程统一读取合并 |
+
+首次使用时 Skill 会将上游 URL 写入 `.sync-upstream.json`，后续无需再次提供。
+
+如用户未提供起始 commit，**先检查 Step 0 是否已从 `.sync-upstream.json` 读到**，若无则询问用户。
+
+---
+
+## Step 1：主进程调度（并行模式入口）
+
+### 1.1 构建 Worker 任务列表
+
+从 `.sync-upstream.json` 读取所有上游配置，按 `worker_granularity` 拆分任务：
+
+**按下游子包划分（每个 `packages` 条目一个 worker）**：
+
+```
+ant-design            → worker-0（upstream: .,               downstream: packages/components）
+ant-design-icons      → worker-1（upstream: packages/icons-vue, downstream: packages/icons）
+pro-components/table  → worker-2（upstream: packages/table,   downstream: packages/pro-table）
+pro-components/form   → worker-3（upstream: packages/form,    downstream: packages/pro-form）
+```
+
+这是最细粒度，每个下游子包独立并行，互不阻塞。
+同一上游（如 `pro-components`）的多个 worker 会**复用同一次 clone**，不重复拉取。
+
+### 1.2 并发控制
+
+```
+总任务数 = N
+实际并发 = min(settings.max_workers, N)   # 不超过实际任务数，默认 4
+
+超出并发上限的任务进入等待队列
+有 worker 完成后立即从队列取出下一个执行
+```
+
+进度实时打印到主进程 stdout，便于用户了解各 worker 状态。
+
+### 1.3 启动 Worker
+
+每个 worker 接收以下输入并独立执行 Step 2~4：
+
+```json
+{
+  "worker_id": "worker-C",
+  "upstream_name": "pro-components",
+  "remote_url": "https://github.com/ant-design/pro-components.git",
+  "local_path": null,
+  "upstream_path": "packages/table",
+  "downstream_path": "packages/pro-table",
+  "last_synced_commit": "c3d4e5f",
+  "results_dir": "/tmp/sync-results-1712345678/",
+  "max_prs": 50
+}
+```
+
+主进程启动所有 worker 后**挂起等待**，直到全部完成（或超时）后进入 Step 5 汇总。
+
+> Worker 内部执行流程详见 `references/worker.md`
+
+---
+
+## Step 2（Worker 内）：获取 Commit 列表
+
+### 🖥️ Local / Auto-clone 模式（推荐）
+
+```bash
+# $UPSTREAM_DIR = upstream 的 local_path（相对路径）或 auto-clone 的 tmp 路径
+git -C $UPSTREAM_DIR log <start_commit>..HEAD \
+  --pretty=format:"%H|%h|%s|%ad|%an" \
+  --date=short \
+  --extended-regexp \
+  --grep="^(fix|feat|feature|perf|revert)(\(.+\))?!?:|^Merge pull request #"
+```
+
+> 完整命令和批量脚本见 `references/local-git.md` → Section 1 & 7
+
+### 🌐 Remote 模式
+
+通过 GitHub API 获取从 `start_commit` 往后的所有提交：
+
+```
+GET https://api.github.com/repos/{upstream_repo}/commits
+  ?sha=HEAD          # 从最新往前，需要客户端过滤
+  &per_page=100
+```
+
+**过滤策略**：
+
+- 只保留 `type` 为 `fix` 或 `feat` 的 conventional commits
+- commit message 模式匹配：
+  - `fix(component): ...`
+  - `feat(component): ...`
+  - `fix: ...` / `feature: ...`
+  - PR 合并提交：`Merge pull request #xxx`
+
+> 详见 `references/github-api.md` 中的 API 调用示例和分页处理
+
+---
+
+## Step 3（Worker 内）：关联 PR 信息 & 检查同步状态
+
+### 🖥️ Local 模式
+
+从 commit message 中提取 PR 编号，并检查下游是否已同步：
+
+```bash
+# 检查下游是否已同步某个 PR
+git -C $DOWNSTREAM_DIR log --oneline --grep="12345"
+```
+
+> 详见 `references/local-git.md` → Section 3 & 5
+
+### 🌐 Remote 模式
+
+对每个 commit，通过以下方式关联 PR：
+
+```
+GET https://api.github.com/repos/{upstream_repo}/commits/{sha}/pulls
+```
+
+从 PR 中提取：
+
+- PR 编号、标题、URL
+- Labels（标签，用于判断优先级）
+- 涉及的文件路径（推断影响的组件）
+- PR body 中的关联 issue
+- 合并时间
+
+---
+
+## Step 4（Worker 内）：分析影响范围
+
+### 3.1 获取 commit 改动文件列表
+
+**🖥️ Local / Auto-clone 模式**：
+
+```bash
+git -C $UPSTREAM_DIR diff-tree --no-commit-id -r <sha> --name-only
+```
+
+**🌐 Remote 模式**：`GET /repos/{owner}/{repo}/pulls/{number}/files`
+
+---
+
+### 3.2 路径映射：上游文件 → 下游子包
+
+读取 `.sync-upstream.json` 中该上游的 `packages` 映射表，将上游改动文件路径转换为下游 monorepo 的子包路径。
+
+**映射逻辑**：
+
+```
+upstream 改动文件路径
+        ↓
+匹配 packages[].upstream_path 前缀
+        ↓
+替换为 packages[].downstream_path
+        ↓
+输出：下游子包 + 组件名
+```
+
+**示例**（pro-components → antdv-next monorepo）：
+
+```
+上游改动文件                          packages 映射                    下游定位
+─────────────────────────────────────────────────────────────────────────────
+packages/table/src/Table.tsx    →  upstream: packages/table      →  packages/pro-table / Table
+                                   downstream: packages/pro-table
+packages/form/src/Form.tsx      →  upstream: packages/form       →  packages/pro-form / Form
+                                   downstream: packages/pro-form
+components/button/index.tsx     →  upstream: .                   →  packages/components / Button
+                                   downstream: packages/components
+site/docs/intro.md              →  (无匹配，标记为文档，P3)
+```
+
+**无 `packages` 字段时**（上游是单包仓库，下游也是单包）：
+
+- 直接按 `components/{name}/` 规则推断组件名，不做路径转换
+
+---
+
+### 3.3 组件名推断
+
+路径确定后，从子路径中提取组件名：
+
+- `components/{name}/` → `{Name}`（首字母大写）
+- `src/{Name}.tsx` → `{Name}`
+- `site/` / `docs/` → 文档类，优先级自动降低
+- `scripts/` / `.github/` / `__tests__/` only → 跳过或 P3
+
+> 详见 `references/local-git.md` → Section 4
+
+---
+
+## Step 5（Worker 内）：评估同步优先级
+
+按以下规则自动评分，生成优先级：
+
+### 优先级规则表
+
+| 优先级  | 标记 | 判断条件                                                                              |
+| ------- | ---- | ------------------------------------------------------------------------------------- |
+| P0 紧急 | 🔴   | Labels 含 `Security`；标题含 `crash`/`security`/`XSS`/`data loss`                     |
+| P1 高   | 🟠   | Bug fix 影响核心组件（Button/Form/Table/Select/Input）；Labels 含 `bug`+`important`   |
+| P2 中   | 🟡   | 普通 bug fix；功能增强；体验优化；Labels 含 `feat`                                    |
+| P3 低   | 🟢   | 文档更新；样式微调；废弃警告；TypeScript 类型修复                                     |
+| Skip    | ⚪   | 仅 React 特有（如 `ReactNode`、`React.forwardRef` 特有改动）；SSR 专属；测试文件 only |
+
+### 同步难度评估
+
+| 难度   | 判断条件                                             |
+| ------ | ---------------------------------------------------- |
+| Low    | 纯逻辑/样式修复，无 JSX 特有写法                     |
+| Medium | 需要 React→Vue3 语法转换（props/emit/slots）         |
+| High   | 涉及 Hooks 深度改造、Context API、React 特有生命周期 |
+
+---
+
+## Step 6（Worker 内）：写出结果
+
+每个 worker 完成分析后，将结果写入 `results_dir/{worker_id}.json`：
+
+```json
+{
+  "worker_id": "worker-C",
+  "upstream_name": "pro-components",
+  "upstream_path": "packages/table",
+  "downstream_path": "packages/pro-table",
+  "latest_commit": "d4e5f6a7b8c9",
+  "latest_commit_short": "d4e5f6a",
+  "latest_tag": "v2.7.0",
+  "analyzed_at": "2024-03-01T12:05:00Z",
+  "prs": [
+    {
+      "pr_number": 8800,
+      "title": "fix(table): sort not reset on filter change",
+      "type": "fix",
+      "commit": "c3d4e5f",
+      "components": ["ProTable"],
+      "priority": "P1",
+      "difficulty": "Medium",
+      "upstream_url": "https://github.com/ant-design/pro-components/pull/8800",
+      "status": "pending"
+    }
+  ],
+  "error": null
+}
+```
+
+若 worker 执行出错（clone 失败、网络超时等），写入 `error` 字段，`prs` 为空数组，主进程收到后单独标记该 worker 失败，不影响其他 worker 结果。
+
+---
+
+## Step 7（主进程）：汇总输出 + 自动创建分支
+
+### 7.1 合并所有 worker 结果
+
+读取 `results_dir/` 下所有 `{worker_id}.json`，按优先级统一排序，生成汇总表格和 `.sync-report.md`。
+
+### 7.2 自动创建同步分支（全部 PR，Skip 除外）
+
+对所有非 Skip 的 PR，主进程逐一执行：
+
+```
+每个 PR → git checkout -b sync/{upstream-name}-{pr-number} origin/{base_branch}
+         → 写入 .sync-checklist-{upstream-name}-{pr-number}.md
+         → git commit
+         → git checkout {base_branch}
+```
+
+**分支命名**：`sync/{upstream-name}-{pr-number}`，例如 `sync/ant-design-12345`
+
+**基准分支**：`settings.base_branch`，默认 `main`
+
+**已存在的分支**自动跳过，不覆盖，保护正在进行中的工作。
+
+> 完整实现和 git 命令见 `references/branch-management.md`
+
+### 7.3 输出格式
+
+### 5.1 汇总表格
+
+输出 Markdown 表格，按优先级从高到低排列：
+
+```markdown
+## 📋 同步 PR 汇总表
+
+> 上游仓库: ant-design/ant-design
+> 分析起点: commit `a1b2c3d` (2024-01-15)
+> 分析范围: 从起点到最新，共 X 个 fix/feat PR
+> 生成时间: YYYY-MM-DD
+
+| 优先级  | 上游仓库         | PR #   | 类型 | 标题                   | 上游路径 → 下游子包                     | 涉及组件 | 同步难度 | 状态 | 链接   |
+| ------- | ---------------- | ------ | ---- | ---------------------- | --------------------------------------- | -------- | -------- | ---- | ------ |
+| 🔴 P0   | ant-design       | #12345 | fix  | fix: Button crash      | `.` → `packages/components`             | Button   | Low      | ⬜   | [链接] |
+| 🟠 P1   | pro-components   | #8800  | fix  | fix: ProTable sort bug | `packages/table` → `packages/pro-table` | ProTable | Medium   | ⬜   | [链接] |
+| 🟡 P2   | ant-design       | #12280 | feat | feat: Input clearIcon  | `.` → `packages/components`             | Input    | Low      | ⬜   | [链接] |
+| 🟡 P2   | ant-design-icons | #560   | feat | feat: add new icons    | `packages/icons-vue` → `packages/icons` | -        | Low      | ⬜   | [链接] |
+| 🟢 P3   | ant-design       | #12200 | docs | docs: Form examples    | `.` → `packages/components`             | Form     | -        | ⬜   | [链接] |
+| ⚪ Skip | ant-design       | #12100 | fix  | fix: SSR hydration     | -                                       | -        | -        | 跳过 | [链接] |
+```
+
+状态值：`⬜ 待同步` / `🔄 进行中` / `✅ 已完成` / `❌ 不适用`
+
+> 多上游时，表格按优先级统一排序，上游仓库列便于快速识别来源。
+
+### 5.2 逐 PR Checklist 模板
+
+对每个**非 Skip**的 PR，生成以下模板：
+
+```markdown
+---
+
+## ✅ 同步任务：#{PR编号} - {PR标题}
+
+**优先级**: {🔴/🟠/🟡/🟢} {P0/P1/P2/P3}
+**类型**: {fix/feat/docs}
+**上游 PR**: https://github.com/{upstream_repo}/pull/{编号}
+**上游 Commit**: `{sha}`
+**涉及组件**: {组件名}
+**同步难度**: {Low/Medium/High}
+**关联 Issue**: {issue 链接，若有}
+
+### 📖 变更摘要
+
+{PR body 或 commit message 的简要总结}
+
+### 🔍 Pre-sync 分析
+
+- [ ] 阅读上游 PR 完整内容和 review 评论
+- [ ] 确认 antdv-next 中是否存在相同问题/缺失相同功能
+- [ ] 查看上游变更的文件列表，评估 Vue3 适配工作量
+- [ ] 检查是否有相关联的其他 PR 需要一起同步
+
+### 🛠️ 实现步骤
+
+- [ ] 创建功能分支：`sync/ant-design-#{PR编号}`
+- [ ] 实现对应的 fix/feat（参考上游代码逻辑）
+- [ ] 处理 React→Vue3 差异（见下方注意事项）
+- [ ] 编写/更新单元测试
+- [ ] 更新组件文档（若有 API 变更）
+- [ ] 本地运行测试套件确认无回归
+
+### ⚠️ React→Vue3 差异注意事项
+
+- [ ] `children` / `ReactNode` → `slots`
+- [ ] `React.forwardRef` → `defineExpose` / `ref`
+- [ ] `useEffect` → `watchEffect` / `onMounted`
+- [ ] `className` → `class`
+- [ ] `onChange` → `@update:value` 或 `@change`（确认 emits 声明）
+- [ ] Context API → `provide` / `inject`
+- [ ] `React.cloneElement` → 无直接等价，需重构
+
+### 📦 提交与发布
+
+- [ ] 创建 antdv-next PR，标题格式：`[sync] fix(Button): xxx (#上游PR编号)`
+- [ ] PR 描述中链接上游 PR
+- [ ] Code Review 通过（至少 1 人）
+- [ ] CI 全部通过
+- [ ] Merge 到主分支
+- [ ] 确认是否需要单独发布 patch 版本
+```
+
+---
+
+## 使用示例
+
+### 场景 A：首次初始化（monorepo，多个上游）
+
+用户输入：
+
+```
+帮我追踪 antdv-next（/home/user/antdv-next）的上游同步，
+上游有三个仓库：
+- ant-design: https://github.com/ant-design/ant-design.git → packages/components
+- ant-design-icons: https://github.com/ant-design/ant-design-icons.git（packages/icons-vue）→ packages/icons
+- pro-components: https://github.com/ant-design/pro-components.git（packages/table → packages/pro-table，packages/form → packages/pro-form）
+从各自的最新 tag 开始
+```
+
+Claude 执行流程：
+
+1. 检查 `.sync-upstream.json` → 不存在，进入初始化
+2. 按用户描述创建配置文件，写入三个上游的 `remote_url` 和 `packages` 映射
+3. 依次 clone 三个上游到 tmp，各取当前 HEAD 作为 `last_synced_commit`
+4. 清理 tmp，告知用户配置完成
+
+### 场景 B：续传同步（已有配置）
+
+用户输入：
+
+```
+同步仓库
+```
+
+Claude 执行流程：
+
+1. 读取 `.sync-upstream.json` → 找到三个上游及各自的 `last_synced_commit`
+2. 对每个上游依次（或并行）：clone to tmp → 分析新 commit → 按 `packages` 映射定位下游子包
+3. 合并输出一张汇总表格，按上游分组、优先级排序
+4. 输出每个 PR 的 checklist，标注影响的下游子包路径
+5. 更新三个上游各自的 `last_synced_commit`，清理 tmp
+
+---
+
+## Step 8（主进程）：更新同步状态文件
+
+每次完成分析后，将本次分析到的**上游最新 commit** 写回 `.sync-upstream.json`：
+
+```bash
+# 获取上游当前 HEAD commit
+LATEST=$(git -C $UPSTREAM_DIR rev-parse HEAD)
+LATEST_SHORT=$(git -C $UPSTREAM_DIR rev-parse --short HEAD)
+LATEST_TAG=$(git -C $UPSTREAM_DIR describe --tags --abbrev=0 2>/dev/null || echo "")
+NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+```
+
+更新 `last_synced_commit` 为 `$LATEST`，`last_synced_at` 为 `$NOW`。
+
+告知用户：
+
+> ✅ 同步状态已更新：下次直接说"继续同步"即可，无需提供 commit SHA。
+
+> 详见 `references/sync-state.md` 了解完整的读写操作和多上游支持
+
+---
+
+## 注意事项
+
+- GitHub API 未认证限流为 60次/小时，认证后为 5000次/小时，建议用户提供 token
+- 部分 commit 可能没有关联 PR（直接 push），这类提交单独列出供人工判断
+- "Skip" 类 PR 仍然列出，方便人工复核是否真的不适用
+- 如果 PR 数量 > 50，建议分批处理或按时间段拆分
+- `.sync-upstream.json` 加入版本控制，团队共享同步进度；`.sync-upstream.local.json` 加入 `.gitignore`，存放个人本地路径，互不干扰
+- 详细 API 调用示例见 `references/github-api.md`
+- 优先级规则可按项目需求调整，见 `references/priority-rules.md`

--- a/.agents/skills/cross-repo-pr-sync/assets/checklist-templates.md
+++ b/.agents/skills/cross-repo-pr-sync/assets/checklist-templates.md
@@ -1,0 +1,142 @@
+# Checklist 模板库
+
+## 标准同步 Checklist（通用）
+
+```markdown
+---
+
+## ✅ 同步任务：#{PR编号} - {PR标题}
+
+> **优先级**: {🔴 P0 / 🟠 P1 / 🟡 P2 / 🟢 P3}
+> **类型**: {fix / feat / perf / docs}
+> **上游 PR**: https://github.com/{upstream_repo}/pull/{PR编号}
+> **上游 Commit**: `{commit_sha_short}`
+> **涉及组件**: {ComponentName}
+> **同步难度**: {Low / Medium / High}
+> **关联 Issue**: {issue_url 或 N/A}
+> **预估工时**: {0.5h / 1h / 2h / 3h+}
+
+### 📖 变更摘要
+<!-- 简要描述上游 PR 解决了什么问题 -->
+{摘要内容}
+
+### 🔗 参考资源
+- 上游 PR：[#{PR编号} {PR标题}]({pr_url})
+- 相关 issue：{issue_url}
+- 上游 diff：{diff_url}
+
+---
+
+### 🔍 Phase 1：Pre-sync 分析
+
+- [ ] 阅读上游 PR 完整内容和所有 review 评论
+- [ ] 阅读关联 issue，了解问题背景
+- [ ] 在 antdv-next 中复现/确认同样的问题或缺失功能
+- [ ] 查看上游变更的完整文件列表
+- [ ] 评估 Vue3 适配工作量，确认难度估计是否准确
+- [ ] 检查是否有其他依赖 PR 需要先同步
+
+### 🛠️ Phase 2：实现
+
+- [ ] 创建功能分支：`sync/ant-design-#{PR编号}`
+- [ ] 实现对应的 fix/feat
+  - [ ] 核心逻辑实现
+  - [ ] 处理 React→Vue3 语法差异（见下方 Checklist）
+  - [ ] 处理 CSS/样式差异（class 绑定方式等）
+- [ ] 编写/更新单元测试（`.spec.ts` 或 `.test.ts`）
+- [ ] 更新组件 API 文档（若有新增/修改 prop/event/slot）
+- [ ] 更新 CHANGELOG（若适用）
+
+### ⚠️ Phase 3：React→Vue3 差异检查
+
+<!-- 根据实际情况勾选需要处理的项 -->
+
+- [ ] `children` / `ReactNode` → `slots`（默认 slot 或具名 slot）
+- [ ] `React.forwardRef` → `defineExpose` / `ref` 透传
+- [ ] `useEffect(() => {}, [])` → `onMounted` / `watchEffect`
+- [ ] `useCallback` / `useMemo` → `computed` / `watch`
+- [ ] `useRef` → `ref()` / `shallowRef()`
+- [ ] `className` → `class`（模板中）或 `:class` 绑定
+- [ ] `style={{ key: value }}` → `:style="{ key: value }"`
+- [ ] `onChange` → `@change` / `@update:value` + `emits` 声明
+- [ ] Context API → `provide` / `inject`
+- [ ] `React.cloneElement` → slot 重构或 `h()` 函数
+- [ ] `React.createPortal` → `<Teleport>` 组件
+- [ ] `React.memo` → 无直接等价（Vue3 本身优化较好）
+- [ ] 事件修饰符差异（`.stop`, `.prevent` 等）
+
+### 🧪 Phase 4：验证
+
+- [ ] 本地运行单元测试套件：`pnpm test`
+- [ ] 本地运行 E2E 测试（若有）
+- [ ] 在 demo 环境中手动验证修复效果
+- [ ] 验证修复不引入回归（测试相邻功能）
+- [ ] 验证 TypeScript 类型正确（`pnpm type-check`）
+
+### 📦 Phase 5：提交与发布
+
+- [ ] 创建 antdv-next PR
+  - 标题格式：`[sync] {type}({Component}): {描述} (ant-design#{PR编号})`
+  - 示例：`[sync] fix(Button): loading state not cleared (#12345)`
+- [ ] PR 描述中：
+  - [ ] 链接上游 PR
+  - [ ] 说明适配了哪些 Vue3 差异
+  - [ ] 附上 before/after 截图（UI 变更时）
+- [ ] 至少 1 位 Reviewer 完成 Code Review
+- [ ] CI 所有 Job 通过
+- [ ] Squash and Merge 到主分支
+- [ ] 确认是否需要单独发布 patch 版本
+
+---
+
+**完成时间**: **\_\_\_\_** / **实际工时**: **\_\_\_\_** / **负责人**: **\_\_\_\_**
+```
+
+---
+
+## Batch Checklist（批量同步多个 P3/文档类）
+
+```markdown
+## 📦 批量同步任务 - {日期} - {组件名} 文档/样式更新
+
+| PR #    | 标题   | 状态 |
+| ------- | ------ | ---- |
+| #{编号} | {标题} | ⬜   |
+| #{编号} | {标题} | ⬜   |
+
+### 执行步骤
+
+- [ ] 创建统一分支：`sync/batch-{日期}-{主题}`
+- [ ] 按表格顺序逐一处理
+- [ ] 统一 PR 提交，引用所有上游 PR
+- [ ] 一次性合并发布
+```
+
+---
+
+## 团队同步会议模板
+
+```markdown
+## 🔄 上游同步周会 - {日期}
+
+### 本期新增 PR（需同步）
+
+{汇总表格}
+
+### 进行中任务更新
+
+| PR # | 负责人 | 进度 | 阻塞点 |
+| ---- | ------ | ---- | ------ |
+|      |        |      |        |
+
+### 已完成同步
+
+| PR # | 完成日期 | antdv-next PR |
+| ---- | -------- | ------------- |
+|      |          |               |
+
+### 决策事项
+
+- [ ] 是否发布 patch 版本（修复了哪些 P0/P1）
+- [ ] 下周重点同步哪些 PR
+```

--- a/.agents/skills/cross-repo-pr-sync/references/branch-management.md
+++ b/.agents/skills/cross-repo-pr-sync/references/branch-management.md
@@ -1,0 +1,220 @@
+# 分支管理：一 PR 一分支
+
+每个上游 PR 在下游 monorepo 中对应一个独立的本地分支，
+主进程在汇总阶段对所有非 Skip 的 PR 统一自动创建分支，每个分支附带对应的 checklist 文件。
+
+---
+
+## 分支命名规则
+
+```
+sync/{upstream-name}-{pr-number}
+```
+
+示例：
+
+| 上游 PR               | 分支名                      |
+| --------------------- | --------------------------- |
+| ant-design #12345     | `sync/ant-design-12345`     |
+| pro-components #8800  | `sync/pro-components-8800`  |
+| ant-design-icons #560 | `sync/ant-design-icons-560` |
+
+命名规则说明：
+
+- `upstream-name` 取 `.sync-upstream.json` 中的 `name` 字段，统一小写，空格替换为 `-`
+- `pr-number` 直接使用上游 PR 编号，无需补零
+- 前缀固定为 `sync/`，方便在 git 中统一过滤和管理
+
+---
+
+## 自动创建策略
+
+| 优先级  | 行为                               |
+| ------- | ---------------------------------- |
+| 🔴 P0   | 自动创建分支 + 写入 checklist 文件 |
+| 🟠 P1   | 自动创建分支 + 写入 checklist 文件 |
+| 🟡 P2   | 自动创建分支 + 写入 checklist 文件 |
+| 🟢 P3   | 自动创建分支 + 写入 checklist 文件 |
+| ⚪ Skip | 不处理                             |
+
+---
+
+## 分支创建流程
+
+### 主进程在 Step 7 汇总后执行
+
+```bash
+BASE_BRANCH="main"   # 来自 settings.base_branch
+UPSTREAM_NAME="ant-design"
+PR_NUMBER="12345"
+BRANCH="sync/${UPSTREAM_NAME}-${PR_NUMBER}"
+
+# 1. 确认基准分支是最新的
+git fetch origin "$BASE_BRANCH"
+
+# 2. 检查分支是否已存在（避免重复创建）
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+    echo "⚠️  分支 $BRANCH 已存在，跳过创建"
+else
+    # 3. 从基准分支创建
+    git checkout -b "$BRANCH" "origin/$BASE_BRANCH"
+    echo "✅ 已创建分支: $BRANCH"
+
+    # 4. 写入 checklist 文件到分支
+    cat > ".sync-checklist-${UPSTREAM_NAME}-${PR_NUMBER}.md" << CHECKLIST
+$(generate_checklist $PR_DATA)
+CHECKLIST
+    git add ".sync-checklist-${UPSTREAM_NAME}-${PR_NUMBER}.md"
+    git commit -m "chore: add sync checklist for ${UPSTREAM_NAME}#${PR_NUMBER}"
+
+    # 5. 切回基准分支，不留在同步分支上
+    git checkout "$BASE_BRANCH"
+fi
+```
+
+### Python 实现（主进程批量创建）
+
+```python
+import subprocess
+from pathlib import Path
+
+def create_sync_branch(pr: dict, settings: dict) -> bool:
+    """为单个 PR 创建同步分支，返回是否成功"""
+    upstream_name = pr["upstream_name"].lower().replace(" ", "-")
+    pr_number = pr["pr_number"]
+    branch = f"sync/{upstream_name}-{pr_number}"
+    base = settings.get("base_branch", "main")
+
+    # 检查是否已存在
+    result = subprocess.run(
+        ["git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"],
+        capture_output=True
+    )
+    if result.returncode == 0:
+        print(f"   ⚠️  {branch} 已存在，跳过")
+        return False
+
+    try:
+        # 从基准分支创建
+        subprocess.run(
+            ["git", "checkout", "-b", branch, f"origin/{base}"],
+            check=True, capture_output=True
+        )
+
+        # 写入 checklist 文件
+        checklist_path = Path(f".sync-checklist-{upstream_name}-{pr_number}.md")
+        checklist_path.write_text(render_checklist(pr))
+        subprocess.run(["git", "add", str(checklist_path)], check=True)
+        subprocess.run(
+            ["git", "commit", "-m",
+             f"chore: add sync checklist for {upstream_name}#{pr_number}\n\n"
+             f"upstream: {pr['upstream_url']}"],
+            check=True
+        )
+
+        # 切回基准分支
+        subprocess.run(["git", "checkout", base], check=True, capture_output=True)
+        print(f"   ✅ {branch}")
+        return True
+
+    except subprocess.CalledProcessError as e:
+        # 创建失败时切回基准分支，清理残留
+        subprocess.run(["git", "checkout", base], capture_output=True)
+        subprocess.run(["git", "branch", "-D", branch], capture_output=True)
+        print(f"   ❌ {branch} 创建失败: {e}")
+        return False
+
+
+def batch_create_branches(results: list[dict], settings: dict):
+    """主进程汇总后批量创建所有待同步 PR 的分支（Skip 除外）"""
+    candidates = [
+        pr for r in results
+        for pr in r.get("prs", [])
+        if pr["status"] == "pending"
+    ]
+
+    if not candidates:
+        print("📭 无需自动创建同步分支")
+        return
+
+    print(f"\n🌿 自动创建同步分支（共 {len(candidates)} 个）")
+    created, skipped, failed = 0, 0, 0
+
+    for pr in sorted(candidates, key=lambda p: (p["priority"], p["pr_number"])):
+        result = create_sync_branch(pr, settings)
+        if result is True:   created += 1
+        elif result is False: skipped += 1
+        else:                 failed  += 1
+
+    print(f"\n   创建 {created} 个 / 跳过 {skipped} 个（已存在）/ 失败 {failed} 个")
+```
+
+---
+
+## Checklist 文件落地位置
+
+Checklist 文件随分支创建时一并 commit 进去，文件名和分支名对应：
+
+```
+sync/ant-design-12345  分支
+└── .sync-checklist-ant-design-12345.md   ← 随分支一起创建
+```
+
+加入 `.gitignore` 防止合并时带入主分支：
+
+```bash
+# Skill 初始化时自动写入
+echo ".sync-checklist-*.md" >> .gitignore
+```
+
+这样 checklist 文件只在同步分支上存在，合并到 main 后自动消失，不污染主分支历史。
+
+---
+
+## 主进程最终输出摘要
+
+所有分支创建完成后，主进程打印汇总：
+
+```
+════════════════════════════════════════════════
+ 同步分析完成
+════════════════════════════════════════════════
+
+ 📊 发现 22 个待同步 PR
+    🔴 P0:  1 个   🟠 P1:  4 个
+    🟡 P2: 11 个   🟢 P3:  4 个   ⚪ Skip: 2 个
+
+ 🌿 已自动创建 5 个同步分支：
+    ✅ sync/ant-design-12345        fix(Button): loading state
+    ✅ sync/pro-components-8800     fix(Table): sort reset
+    ✅ sync/ant-design-12300        fix(Select): dropdown z-index
+    ⚠️  sync/ant-design-11900       已存在，跳过
+    ✅ sync/ant-design-icons-560    feat: add new icons
+
+ 💾 同步状态已更新，建议执行：
+    git add .sync-upstream.json && git commit -m "chore: sync state update"
+
+════════════════════════════════════════════════
+```
+
+---
+
+## 常用 git 操作
+
+```bash
+# 查看所有同步分支
+git branch | grep "^  sync/"
+
+# 查看某个同步分支的 checklist
+git show sync/ant-design-12345:.sync-checklist-ant-design-12345.md
+
+# 切换到某个同步分支开始工作
+git checkout sync/ant-design-12345
+
+# 同步分支完成后推送并开 PR
+git push origin sync/ant-design-12345
+# 然后在 GitHub/GitLab 上开 PR，目标分支填 main
+
+# 批量删除已合并的同步分支
+git branch --merged main | grep "sync/" | xargs git branch -d
+```

--- a/.agents/skills/cross-repo-pr-sync/references/github-api.md
+++ b/.agents/skills/cross-repo-pr-sync/references/github-api.md
@@ -1,0 +1,220 @@
+# GitHub API 参考手册
+
+## 认证
+
+```http
+Authorization: Bearer {GITHUB_TOKEN}
+Accept: application/vnd.github+json
+X-GitHub-Api-Version: 2022-11-28
+```
+
+---
+
+## 1. 获取从指定 commit 往后的所有提交
+
+GitHub API 的 `/commits` 接口只支持从最新往前翻，所以需要客户端处理：
+
+### 策略 A：获取全部后过滤（推荐，commit 数量 < 500 时）
+
+```bash
+# 获取所有 commit，直到找到 start_commit 为止
+GET https://api.github.com/repos/{owner}/{repo}/commits
+  ?sha=HEAD
+  &per_page=100
+  &page=1
+```
+
+客户端逻辑（伪代码）：
+
+```python
+commits = []
+page = 1
+while True:
+    batch = api_get(f"/commits?per_page=100&page={page}")
+    for commit in batch:
+        if commit.sha.startswith(start_commit):
+            return commits  # 找到起点，停止
+        commits.append(commit)
+    page += 1
+    if len(batch) < 100:
+        break  # 已到仓库末尾
+return commits
+```
+
+### 策略 B：使用 compare API（推荐，精确高效）
+
+```
+GET https://api.github.com/repos/{owner}/{repo}/compare/{start_commit}...HEAD
+```
+
+返回字段：
+
+```json
+{
+  "commits": [
+    {
+      "sha": "abc123",
+      "commit": {
+        "message": "fix(Button): loading state not cleared",
+        "author": { "date": "2024-01-20T10:00:00Z" }
+      },
+      "html_url": "https://github.com/..."
+    }
+  ],
+  "total_commits": 42
+}
+```
+
+> ⚠️ compare API 最多返回 250 个 commit，超过时需要分段使用
+
+---
+
+## 2. 过滤 fix/feat commits
+
+### Conventional Commits 正则匹配
+
+```python
+import re
+
+CONVENTIONAL_PATTERN = re.compile(
+    r'^(fix|feat|feature|bugfix|perf|revert)(\([^)]+\))?!?:\s+.+',
+    re.IGNORECASE
+)
+
+PR_MERGE_PATTERN = re.compile(
+    r'^Merge pull request #(\d+)',
+    re.IGNORECASE
+)
+
+def is_sync_candidate(message: str) -> bool:
+    first_line = message.split('\n')[0]
+    return bool(
+        CONVENTIONAL_PATTERN.match(first_line) or
+        PR_MERGE_PATTERN.match(first_line)
+    )
+```
+
+---
+
+## 3. 查询 commit 关联的 PR
+
+```
+GET https://api.github.com/repos/{owner}/{repo}/commits/{commit_sha}/pulls
+```
+
+Headers 需要加：
+
+```
+Accept: application/vnd.github.groot-preview+json
+```
+
+返回 PR 列表（通常 0 或 1 个），取第一个。
+
+---
+
+## 4. 获取 PR 详情
+
+```
+GET https://api.github.com/repos/{owner}/{repo}/pulls/{pull_number}
+```
+
+重要字段：
+
+```json
+{
+  "number": 12345,
+  "title": "fix(Button): loading state not cleared after async",
+  "body": "## Summary\n...",
+  "labels": [{ "name": "bug" }, { "name": "🐛 Bug" }],
+  "html_url": "https://github.com/...",
+  "merged_at": "2024-01-20T12:00:00Z",
+  "user": { "login": "contributor" }
+}
+```
+
+---
+
+## 5. 获取 PR 文件变更列表
+
+```
+GET https://api.github.com/repos/{owner}/{repo}/pulls/{pull_number}/files
+```
+
+返回：
+
+```json
+[
+  {
+    "filename": "components/button/index.tsx",
+    "status": "modified",
+    "additions": 10,
+    "deletions": 3
+  }
+]
+```
+
+用于推断影响的组件名。
+
+---
+
+## 6. 组件名推断规则
+
+```python
+import re
+
+def extract_components(files: list[str]) -> list[str]:
+    components = set()
+    for f in files:
+        # components/button/xxx -> Button
+        m = re.match(r'components/([^/]+)/', f)
+        if m:
+            name = m.group(1)
+            # 过滤非组件目录
+            if name not in ('_util', 'style', '__tests__', 'locale'):
+                components.add(name.replace('-', ' ').title().replace(' ', ''))
+    return sorted(components)
+```
+
+---
+
+## 7. 限流处理
+
+```python
+import time
+
+def api_get_with_retry(url, headers, max_retries=3):
+    for i in range(max_retries):
+        resp = requests.get(url, headers=headers)
+        if resp.status_code == 403:
+            reset_time = int(resp.headers.get('X-RateLimit-Reset', 0))
+            wait = reset_time - time.time() + 5
+            print(f"限流，等待 {wait:.0f} 秒...")
+            time.sleep(max(wait, 1))
+            continue
+        if resp.status_code == 200:
+            # 检查剩余次数
+            remaining = int(resp.headers.get('X-RateLimit-Remaining', 100))
+            if remaining < 10:
+                print(f"⚠️ API 剩余调用次数: {remaining}")
+            return resp.json()
+    raise Exception(f"API 请求失败: {url}")
+```
+
+---
+
+## 8. 完整示例脚本
+
+见 `../scripts/fetch_prs.py`（如需运行脚本版本）
+
+---
+
+## 常见问题
+
+**Q: commit 没有关联 PR 怎么办？**
+A: 直接用 commit message 作为条目，在表格中标注 `(no PR)` 并降低优先级。
+
+**Q: PR 被 revert 了怎么办？**
+A: 检查 PR 标题是否以 `Revert "..."` 开头，若是则标注 `⚪ Reverted`，跳过同步。
+
+**Q: 同一个 bug 有多个 PR 修复怎么办？**
+A: 只保留最终合并的那个；可以通过 PR body 中的 `Supersedes #xxx` 关键词识别。

--- a/.agents/skills/cross-repo-pr-sync/references/local-git.md
+++ b/.agents/skills/cross-repo-pr-sync/references/local-git.md
@@ -1,0 +1,201 @@
+# 本地 Git 命令参考手册
+
+适用于用户提供了本地仓库路径的场景，直接使用 `git` CLI，无需 GitHub API 或网络连接。
+
+---
+
+## 前置检查
+
+> **变量说明**：本文档中 `$UPSTREAM_DIR` 为上游仓库路径（来自 `local_path` 或 auto-clone 的 tmp 路径），`$DOWNSTREAM_DIR` 为下游仓库路径（通常为 `./`）。
+
+```bash
+# 确认路径有效且是 git 仓库
+git -C $UPSTREAM_DIR rev-parse --git-dir
+git -C $DOWNSTREAM_DIR rev-parse --git-dir
+
+# 确认起始 commit 存在
+git -C $UPSTREAM_DIR cat-file -t <start_commit>
+# 输出应为 "commit"
+```
+
+---
+
+## 1. 获取从起始 commit 往后的所有提交
+
+```bash
+# 基础：从 start_commit 到 HEAD 的全部提交
+git -C $UPSTREAM_DIR log <start_commit>..HEAD \
+  --pretty=format:"%H|%h|%s|%ad|%an" \
+  --date=short
+
+# 只看 fix / feat 类型（conventional commits）
+git -C $UPSTREAM_DIR log <start_commit>..HEAD \
+  --pretty=format:"%H|%h|%s|%ad|%an" \
+  --date=short \
+  --extended-regexp \
+  --grep="^(fix|feat|feature|perf|revert)(\(.+\))?!?:"
+
+# 同时匹配 PR merge commit（GitHub 风格）
+git -C $UPSTREAM_DIR log <start_commit>..HEAD \
+  --pretty=format:"%H|%h|%s|%ad|%an" \
+  --date=short \
+  --extended-regexp \
+  --grep="^(fix|feat|feature|perf|revert)(\(.+\))?!?:|^Merge pull request #"
+```
+
+输出示例：
+
+```
+a1b2c3d4e5f6|a1b2c3d|fix(Button): loading state not cleared|2024-03-01|contributor
+```
+
+---
+
+## 2. 查看某次提交的完整信息
+
+```bash
+# 完整 commit 信息 + 文件统计
+git -C $UPSTREAM_DIR show <sha> --stat
+
+# 只看改动了哪些文件
+git -C $UPSTREAM_DIR diff-tree --no-commit-id -r <sha> --name-only
+
+# 查看具体 diff 内容
+git -C $UPSTREAM_DIR show <sha> -- components/button/index.tsx
+```
+
+---
+
+## 3. 从 commit message 提取 PR 编号
+
+GitHub merge commit 格式为 `Merge pull request #123 from branch`，可用以下命令提取：
+
+```bash
+git -C $UPSTREAM_DIR log <start_commit>..HEAD \
+  --pretty=format:"%H %s" \
+  --extended-regexp \
+  --grep="Merge pull request #" \
+| grep -oP "#\d+"
+```
+
+对于 squash merge，PR 编号通常在 commit message 末尾：
+
+```
+fix(Button): loading state not cleared (#12345)
+```
+
+```bash
+# 提取括号内的 PR 编号
+echo "fix(Button): loading state not cleared (#12345)" \
+| grep -oP "\(#\d+\)" | grep -oP "\d+"
+```
+
+---
+
+## 4. 推断涉及的组件
+
+```bash
+# 获取某 commit 改动的文件列表，过滤出组件路径
+git -C $UPSTREAM_DIR diff-tree --no-commit-id -r <sha> --name-only \
+| grep "^components/" \
+| sed 's|components/\([^/]*\)/.*|\1|' \
+| sort -u
+```
+
+排除非组件目录：
+
+```bash
+| grep -vE "^(_util|style|locale|theme|__tests__)$"
+```
+
+---
+
+## 5. 检查下游仓库是否已同步某个 PR
+
+```bash
+# 在下游 commit message 中搜索上游 PR 编号
+git -C $DOWNSTREAM_DIR log --oneline \
+| grep -i "#12345\|ant-design.*12345\|sync.*12345"
+
+# 更宽泛的搜索（搜索关键词）
+git -C $DOWNSTREAM_DIR log --oneline --grep="12345"
+```
+
+若搜索无结果，则该 PR **尚未同步**，状态标记为 `⬜ 待同步`。
+
+---
+
+## 6. 对比两个仓库的文件差异
+
+```bash
+# 对比上游某组件文件与下游对应文件的差异
+diff \
+  <(git -C $UPSTREAM_DIR show HEAD:components/button/index.tsx) \
+  <(git -C $DOWNSTREAM_DIR show HEAD:components/button/index.vue)
+
+# 使用 git diff 风格输出
+git diff \
+  --no-index \
+  $UPSTREAM_DIR/components/button/index.tsx \
+  $DOWNSTREAM_DIR/components/button/index.vue
+```
+
+---
+
+## 7. 批量处理：生成完整的待同步清单
+
+```bash
+#!/bin/bash
+UPSTREAM=$UPSTREAM_DIR  # 从 local_path 或 auto-clone tmp 路径读取
+START_COMMIT=abc123
+
+git -C "$UPSTREAM" log "${START_COMMIT}..HEAD" \
+  --pretty=format:"%h|%s|%ad" \
+  --date=short \
+  --extended-regexp \
+  --grep="^(fix|feat|feature|perf)(\(.+\))?!?:|Merge pull request #" \
+| while IFS='|' read -r sha subject date; do
+    # 提取组件名
+    components=$(git -C "$UPSTREAM" diff-tree --no-commit-id -r "$sha" --name-only \
+      | grep "^components/" \
+      | sed 's|components/\([^/]*\)/.*|\1|' \
+      | grep -vE "^(_util|style|locale)$" \
+      | sort -u | tr '\n' ',' | sed 's/,$//')
+
+    echo "$sha | $date | $subject | ${components:-unknown}"
+done
+```
+
+---
+
+## 8. 常见问题
+
+**Q: 起始 commit 是浅克隆（shallow）找不到怎么办？**
+
+```bash
+git -C $UPSTREAM_DIR fetch --unshallow
+```
+
+**Q: 想按时间范围而不是 commit 范围筛选？**
+
+```bash
+git -C $UPSTREAM_DIR log \
+  --after="2024-01-01" --before="2024-06-01" \
+  --pretty=format:"%h|%s|%ad" --date=short \
+  --extended-regexp \
+  --grep="^(fix|feat)(\(.+\))?!?:"
+```
+
+**Q: 下游仓库用的不是 GitHub PR 格式，怎么追踪同步状态？**
+
+在 commit message 中约定格式，例如：
+
+```
+[sync] fix(Button): loading (#upstream-12345)
+```
+
+然后用：
+
+```bash
+git -C /downstream log --grep="\[sync\]" --oneline
+```

--- a/.agents/skills/cross-repo-pr-sync/references/priority-rules.md
+++ b/.agents/skills/cross-repo-pr-sync/references/priority-rules.md
@@ -1,0 +1,150 @@
+# 同步优先级规则详解
+
+## 优先级体系
+
+本规则专为 React 组件库 → Vue3 移植场景设计，
+以 ant-design → antdv-next 为典型案例，也可适用于其他跨框架同步场景。
+
+---
+
+## P0 🔴 紧急（当天处理）
+
+**判断条件（满足任意一条）**：
+
+- Labels 含 `Security` / `security`
+- 标题或 body 含关键词：`XSS`, `CSRF`, `injection`, `security`, `vulnerability`
+- 标题含：`crash`, `fatal`, `data loss`, `corruption`
+- 影响用户数据的严重 bug
+
+**处理原则**：
+
+- 不等下次版本周期，单独发 patch
+- 可以简化 review 流程，但至少 1 人审核
+
+---
+
+## P1 🟠 高优先级（本迭代内完成）
+
+**判断条件（满足任意一条）**：
+
+- Labels 含 `bug` 且影响核心交互组件：
+  - Form / FormItem（表单提交、校验逻辑）
+  - Table（渲染、分页、排序）
+  - Select / AutoComplete（选项、搜索）
+  - Modal / Drawer（开关状态、层级）
+  - Upload（文件处理）
+- 标题含：`regression`, `broken`, `not working`
+- PR 关联的 issue 有大量 👍 反应（>10）
+- commit message 含 `!`（breaking change marker）
+
+**处理原则**：
+
+- 排入当前 sprint
+- 需要完整测试覆盖
+
+---
+
+## P2 🟡 中优先级（下个迭代）
+
+**判断条件（大多数 PR 属于此类）**：
+
+- 普通 bug fix（非核心组件，或影响面较小）
+- `feat` 类型：新增 prop、新增功能
+- 体验优化（动画、过渡、响应速度）
+- TypeScript 类型完善（有实际影响的）
+- 无障碍（a11y）改进
+
+**处理原则**：
+
+- 按组件分批同步
+- 可以批量处理同一组件的多个 P2
+
+---
+
+## P3 🟢 低优先级（有空再做）
+
+**判断条件**：
+
+- `docs` 类型：仅文档更新
+- 样式微调（px 级别的间距调整）
+- 废弃警告（deprecation notice）
+- 内部重构（对外 API 无变化）
+- 纯 TypeScript 类型的细微修复（无运行时影响）
+
+**处理原则**：
+
+- 积累后批量处理
+- 文档类可直接由 AI 辅助生成对应 Vue3 文档
+
+---
+
+## ⚪ Skip（跳过，不同步）
+
+**判断条件（满足任意一条则跳过）**：
+
+- 文件变更仅包含：
+  - `site/` - 演示站点
+  - `.github/` - GitHub Actions / issue 模板
+  - `scripts/` - 构建脚本（React 特有）
+  - `*.test.tsx` only - 仅测试文件（需对应写 Vue 测试）
+- 标题明确包含：`[React 18]`, `[SSR]`, `[Next.js]`
+- 变更内容是 React 特有 API，Vue3 没有等价实现且不需要：
+  - `React.Suspense` / `React.lazy` 相关
+  - `ReactDOM.createPortal`（Vue3 有 Teleport 替代，记录为 Medium 难度）
+  - Server Components 相关
+
+**注意**：Skip 不代表永远不处理，而是当前阶段不主动同步。
+表格中仍然列出，人工复核后可降级为 P3。
+
+---
+
+## 同步难度评估
+
+### Low（直接移植，1-2小时）
+
+- 纯 CSS/Less 变量修改
+- 计算逻辑修复（不涉及渲染）
+- 新增一个 prop（类型简单，无副作用）
+- 事件 handler 逻辑修复
+
+### Medium（需要适配，半天到1天）
+
+- JSX → Template/Render Function 转换
+- `props.children` → `slots`
+- `useRef` → `ref` / `defineExpose`
+- `React.cloneElement` → 需要重构为 slot 方案
+- Context → provide/inject 重构
+- `useEffect` → watch/watchEffect/onMounted
+
+### High（需要架构讨论，1-3天）
+
+- 深度使用 React Hooks 的组件逻辑重写
+- HOC（高阶组件）模式 → Vue3 组合式重构
+- 状态管理方案差异导致的架构调整
+- 渲染性能优化（React 特有，如 memo/useMemo）
+
+---
+
+## 优先级覆盖规则
+
+当自动判断的优先级与实际情况不符时，可手动覆盖：
+
+```markdown
+<!-- 在 PR checklist 顶部添加 -->
+
+**优先级覆盖**: P2 → P1
+**覆盖原因**: 社区反馈强烈，issues #xxx 有 50+ 反馈
+```
+
+---
+
+## 组件重要性排序（供 P1 判断参考）
+
+**Tier 1（核心，bug 直接升 P1）**：
+Form, Table, Select, Input, Button, Modal, DatePicker, Upload, Tree
+
+**Tier 2（重要，bug 保持 P2）**：
+Drawer, Tabs, Menu, Pagination, Checkbox, Radio, Switch
+
+**Tier 3（辅助，bug 可降 P3）**：
+Tag, Badge, Avatar, Tooltip, Popover, Divider, Breadcrumb

--- a/.agents/skills/cross-repo-pr-sync/references/sync-state.md
+++ b/.agents/skills/cross-repo-pr-sync/references/sync-state.md
@@ -1,0 +1,431 @@
+# 同步状态文件参考：.sync-upstream.json
+
+下游仓库根目录下的 `.sync-upstream.json` 记录了与上游仓库的同步进度，
+是实现"继续同步"功能的核心，支持同时追踪多个上游仓库。
+
+---
+
+## 文件格式
+
+### 单包仓库对应 monorepo 子包（典型场景）
+
+```json
+{
+  "version": "1",
+  "downstream": {
+    "name": "antdv-next",
+    "local_path": "./"
+  },
+  "settings": {
+    "parallel": true,
+    "max_workers": 4,
+    "max_prs": 50,
+    "base_branch": "main"
+  },
+  "upstreams": [
+    {
+      "name": "ant-design",
+      "remote_url": "https://github.com/ant-design/ant-design.git",
+      "local_path": null,
+      "packages": [
+        {
+          "upstream_path": ".",
+          "downstream_path": "packages/components",
+          "description": "核心组件库"
+        }
+      ],
+      "last_synced_commit": "a1b2c3d4e5f6",
+      "last_synced_commit_short": "a1b2c3d",
+      "last_synced_at": "2024-03-01T12:00:00Z",
+      "last_synced_tag": "v5.15.0",
+      "sync_count": 3
+    },
+    {
+      "name": "ant-design-icons",
+      "remote_url": "https://github.com/ant-design/ant-design-icons.git",
+      "local_path": null,
+      "packages": [
+        {
+          "upstream_path": "packages/icons-vue",
+          "downstream_path": "packages/icons",
+          "description": "图标库 Vue3 子包"
+        }
+      ],
+      "last_synced_commit": "b2c3d4e5f6a7",
+      "last_synced_commit_short": "b2c3d4e",
+      "last_synced_at": "2024-02-15T08:00:00Z",
+      "last_synced_tag": "v5.3.0",
+      "sync_count": 1
+    },
+    {
+      "name": "pro-components",
+      "remote_url": "https://github.com/ant-design/pro-components.git",
+      "local_path": null,
+      "packages": [
+        {
+          "upstream_path": "packages/table",
+          "downstream_path": "packages/pro-table",
+          "description": "ProTable"
+        },
+        {
+          "upstream_path": "packages/form",
+          "downstream_path": "packages/pro-form",
+          "description": "ProForm"
+        }
+      ],
+      "last_synced_commit": "c3d4e5f6a7b8",
+      "last_synced_commit_short": "c3d4e5f",
+      "last_synced_at": "2024-02-01T00:00:00Z",
+      "last_synced_tag": "v2.6.0",
+      "sync_count": 2
+    }
+  ]
+}
+```
+
+### 字段说明
+
+| 字段                                   | 必填     | 说明                                                                 |
+| -------------------------------------- | -------- | -------------------------------------------------------------------- |
+| `version`                              | 是       | 文件格式版本，当前为 `"1"`                                           |
+| `downstream.name`                      | 否       | 下游仓库名称，便于显示                                               |
+| `downstream.local_path`                | 否       | 下游仓库根目录路径                                                   |
+| `upstreams[].name`                     | 是       | 上游仓库名称（唯一标识）                                             |
+| `upstreams[].remote_url`               | 条件必填 | 上游 Git remote 地址，支持任意平台。`local_path` 为 null 时必填      |
+| `upstreams[].local_path`               | 条件必填 | 上游仓库本地路径，有本地副本时填写，优先于 remote_url，无则填 `null` |
+| `upstreams[].packages`                 | 否       | 路径映射表，描述上游路径到下游 monorepo 子包路径的对应关系（见下）   |
+| `upstreams[].last_synced_commit`       | 是       | 上次分析到的上游 commit 完整 SHA                                     |
+| `upstreams[].last_synced_commit_short` | 否       | SHA 短版本（7位）                                                    |
+| `upstreams[].last_synced_at`           | 是       | 上次同步时间（ISO 8601 UTC）                                         |
+| `upstreams[].last_synced_tag`          | 否       | 上次同步时对应的 tag                                                 |
+| `upstreams[].sync_count`               | 否       | 累计同步次数                                                         |
+
+### packages 路径映射字段
+
+| 字段              | 必填 | 说明                                               |
+| ----------------- | ---- | -------------------------------------------------- |
+| `upstream_path`   | 是   | 上游仓库中的路径，`.` 表示整个仓库根目录           |
+| `downstream_path` | 是   | 下游 monorepo 中对应的子包路径（相对于仓库根目录） |
+| `description`     | 否   | 说明这个映射的用途                                 |
+
+> **`packages` 字段的作用**：分析 PR 时，Skill 会根据 commit 改动的文件路径，结合 `packages` 映射，判断该变更影响下游 monorepo 中的哪个子包，并在输出表格中标注。若不填，则只显示上游路径，不做映射。
+
+### settings 字段
+
+| 字段                   | 默认值   | 说明                                 |
+| ---------------------- | -------- | ------------------------------------ |
+| `settings.parallel`    | `true`   | 是否启用多 worker 并行               |
+| `settings.max_workers` | `4`      | 最大并发 worker 数，超出任务排队等待 |
+| `settings.max_prs`     | `50`     | 每个 worker 最多分析的 PR 数量       |
+| `settings.base_branch` | `"main"` | 自动创建同步分支时的基准分支         |
+
+**Worker 粒度固定为：每个 `packages` 条目一个 worker**（下游子包粒度）。
+同一上游的多个子包 worker 共享一次 clone，由主进程统一管理 clone 生命周期。
+
+**数据源优先级**：`local_path`（本地仓库）> 自动克隆 `remote_url` 到 tmp > GitHub API
+
+**Worker 并行说明**：同一个 `remote_url` 的多个子包 worker 会复用一次 clone，主进程统一管理 clone 生命周期，各 worker 只负责过滤自己的 `upstream_path` 范围，结果写入独立的 `{worker_id}.json`，主进程完成后统一清理。详见 `references/worker.md`。
+
+---
+
+## 读取操作
+
+### 检查文件是否存在
+
+```bash
+# 在下游仓库根目录执行
+if [ -f ".sync-upstream.json" ]; then
+    echo "✅ 找到同步记录"
+    cat ".sync-upstream.json"
+else
+    echo "⚠️ 首次使用，需要初始化"
+fi
+```
+
+### 读取上次同步的 commit（bash）
+
+```bash
+LAST_COMMIT=$(cat ".sync-upstream.json" \
+  | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['upstreams'][0]['last_synced_commit'])")
+
+echo "上次同步到: $LAST_COMMIT"
+```
+
+### 读取指定上游的同步记录（多上游场景）
+
+```bash
+# 读取名为 "ant-design" 的上游记录
+UPSTREAM_NAME="ant-design"
+LAST_COMMIT=$(cat ".sync-upstream.json" \
+  | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+upstream = next((u for u in d['upstreams'] if u['name'] == '$UPSTREAM_NAME'), None)
+print(upstream['last_synced_commit'] if upstream else 'NOT_FOUND')
+")
+```
+
+---
+
+## 写入操作
+
+### 初始化文件（首次使用）
+
+```bash
+# 在下游仓库根目录执行，无需任何路径参数
+UPSTREAM_REMOTE="https://github.com/ant-design/ant-design.git"
+START_COMMIT="a1b2c3d4e5f6"
+
+NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+REPO_NAME=$(basename "$(git rev-parse --show-toplevel)")
+
+cat > ".sync-upstream.json" << JSON
+{
+  "version": "1",
+  "downstream": {
+    "name": "$REPO_NAME",
+    "local_path": "./"
+  },
+  "settings": {
+    "parallel": true,
+    "max_workers": 4,
+    "max_prs": 50,
+    "base_branch": "main"
+  },
+  "upstreams": [
+    {
+      "name": "ant-design",
+      "remote_url": "$UPSTREAM_REMOTE",
+      "local_path": null,
+      "packages": [
+        {
+          "upstream_path": ".",
+          "downstream_path": "packages/components",
+          "description": "核心组件库"
+        }
+      ],
+      "last_synced_commit": "$START_COMMIT",
+      "last_synced_commit_short": "${START_COMMIT:0:7}",
+      "last_synced_at": "$NOW",
+      "last_synced_tag": "",
+      "sync_count": 0
+    }
+  ]
+}
+JSON
+
+echo "✅ 已创建 .sync-upstream.json"
+```
+
+### 更新文件（每次同步后）
+
+```bash
+# 在下游仓库根目录执行
+UPSTREAM_NAME="ant-design"
+# LATEST 由主进程在分析完成后从 worker 结果中读取，写回到配置
+LATEST="d4e5f6a7b8c9"
+LATEST_SHORT="d4e5f6a"
+LATEST_TAG="v5.16.0"
+NOW=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+python3 - << PYEOF
+import json, sys
+
+path = ".sync-upstream.json"
+with open(path, 'r') as f:
+    data = json.load(f)
+
+# 找到对应的上游记录并更新
+for upstream in data['upstreams']:
+    if upstream['name'] == '$UPSTREAM_NAME':
+        upstream['last_synced_commit'] = '$LATEST'
+        upstream['last_synced_commit_short'] = '$LATEST_SHORT'
+        upstream['last_synced_at'] = '$NOW'
+        upstream['last_synced_tag'] = '$LATEST_TAG'
+        upstream['sync_count'] = upstream.get('sync_count', 0) + 1
+        break
+
+with open(path, 'w') as f:
+    json.dump(data, f, indent=2, ensure_ascii=False)
+
+print("✅ 同步状态已更新")
+PYEOF
+```
+
+### 添加新的上游记录（多上游扩展）
+
+```bash
+python3 - << PYEOF
+import json
+
+path = ".sync-upstream.json"
+with open(path, 'r') as f:
+    data = json.load(f)
+
+new_upstream = {
+    "name": "new-upstream",
+    "repo": "owner/new-upstream",
+    "local_path": "../new-upstream",
+    "last_synced_commit": "$LATEST",
+    "last_synced_commit_short": "$LATEST_SHORT",
+    "last_synced_at": "$NOW",
+    "last_synced_tag": "",
+    "sync_count": 0
+}
+
+# 避免重复添加
+names = [u['name'] for u in data['upstreams']]
+if new_upstream['name'] not in names:
+    data['upstreams'].append(new_upstream)
+
+with open(path, 'w') as f:
+    json.dump(data, f, indent=2, ensure_ascii=False)
+PYEOF
+```
+
+---
+
+## 本地路径覆盖文件：.sync-upstream.local.json
+
+团队共享的 `.sync-upstream.json` 里上游 `local_path` 填 `null`，
+用本地有仓库副本的成员在 `.sync-upstream.local.json` 里单独覆盖，
+这样既能共享同步进度，又不把个人本地路径污染到 git 历史。
+
+### 文件格式
+
+只需列出需要覆盖的上游名称和对应的本地路径，其余字段全部继承主配置：
+
+```json
+{
+  "upstreams": [
+    {
+      "name": "ant-design",
+      "local_path": "../ant-design"
+    },
+    {
+      "name": "pro-components",
+      "local_path": "/Users/yourname/projects/pro-components"
+    }
+  ]
+}
+```
+
+> `local_path` 支持相对路径（相对于下游仓库根目录）或绝对路径，两者均可，填自己机器上实际的位置即可。
+
+### 加入 .gitignore（初始化时自动执行）
+
+```bash
+# Skill 初始化时自动写入，无需手动操作
+echo ".sync-upstream.local.json" >> .gitignore
+```
+
+### Skill 读取合并逻辑
+
+```
+读取 .sync-upstream.json          （基础配置，必须存在）
+        ↓
+读取 .sync-upstream.local.json    （可选，不存在则跳过）
+        ↓
+按 upstream name 做浅合并：
+  local 文件中有的字段 → 覆盖主配置对应字段
+  local 文件中没有的字段 → 保留主配置原值
+        ↓
+合并结果交给后续 worker 使用
+```
+
+**合并优先级**：`.sync-upstream.local.json` > `.sync-upstream.json`
+
+**只覆盖 `local_path`，不覆盖 `last_synced_commit`**：同步进度始终以主配置为准，
+本地文件仅用于提供路径加速，不影响团队共享的同步状态。
+
+### Python 合并实现
+
+```python
+import json
+from pathlib import Path
+
+def load_config() -> dict:
+    """读取并合并主配置与本地覆盖配置"""
+    base = json.loads(Path(".sync-upstream.json").read_text())
+
+    local_path = Path(".sync-upstream.local.json")
+    if not local_path.exists():
+        return base
+
+    local = json.loads(local_path.read_text())
+
+    # 按 name 索引本地覆盖
+    local_index = {u["name"]: u for u in local.get("upstreams", [])}
+
+    for upstream in base["upstreams"]:
+        override = local_index.get(upstream["name"], {})
+        # 只允许覆盖 local_path，保护 last_synced_commit 等共享字段
+        if "local_path" in override:
+            upstream["local_path"] = override["local_path"]
+
+    return base
+```
+
+---
+
+## 建议的 Git 管理方式
+
+### 加入版本控制（推荐）
+
+```bash
+# 加入 git 追踪，让团队共享同步进度
+# 在下游仓库根目录执行
+git add .sync-upstream.json
+git commit -m "chore: update upstream sync state to $LATEST_SHORT"
+```
+
+这样团队成员 pull 之后就能看到最新的同步起点，不会重复同步。
+
+### 加入 .gitignore（不推荐，但如需本地独立管理）
+
+```bash
+echo ".sync-upstream.json" >> ".gitignore"
+```
+
+---
+
+## 用户体验提示语模板
+
+**首次初始化后**：
+
+> ✅ 已在下游仓库创建 `.sync-upstream.json`，记录了本次同步起点。
+> 下次只需说**"继续同步"**，无需再提供 commit SHA 或仓库地址。
+
+**续传同步时**：
+
+> 📖 读取到同步记录：上次同步到 `{short_sha}`（{date}，{tag}）
+> 正在从该点往后分析新的 fix/feat...
+
+**更新后**：
+
+> ✅ 同步状态已更新至 `{new_short_sha}`（{new_tag}），建议 commit 这个文件以共享团队进度。
+
+---
+
+## 常见问题
+
+**Q: commit SHA 过期了（上游 rebase/force push）怎么办？**
+
+```bash
+# 验证 commit 是否还存在
+git -C $UPSTREAM_DIR cat-file -t <last_synced_commit>
+# 若输出不是 "commit"，说明已失效，需要用户重新指定起点
+```
+
+**Q: 文件内容损坏或格式错误怎么办？**
+
+```bash
+# 验证 JSON 格式
+python3 -m json.tool "$DOWNSTREAM/.sync-upstream.json"
+# 若报错，提示用户手动修复或删除文件重新初始化
+```
+
+**Q: 多人协作时 commit 冲突怎么处理？**
+
+建议在更新 `.sync-upstream.json` 时，先 `git pull` 再更新，
+或者约定由负责同步的人统一更新该文件。

--- a/.agents/skills/cross-repo-pr-sync/references/tmp-clone.md
+++ b/.agents/skills/cross-repo-pr-sync/references/tmp-clone.md
@@ -1,0 +1,234 @@
+# 临时仓库克隆管理
+
+当用户没有上游仓库的本地副本时，Skill 自动将其克隆到系统临时目录，
+用完即删，不留缓存。支持 GitHub / GitLab / Gitea / Bitbucket / 自建 Git 任意平台。
+
+---
+
+## 工作流概览
+
+```
+读取 .sync-upstream.json
+        ↓
+local_path 存在且有效？
+   ├── Yes → 直接使用本地仓库（最快）
+   └── No  → 使用 remote_url 自动克隆
+                  ↓
+            克隆到 /tmp/sync-upstream-{name}-{timestamp}/
+                  ↓
+            执行分析（git log / diff-tree ...）
+                  ↓
+            分析完成 → rm -rf 临时目录
+```
+
+---
+
+## Step A：确定临时目录路径
+
+```bash
+UPSTREAM_NAME="ant-design"
+TMP_DIR="/tmp/sync-upstream-${UPSTREAM_NAME}-$(date +%s)"
+
+echo "临时目录: $TMP_DIR"
+```
+
+---
+
+## Step B：克隆仓库
+
+### 标准浅克隆（推荐，只需最近历史）
+
+```bash
+REMOTE_URL="https://github.com/ant-design/ant-design.git"
+LAST_COMMIT="a1b2c3d4e5f6"  # 从 .sync-upstream.json 读取
+
+# 浅克隆，深度足够覆盖上次同步到现在的提交即可
+# --filter=blob:none 只下载 commit/tree 元数据，不下载文件内容（速度极快）
+git clone \
+  --filter=blob:none \
+  --no-checkout \
+  --single-branch \
+  "$REMOTE_URL" \
+  "$TMP_DIR"
+
+echo "✅ 克隆完成: $TMP_DIR"
+```
+
+### 私有仓库（带认证）
+
+```bash
+# 方式1：URL 内嵌 token（GitLab/Gitea 常用）
+git clone "https://oauth2:${TOKEN}@gitlab.example.com/org/repo.git" "$TMP_DIR"
+
+# 方式2：使用 SSH（需要 SSH key 已配置）
+git clone "git@github.com:ant-design/ant-design.git" "$TMP_DIR"
+
+# 方式3：临时 credential helper（不污染全局 git 配置）
+GIT_ASKPASS=/dev/null GIT_TERMINAL_PROMPT=0 \
+git -c "credential.helper=store --file=/tmp/git-creds-$$" \
+clone "$REMOTE_URL" "$TMP_DIR"
+```
+
+### 验证克隆结果
+
+```bash
+if [ -d "$TMP_DIR/.git" ]; then
+    echo "✅ 克隆成功"
+    git -C "$TMP_DIR" log --oneline -3  # 展示最新3条确认正常
+else
+    echo "❌ 克隆失败，请检查 remote_url 和网络"
+    exit 1
+fi
+```
+
+---
+
+## Step C：验证 last_synced_commit 是否存在
+
+```bash
+if git -C "$TMP_DIR" cat-file -t "$LAST_COMMIT" 2>/dev/null | grep -q "commit"; then
+    echo "✅ 起始 commit 存在，开始分析"
+else
+    echo "⚠️ 起始 commit $LAST_COMMIT 不在此仓库中"
+    echo "   可能原因：浅克隆深度不够，尝试 --unshallow 或重新指定起点"
+    # 回退方案：从最近100个 commit 开始
+    FALLBACK=$(git -C "$TMP_DIR" log --oneline -100 | tail -1 | awk '{print $1}')
+    echo "   建议使用回退起点: $FALLBACK"
+fi
+```
+
+---
+
+## Step D：执行分析
+
+克隆完成后，`$TMP_DIR` 就是一个普通的 git 仓库，
+所有 `references/local-git.md` 中的命令均可直接使用，
+只需将路径替换为 `$TMP_DIR`：
+
+```bash
+# 获取 fix/feat commit 列表
+git -C "$TMP_DIR" log "${LAST_COMMIT}..HEAD" \
+  --pretty=format:"%H|%h|%s|%ad|%an" \
+  --date=short \
+  --extended-regexp \
+  --grep="^(fix|feat|feature|perf|revert)(\(.+\))?!?:|^Merge pull request #"
+
+# 获取某 commit 的改动文件
+git -C "$TMP_DIR" diff-tree --no-commit-id -r <sha> --name-only
+```
+
+---
+
+## Step E：清理临时目录（必须执行）
+
+```bash
+cleanup() {
+    if [ -d "$TMP_DIR" ]; then
+        rm -rf "$TMP_DIR"
+        echo "🧹 已清理临时目录: $TMP_DIR"
+    fi
+}
+
+# 注册退出钩子，确保异常退出时也能清理
+trap cleanup EXIT
+
+# 或者分析完成后手动调用
+cleanup
+```
+
+---
+
+## 完整封装脚本
+
+```bash
+#!/bin/bash
+# sync-clone.sh - 自动克隆、分析、清理
+
+set -e
+
+# 在下游仓库根目录执行
+UPSTREAM_NAME="${2:-}"   # 指定上游名称（多上游时用）
+
+# ── 读取配置 ──────────────────────────────────────────
+CONFIG=".sync-upstream.json"
+if [ ! -f "$CONFIG" ]; then
+    echo "❌ 未找到 .sync-upstream.json，请先初始化"
+    exit 1
+fi
+
+read_config() {
+    python3 -c "
+import json, sys
+with open('.sync-upstream.json') as f:
+    d = json.load(f)
+upstreams = d['upstreams']
+name = '$UPSTREAM_NAME'
+u = next((x for x in upstreams if not name or x['name'] == name), upstreams[0])
+print(u.get('remote_url', ''))
+print(u.get('local_path') or '')
+print(u.get('last_synced_commit', ''))
+print(u.get('name', 'upstream'))
+"
+}
+
+IFS=$'\n' read -r REMOTE_URL LOCAL_PATH LAST_COMMIT UNAME <<< "$(read_config)"
+
+# ── 选择数据源 ─────────────────────────────────────────
+if [ -n "$LOCAL_PATH" ] && [ -d "$LOCAL_PATH/.git" ]; then
+    echo "📂 使用本地仓库: $LOCAL_PATH"
+    REPO_DIR="$LOCAL_PATH"
+    CLEANUP=false
+elif [ -n "$REMOTE_URL" ]; then
+    echo "🌐 本地仓库不可用，从远程克隆: $REMOTE_URL"
+    TMP_DIR="/tmp/sync-upstream-${UNAME}-$(date +%s)"
+    git clone --filter=blob:none --no-checkout --single-branch "$REMOTE_URL" "$TMP_DIR"
+    REPO_DIR="$TMP_DIR"
+    CLEANUP=true
+    trap 'rm -rf "$TMP_DIR"; echo "🧹 已清理 $TMP_DIR"' EXIT
+else
+    echo "❌ 既无 local_path 也无 remote_url，请检查 .sync-upstream.json"
+    exit 1
+fi
+
+# ── 验证起始 commit ────────────────────────────────────
+if ! git -C "$REPO_DIR" cat-file -t "$LAST_COMMIT" 2>/dev/null | grep -q "commit"; then
+    echo "⚠️ 起始 commit $LAST_COMMIT 未找到，将从全量历史分析"
+    LAST_COMMIT=""
+fi
+
+# ── 执行分析 ───────────────────────────────────────────
+RANGE="${LAST_COMMIT:+${LAST_COMMIT}..}HEAD"
+echo "📊 分析范围: $RANGE"
+
+git -C "$REPO_DIR" log $RANGE \
+  --pretty=format:"%H|%h|%s|%ad|%an" \
+  --date=short \
+  --extended-regexp \
+  --grep="^(fix|feat|feature|perf|revert)(\(.+\))?!?:|^Merge pull request #"
+
+# ── 清理由 trap 自动处理 ───────────────────────────────
+```
+
+---
+
+## 支持的 Remote URL 格式
+
+| 平台          | URL 示例                                               |
+| ------------- | ------------------------------------------------------ |
+| GitHub        | `https://github.com/ant-design/ant-design.git`         |
+| GitHub SSH    | `git@github.com:ant-design/ant-design.git`             |
+| GitLab        | `https://gitlab.com/group/project.git`                 |
+| GitLab 自建   | `https://git.company.com/group/repo.git`               |
+| Gitea         | `https://gitea.example.com/owner/repo.git`             |
+| Bitbucket     | `https://bitbucket.org/workspace/repo.git`             |
+| 私有（token） | `https://oauth2:TOKEN@gitlab.example.com/org/repo.git` |
+
+---
+
+## 注意事项
+
+- `--filter=blob:none` 只下载元数据，**不下载文件内容**，速度快，适合只需要 commit log 的场景
+- 如果需要查看文件内容（如 `git show <sha> -- file`），git 会按需下载对应 blob，仍很快
+- 临时目录使用时间戳命名，并发执行时不会冲突
+- `trap ... EXIT` 确保脚本异常中断时也会清理，不留垃圾文件
+- 私有仓库 token 不要硬编码，通过环境变量传入：`SYNC_TOKEN=xxx bash sync-clone.sh`

--- a/.agents/skills/cross-repo-pr-sync/references/worker.md
+++ b/.agents/skills/cross-repo-pr-sync/references/worker.md
@@ -1,0 +1,316 @@
+# Worker 并行执行参考
+
+每个 worker 是一个独立子进程，负责一个上游仓库（或子包）的完整分析流程，
+与其他 worker 完全隔离，结果通过共享临时目录传递给主进程。
+
+---
+
+## Worker 生命周期
+
+```
+主进程派发任务 (worker_input.json)
+        ↓
+Worker 启动
+        ↓
+① 准备数据源（本地 or clone to tmp）
+        ↓
+② git log 过滤 fix/feat commits
+        ↓
+③ 按 upstream_path 过滤文件范围
+        ↓
+④ 提取 PR 编号，检查下游同步状态
+        ↓
+⑤ 评估优先级 & 同步难度
+        ↓
+⑥ 写出 {worker_id}.json 到 results_dir
+        ↓
+⑦ 清理临时 clone（若有）
+        ↓
+Worker 退出（exit code 0=成功, 1=失败）
+```
+
+---
+
+## Worker 输入格式
+
+主进程通过文件或 stdin 传递给每个 worker：
+
+```json
+{
+  "worker_id": "worker-C",
+  "upstream_name": "pro-components",
+  "remote_url": "https://github.com/ant-design/pro-components.git",
+  "local_path": null,
+  "upstream_path": "packages/table",
+  "downstream_path": "packages/pro-table",
+  "downstream_local_path": "./",
+  "last_synced_commit": "c3d4e5f6a7b8",
+  "max_prs": 50,
+  "results_dir": "/tmp/sync-results-1712345678"
+}
+```
+
+---
+
+## Worker 核心：按子路径过滤
+
+当 `upstream_path` 不是 `.` 时，worker 只分析改动了该路径下文件的 commits：
+
+```bash
+UPSTREAM_PATH="packages/table"
+LAST_COMMIT="c3d4e5f"
+REPO_DIR="/tmp/sync-upstream-pro-components-xxx"
+
+# 获取改动了指定子路径的 fix/feat commits
+git -C "$REPO_DIR" log "${LAST_COMMIT}..HEAD" \
+  --pretty=format:"%H|%h|%s|%ad|%an" \
+  --date=short \
+  --extended-regexp \
+  --grep="^(fix|feat|feature|perf|revert)(\(.+\))?!?:|^Merge pull request #" \
+  -- "$UPSTREAM_PATH"   # ← 关键：只看这个子路径的变更
+```
+
+`-- <path>` 参数告诉 git 只返回影响该路径的提交，天然隔离各 worker 的分析范围。
+
+当 `upstream_path` 为 `.` 时，省略 `--` 参数，分析整个仓库。
+
+---
+
+## Worker 输出格式
+
+写入 `{results_dir}/{worker_id}.json`：
+
+```json
+{
+  "worker_id": "worker-C",
+  "upstream_name": "pro-components",
+  "upstream_path": "packages/table",
+  "downstream_path": "packages/pro-table",
+  "latest_commit": "d4e5f6a7b8c9",
+  "latest_commit_short": "d4e5f6a",
+  "latest_tag": "v2.7.0",
+  "analyzed_at": "2024-03-01T12:05:33Z",
+  "duration_seconds": 18,
+  "total_commits_scanned": 142,
+  "prs": [
+    {
+      "pr_number": 8800,
+      "title": "fix(table): sort not reset on filter change",
+      "type": "fix",
+      "commit": "c3d4e5f6",
+      "commit_short": "c3d4e5f",
+      "committed_at": "2024-02-20",
+      "components": ["ProTable"],
+      "priority": "P1",
+      "difficulty": "Medium",
+      "upstream_url": "https://github.com/ant-design/pro-components/pull/8800",
+      "upstream_path": "packages/table",
+      "downstream_path": "packages/pro-table",
+      "status": "pending",
+      "skip_reason": null
+    }
+  ],
+  "skipped_prs": [
+    {
+      "pr_number": 8750,
+      "title": "fix: SSR support for table",
+      "skip_reason": "SSR 专属"
+    }
+  ],
+  "error": null
+}
+```
+
+**错误情况**（clone 失败、网络超时等）：
+
+```json
+{
+  "worker_id": "worker-C",
+  "upstream_name": "pro-components",
+  "prs": [],
+  "error": "clone failed: Repository not found or network timeout after 60s",
+  "analyzed_at": "2024-03-01T12:05:00Z"
+}
+```
+
+---
+
+## 并发调度实现（Python 参考）
+
+```python
+#!/usr/bin/env python3
+"""主进程调度器示例"""
+import json
+import subprocess
+import concurrent.futures
+import os
+import time
+from pathlib import Path
+
+def build_worker_tasks(config: dict, results_dir: str) -> list[dict]:
+    """从 .sync-upstream.json 构建 worker 任务列表。
+
+    粒度固定为：每个 packages 条目一个 worker（下游子包粒度）。
+    """
+    settings = config.get("settings", {})
+    tasks = []
+    worker_id = 0
+
+    for upstream in config["upstreams"]:
+        packages = upstream.get("packages", [{"upstream_path": ".", "downstream_path": ""}])
+
+        for pkg in packages:
+            tasks.append({
+                "worker_id": f"worker-{worker_id}",
+                "upstream_name": upstream["name"],
+                "remote_url": upstream.get("remote_url"),
+                "local_path": upstream.get("local_path"),
+                "upstream_path": pkg["upstream_path"],
+                "downstream_path": pkg["downstream_path"],
+                "last_synced_commit": upstream["last_synced_commit"],
+                "results_dir": results_dir,
+                "max_prs": settings.get("max_prs", 50),
+            })
+            worker_id += 1
+
+    return tasks
+
+
+def run_worker(task: dict) -> dict:
+    """在子进程中运行单个 worker，返回结果"""
+    worker_id = task["worker_id"]
+    result_path = Path(task["results_dir"]) / f"{worker_id}.json"
+
+    # 写入 worker 输入
+    input_path = Path(task["results_dir"]) / f"{worker_id}_input.json"
+    input_path.write_text(json.dumps(task, indent=2))
+
+    try:
+        subprocess.run(
+            ["python3", "worker.py", str(input_path)],
+            timeout=300,  # 5分钟超时
+            check=True
+        )
+        return json.loads(result_path.read_text())
+    except subprocess.TimeoutExpired:
+        return {"worker_id": worker_id, "prs": [], "error": "Worker timeout after 300s"}
+    except Exception as e:
+        return {"worker_id": worker_id, "prs": [], "error": str(e)}
+
+
+def orchestrate(config_path: str):
+    """主进程入口"""
+    # 合并主配置与本地覆盖（.sync-upstream.local.json）
+    config = load_config()  # 见 references/sync-state.md → 合并实现
+    settings = config.get("settings", {})
+
+    # 准备结果目录
+    results_dir = f"/tmp/sync-results-{int(time.time())}"
+    os.makedirs(results_dir, exist_ok=True)
+
+    # 构建任务
+    tasks = build_worker_tasks(config, results_dir)
+    max_workers = settings.get("max_workers", 4)
+
+    print(f"🚀 启动 {len(tasks)} 个 worker，最大并发 {max_workers}")
+    for t in tasks:
+        pkg_info = t.get('upstream_path', 'all packages')
+        print(f"   {t['worker_id']}: {t['upstream_name']} ({pkg_info}) → {t.get('downstream_path', '')}")
+
+    # 并发执行
+    results = []
+    with concurrent.futures.ProcessPoolExecutor(max_workers=max_workers) as executor:
+        futures = {executor.submit(run_worker, task): task for task in tasks}
+        for future in concurrent.futures.as_completed(futures):
+            task = futures[future]
+            result = future.result()
+            status = "✅" if not result.get("error") else "❌"
+            pr_count = len(result.get("prs", []))
+            print(f"   {status} {task['worker_id']} 完成，发现 {pr_count} 个待同步 PR")
+            results.append(result)
+
+    # 清理 worker 输入文件
+    for f in Path(results_dir).glob("*_input.json"):
+        f.unlink()
+
+    return results, results_dir
+```
+
+---
+
+## 进度展示（主进程实时输出）
+
+```
+🚀 启动 4 个 worker，最大并发 4
+   worker-0: ant-design (.) → packages/components
+   worker-1: ant-design-icons (packages/icons-vue) → packages/icons
+   worker-2: pro-components (packages/table) → packages/pro-table
+   worker-3: pro-components (packages/form) → packages/pro-form
+
+🌐 worker-0: 正在克隆 ant-design... (预计 30s)
+🌐 worker-1: 正在克隆 ant-design-icons... (预计 10s)
+🌐 worker-2: 正在克隆 pro-components... (预计 20s)
+📂 worker-3: 复用 worker-2 的克隆（同一上游）
+
+✅ worker-1 完成，发现 3 个待同步 PR（用时 12s）
+✅ worker-3 完成，发现 2 个待同步 PR（用时 25s）
+✅ worker-2 完成，发现 5 个待同步 PR（用时 28s）
+✅ worker-0 完成，发现 12 个待同步 PR（用时 45s）
+
+📊 全部完成，共 22 个待同步 PR，开始汇总...
+```
+
+---
+
+## 优化：同一上游跨 worker 复用 clone
+
+当多个 worker 来自**同一个上游仓库**的不同子包时，重复 clone 是浪费。
+优化策略：主进程先做 clone，生成共享的本地路径传给各 worker。
+
+```python
+def preload_shared_clones(tasks: list[dict], results_dir: str) -> list[dict]:
+    """对同一 remote_url 只 clone 一次，复用给多个 worker"""
+    cloned = {}   # remote_url → tmp_path
+
+    for task in tasks:
+        url = task.get("remote_url")
+        local = task.get("local_path")
+
+        if local and Path(local).exists():
+            continue  # 本地已有，不需要 clone
+
+        if url and url not in cloned:
+            tmp = f"/tmp/sync-upstream-{task['upstream_name']}-{int(time.time())}"
+            subprocess.run([
+                "git", "clone", "--filter=blob:none", "--no-checkout",
+                "--single-branch", url, tmp
+            ], check=True, timeout=120)
+            cloned[url] = tmp
+            print(f"🌐 克隆完成: {url} → {tmp}")
+
+        if url and url in cloned:
+            task["local_path"] = cloned[url]
+            task["_shared_clone"] = True  # 标记为共享，worker 不负责清理
+
+    return tasks, cloned
+
+
+def cleanup_shared_clones(cloned: dict):
+    """主进程统一清理共享 clone"""
+    for url, tmp in cloned.items():
+        import shutil
+        shutil.rmtree(tmp, ignore_errors=True)
+        print(f"🧹 清理: {tmp}")
+```
+
+---
+
+## 错误处理策略
+
+| 错误类型                 | 处理方式                                                                        |
+| ------------------------ | ------------------------------------------------------------------------------- |
+| 单个 worker clone 失败   | 标记该 worker `error`，其余 worker 继续，主进程汇总时单独报告                   |
+| Worker 超时（默认 300s） | 强制终止，写入 timeout 错误                                                     |
+| 所有 worker 失败         | 主进程报错退出，不更新 `last_synced_commit`                                     |
+| 部分 worker 失败         | 只更新**成功** worker 对应上游的 `last_synced_commit`，失败的保留原值待下次重试 |
+| results_dir 写入冲突     | 每个 worker 写自己的 `{worker_id}.json`，天然隔离，无冲突                       |

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ packages/docs/public/**/*.md
 packages/docs/public/llms.txt
 packages/docs/public/llms-full.txt
 packages/docs/public/llms-full-cn.txt
+.sync-upstream.local.json
+.sync-checklist-*.md

--- a/.sync-upstream.json
+++ b/.sync-upstream.json
@@ -1,0 +1,53 @@
+{
+  "version": "1",
+  "downstream": {
+    "name": "antdv-next-x",
+    "local_path": "./"
+  },
+  "settings": {
+    "parallel": true,
+    "max_workers": 4,
+    "max_prs": 50,
+    "base_branch": "main"
+  },
+  "upstreams": [
+    {
+      "name": "ant-design-x",
+      "repo": "ant-design/x",
+      "remote_url": "https://github.com/ant-design/x.git",
+      "local_path": null,
+      "packages": [
+        {
+          "upstream_path": "packages/x",
+          "downstream_path": "packages/x",
+          "description": "Ant Design X React 组件库 -> Antdv X Vue 组件库"
+        },
+        {
+          "upstream_path": "packages/x-sdk",
+          "downstream_path": "packages/x-sdk",
+          "description": "Ant Design X SDK -> Antdv X SDK"
+        },
+        {
+          "upstream_path": "packages/x-markdown",
+          "downstream_path": "packages/x-markdown",
+          "description": "Ant Design X Markdown -> Antdv X Markdown"
+        },
+        {
+          "upstream_path": "packages/x-card",
+          "downstream_path": "packages/x-card",
+          "description": "Ant Design X Card -> Antdv X Card"
+        },
+        {
+          "upstream_path": "packages/x-skill",
+          "downstream_path": "packages/x-skill",
+          "description": "Ant Design X Skill -> Antdv X Skill"
+        }
+      ],
+      "last_synced_commit": "ea0ac7ba3024811117f602541ea2483908bce0f8",
+      "last_synced_commit_short": "ea0ac7b",
+      "last_synced_at": "2026-07-01T23:27:11Z",
+      "last_synced_tag": "",
+      "sync_count": 0
+    }
+  ]
+}


### PR DESCRIPTION
[English template / 英文模板](./PULL_REQUEST_TEMPLATE.md)

### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [ ] 🐞 Bug 修复
- [ ] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [x] ❓ 其他（请说明）：Agent skill / 上游同步配置

### 🔗 相关 Issue

无。

### 💡 背景与方案

为了在当前仓库中复用 antdv-next 主仓库的跨仓库 PR 同步追踪能力，本次迁移 `cross-repo-pr-sync` agent skill，并为当前项目初始化上游同步状态。

主要方案：

- 新增 `.agents/skills/cross-repo-pr-sync`，包含技能说明、参考文档与 checklist 模板。
- 新增 `.sync-upstream.json`，配置当前仓库追踪 `ant-design/x`。
- 配置上游 / 下游包路径映射：
  - `packages/x` → `packages/x`
  - `packages/x-sdk` → `packages/x-sdk`
  - `packages/x-markdown` → `packages/x-markdown`
  - `packages/x-card` → `packages/x-card`
  - `packages/x-skill` → `packages/x-skill`
- 更新 `.gitignore`，忽略本地同步覆盖配置和自动生成的 checklist 文件。

### 📝 变更日志

| 语言    | 变更日志 |
| ------- | -------- |
| 🇺🇸 英文 | Add cross-repo PR sync agent skill and initialize upstream sync config for ant-design/x. |
| 🇨🇳 中文 | 新增跨仓库 PR 同步追踪 Agent Skill，并初始化 ant-design/x 上游同步配置。 |
