### PR TITLE
fix(docs): declare fast-color dependency

### DIFF
--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -12,6 +12,7 @@
     "build:llm:semantic": "node ./scripts/llm/generate-llms-semantic.mjs"
   },
   "dependencies": {
+    "@ant-design/fast-color": "catalog:prod",
     "@antdv-next/icons": "catalog:prod",
     "@antdv-next/x-card": "workspace:*",
     "@antdv-next/x-markdown": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -360,6 +360,9 @@ importers:
 
   packages/docs:
     dependencies:
+      '@ant-design/fast-color':
+        specifier: catalog:prod
+        version: 3.0.1
       '@antdv-next/icons':
         specifier: catalog:prod
         version: 1.0.6(vue@3.5.31(typescript@5.9.3))


### PR DESCRIPTION
## Problem
After #117 and #118, the docs build reaches the Vite/Rolldown phase, but CI fails under the default `node-linker=isolated` layout:

```text
Rolldown failed to resolve import "@ant-design/fast-color"
from "packages/docs/src/components/color-chunk/index.vue"
```

`packages/docs/src/components/color-chunk/index.vue` imports `@ant-design/fast-color` directly, but `packages/docs` did not declare it. Locally this was masked by the developer's hoisted node_modules layout because `@ant-design/fast-color` is a dependency of `packages/x`.

In CI isolated mode, docs cannot rely on dependencies declared by sibling packages.

## Fix
Declare `@ant-design/fast-color` in `packages/docs` dependencies using the existing prod catalog:

```json
"@ant-design/fast-color": "catalog:prod"
```

## Verification
I scanned `packages/docs/src` bare imports for modules not declared by either `packages/docs` or the root workspace. The only real missing package was `@ant-design/fast-color`; `uno.css` is the UnoCSS virtual entry.

Then verified with CI-equivalent isolated install and a clean docs build:

```bash
pnpm install --node-linker=isolated --frozen-lockfile
rm -rf packages/x/dist packages/docs/dist packages/docs/src/assets/token.json packages/docs/src/assets/token-meta.json
vp run --filter @antdv-next/docs build
```

The build passes locally under isolated mode.
