### PR TITLE
docs: 为 demo 补充 useTemplateRef 的显式 vue 引用

### DIFF
--- a/packages/docs/src/pages/components/bubble/demo/list-scroll.vue
+++ b/packages/docs/src/pages/components/bubble/demo/list-scroll.vue
@@ -7,7 +7,7 @@ import {
   RedoOutlined,
   UserOutlined,
 } from "@antdv-next/icons";
-import { ref } from "vue";
+import { ref, useTemplateRef } from "vue";
 
 let seed = 0;
 const nextKey = () => `bubble_${seed++}`;

--- a/packages/docs/src/pages/components/sender/demo/agent.vue
+++ b/packages/docs/src/pages/components/sender/demo/agent.vue
@@ -14,7 +14,7 @@ import {
   SearchOutlined,
 } from "@antdv-next/icons";
 import { App } from "antdv-next";
-import { h, ref, watch } from "vue";
+import { h, ref, useTemplateRef, watch } from "vue";
 const { message } = App.useApp();
 
 interface AgentInfoItem {

--- a/packages/docs/src/pages/components/sender/demo/ref-action.vue
+++ b/packages/docs/src/pages/components/sender/demo/ref-action.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { useTemplateRef } from "vue";
+
 const senderRef = useTemplateRef("senderRef");
 </script>
 

--- a/packages/docs/src/pages/components/sender/demo/slot-with-suggestion.vue
+++ b/packages/docs/src/pages/components/sender/demo/slot-with-suggestion.vue
@@ -15,7 +15,7 @@ import {
   SearchOutlined,
 } from "@antdv-next/icons";
 import { App } from "antdv-next";
-import { h, onBeforeUnmount, ref, watch } from "vue";
+import { h, onBeforeUnmount, ref, useTemplateRef, watch } from "vue";
 
 const { message } = App.useApp();
 


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [ ] 🐞 Bug 修复
- [ ] 📝 站点 / 文档改进
- [x] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

> 无相关 Issue。

### 💡 背景与方案

> 部分 demo 使用了 \`useTemplateRef\` 但未显式从 \`vue\` 引用，仅依赖 \`unplugin-auto-import\` 的自动导入。虽然运行正常，但缺少显式引用会降低代码可读性与可维护性，IDE 中也无法直接跳转。
>
> 本次为以下 4 个 demo 补充了显式的 \`useTemplateRef\` 引用：
> - \`components/sender/demo/agent.vue\`
> - \`components/sender/demo/ref-action.vue\`（原本无 vue import，新增一行）
> - \`components/sender/demo/slot-with-suggestion.vue\`
> - \`components/bubble/demo/list-scroll.vue\`
>
> import 顺序遵循各文件已有的字母序惯例，不涉及逻辑变更。

### 📝 变更日志

| 语言    | 变更日志 |
| ------- | -------- |
| 🇺🇸 英文 | Add explicit `useTemplateRef` import from `vue` in demos that relied solely on auto-import. |
| 🇨🇳 中文 | 为仅依赖自动导入的 demo 补充 `useTemplateRef` 的显式 `vue` 引用。 |