### PR TITLE
fix(x): build dist before collecting token statistics

### DIFF
--- a/packages/x/package.json
+++ b/packages/x/package.json
@@ -55,7 +55,7 @@
     "build:esm": "vp build --config vite.esm.config.ts",
     "build:umd": "vp build --config vite.umd.config.ts",
     "build:token-meta": "tsx ./scripts/token/generate-token-meta.ts",
-    "build:token-statistic": "tsx ./scripts/token/collect-token-statistic.ts",
+    "build:token-statistic": "vp run build:comp && tsx ./scripts/token/collect-token-statistic.ts",
     "build:token": "run-p build:token-meta build:token-statistic",
     "build": "vp run build:comp && vp run build:esm && vp run build:umd"
   },


### PR DESCRIPTION
## Problem
After #117, `tsx` is available in CI and the token scripts now execute, but the next latent failure appears:

```text
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/home/runner/work/x/x/packages/x/dist/index.js'
imported from /home/runner/work/x/x/packages/x/scripts/token/collect-token-statistic.ts
```

`collect-token-statistic.ts` imports `../../dist/index.js`, so it requires `packages/x/dist/index.js` to exist before token statistics are collected. In a clean CI environment, `dist/` is gitignored and has not been built yet.

This was masked locally when `packages/x/dist` already existed from a previous build.

## Fix
Make `build:token-statistic` build the component distribution before running the statistic collector:

```json
"build:token-statistic": "vp run build:comp && tsx ./scripts/token/collect-token-statistic.ts"
```

This keeps the requirement close to the script that needs it, so direct invocations of `build:token-statistic` and higher-level `build:token` both work from a clean checkout.

## Verification
Verified from a clean `dist/` state:

```bash
rm -rf packages/x/dist
vp run --filter @antdv-next/x build:token-statistic
```

Also verified the full docs deploy path from a clean state:

```bash
rm -rf packages/x/dist packages/docs/dist packages/docs/src/assets/token.json packages/docs/src/assets/token-meta.json
vp run --filter @antdv-next/docs build
```

Both commands pass locally. The full docs build exercises the same path as `deploy.yml` (`pnpm docs:build` -> `@antdv-next/docs build` -> `@antdv-next/x build:token`).
