### PR TITLE
fix(x): declare tsx as devDependency to fix CI

### DIFF
--- a/packages/x/package.json
+++ b/packages/x/package.json
@@ -71,6 +71,9 @@
     "shiki": "catalog:docs",
     "vue": "catalog:prod"
   },
+  "devDependencies": {
+    "tsx": "catalog:dev"
+  },
   "peerDependencies": {
     "antdv-next": ">=1.0.0",
     "vue": ">=3.5.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ catalogs:
     tinyglobby:
       specifier: ^0.2.15
       version: 0.2.15
+    tsx:
+      specifier: ^4.19.1
+      version: 4.21.0
     typedoc:
       specifier: ^0.28.19
       version: 0.28.19
@@ -515,6 +518,10 @@ importers:
       vue:
         specifier: catalog:prod
         version: 3.5.31(typescript@5.9.3)
+    devDependencies:
+      tsx:
+        specifier: catalog:dev
+        version: 4.21.0
 
   packages/x-card:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,6 +22,7 @@ catalogs:
     npm-run-all2: ^8.0.4
     postcss-selector-parser: ^7.1.0
     tinyglobby: ^0.2.15
+    tsx: ^4.19.1
     typescript: ~5.9.3
     unplugin-auto-import: ^21.0.0
     unplugin-dts: 1.0.0-beta.6


### PR DESCRIPTION
## Problem
CI fails with `command not found: tsx` when building docs:

```
> @antdv-next/x@1.1.2 build:token-meta
> tsx ./scripts/token/generate-token-meta.ts
command not found: tsx
ELIFECYCLE  Command failed with exit code 127.
```

Triggered by `deploy.yml` → `pnpm docs:build` → `vp run --filter @antdv-next/x build:token` → `run-p build:token-meta build:token-statistic` → `tsx ...`.

## Root cause
PR #116 added `build:token-meta` / `build:token-statistic` scripts to `packages/x` that invoke `tsx`, but **`tsx` was never declared as a dependency of `packages/x`**.

- `tsx` is only a devDependency of `packages/x-skill`.
- **Locally** it worked by accident: the developer's *global* pnpm config sets `node-linker=hoisted`, which flattens `x-skill`'s `tsx` into the root `node_modules/.bin`, so `packages/x` scripts could reach it.
- **CI** uses the default `node-linker=isolated`, where `tsx` (only a dep of `x-skill`) is neither in the root `.bin` nor in `packages/x`'s scope → `command not found: tsx`.
- Note `run-p` *did* run in CI (visible in the error) because `npm-run-all2` is a **root** devDep — confirming the failure is specifically the undeclared `tsx`.

## Fix
Declare `tsx` as a direct devDependency of `packages/x`, using the repo's `catalog:` convention:

- `pnpm-workspace.yaml` — add `tsx: ^4.19.1` to the `dev` catalog
- `packages/x/package.json` — add `devDependencies: { "tsx": "catalog:dev" }`
- `pnpm-lock.yaml` — updated via `vp install`

Under both linkers, pnpm now guarantees `tsx` is resolvable from `packages/x`'s scripts.

## Verification
Beyond reasoning, reproduced CI's exact environment and confirmed the fix:

```bash
pnpm install --node-linker=isolated --frozen-lockfile   # mimic CI
ls packages/x/node_modules/.bin/tsx                     # ✓ now exists
vp run --filter @antdv-next/x build:token               # ✓ succeeds
```

This also exercises the `typedoc` / `vite` imports in the token scripts — they resolve via the root `node_modules` upward lookup (both are root devDeps), so no further changes were needed.

Also scanned every workspace package's scripts for other "used but undeclared" binaries — no other issues found.

## Files changed
- `packages/x/package.json` — `+devDependencies.tsx`
- `pnpm-workspace.yaml` — `dev` catalog `+tsx`
- `pnpm-lock.yaml` — lockfile sync (7 lines)

## Note (not addressed here)
The project relies on a *global* `node-linker=hoisted` setting that isn't declared in the repo, which is why this slipped through locally. Keeping the CI (isolated) environment as the source of truth (i.e. declaring what you use) is the safer direction; alternatively a root `.npmrc` with `node-linker=hoisted` would align local/CI but loses pnpm's strict isolation.
