### PR TITLE
docs: fix x-provider tag usage

### DIFF
--- a/packages/docs/src/pages/components/sender/demo/slot-filling.vue
+++ b/packages/docs/src/pages/components/sender/demo/slot-filling.vue
@@ -282,7 +282,7 @@ const xProviderTheme = {
     </a-flex>
 
     <!-- Sender 词槽填空示例 -->
-    <ax-x-provider :theme="xProviderTheme">
+    <ax-provider :theme="xProviderTheme">
       <ax-sender
         ref="senderRef"
         :skill="skill"
@@ -293,7 +293,7 @@ const xProviderTheme = {
         :on-submit="onSubmit"
         :on-change="onChange"
       />
-    </ax-x-provider>
+    </ax-provider>
 
     <a-flex vertical gap="middle">
       <div>{{ skillValue ? `skill:${skillValue}` : null }}</div>

--- a/packages/docs/src/pages/components/x-provider/demo/direction.vue
+++ b/packages/docs/src/pages/components/x-provider/demo/direction.vue
@@ -71,7 +71,7 @@ const actionItems: ActionsProps["items"] = [
   </a-flex>
 
   <a-card>
-    <ax-x-provider :direction="direction">
+    <ax-provider :direction="direction">
       <a-flex :gap="12" style="height: 440px">
         <ax-conversations
           :style="{ width: '220px' }"
@@ -104,6 +104,6 @@ const actionItems: ActionsProps["items"] = [
           </ax-actions>
         </a-flex>
       </a-flex>
-    </ax-x-provider>
+    </ax-provider>
   </a-card>
 </template>

--- a/packages/docs/src/pages/components/x-provider/demo/locale.vue
+++ b/packages/docs/src/pages/components/x-provider/demo/locale.vue
@@ -110,7 +110,7 @@ const actionItems: ActionsProps["items"] = [
     </a-radio-group>
   </a-flex>
 
-  <ax-x-provider :locale="locale">
+  <ax-provider :locale="locale">
     <a-flex :gap="12" vertical>
       <a-card>
         <ax-conversations
@@ -141,5 +141,5 @@ const actionItems: ActionsProps["items"] = [
         </ax-actions>
       </a-card>
     </a-flex>
-  </ax-x-provider>
+  </ax-provider>
 </template>

--- a/packages/docs/src/pages/components/x-provider/demo/shortcut-keys.vue
+++ b/packages/docs/src/pages/components/x-provider/demo/shortcut-keys.vue
@@ -53,7 +53,7 @@ const items: ConversationsProps["items"] = [
   </a-flex>
 
   <a-card>
-    <ax-x-provider :conversations="providerConversationsConfig">
+    <ax-provider :conversations="providerConversationsConfig">
       <ax-conversations
         :style="{ width: '220px' }"
         default-active-key="write"
@@ -66,6 +66,6 @@ const items: ConversationsProps["items"] = [
           <FileSearchOutlined v-else-if="item.key === 'deepSearch'" />
         </template>
       </ax-conversations>
-    </ax-x-provider>
+    </ax-provider>
   </a-card>
 </template>

--- a/packages/docs/src/pages/components/x-provider/demo/theme.vue
+++ b/packages/docs/src/pages/components/x-provider/demo/theme.vue
@@ -70,7 +70,7 @@ function onColorChange(value: { toHexString?: () => string } | string) {
   </a-flex>
 
   <a-card>
-    <ax-x-provider :theme="theme">
+    <ax-provider :theme="theme">
       <a-flex :gap="12" vertical>
         <ax-conversations
           :style="{ width: '220px' }"
@@ -103,6 +103,6 @@ function onColorChange(value: { toHexString?: () => string } | string) {
           </ax-actions>
         </a-card>
       </a-flex>
-    </ax-x-provider>
+    </ax-provider>
   </a-card>
 </template>


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None.

### 💡 Background and Solution

Docs demos used `<ax-x-provider>`, but the registered component tag is `<ax-provider>`. This updates the affected docs examples to use `<ax-provider>` while keeping props and demo behavior unchanged.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix XProvider docs demos to use the correct `<ax-provider>` tag. |
| 🇨🇳 Chinese | 修复 XProvider 文档示例，使用正确的 `<ax-provider>` 标签。 |