### PR TITLE
feat(docs): open external links (e.g. Customize Theme) in a new tab

### DIFF
--- a/packages/docs/plugins/markdown/markdown.ts
+++ b/packages/docs/plugins/markdown/markdown.ts
@@ -27,6 +27,7 @@ import { containerPlugin } from "./plugins/container";
 import { demoPlugin } from "./plugins/demo";
 import { gitHubAlertsPlugin } from "./plugins/github-alerts";
 import { imagePlugin } from "./plugins/image";
+import { linkPlugin } from "./plugins/link";
 import { preWrapperPlugin } from "./plugins/pre-wrapper";
 import { stackblitzPlugin } from "./plugins/stackblitz";
 import { tablePlugin } from "./plugins/table";
@@ -81,6 +82,7 @@ export function loadBaseMd(md: MarkdownItAsync) {
   md.use(titlePlugin);
   md.use(emoji);
   md.use(attrsPlugin);
+  md.use(linkPlugin);
   md.use(containerPlugin);
   md.use(gitHubAlertsPlugin);
 }

--- a/packages/docs/plugins/markdown/plugins/link.ts
+++ b/packages/docs/plugins/markdown/plugins/link.ts
@@ -1,0 +1,31 @@
+import type MarkdownIt from "markdown-it";
+
+import { EXTERNAL_URL_RE } from "../shared";
+
+/**
+ * 让 markdown 中的外部链接在新标签页打开。
+ *
+ * 仅对带协议（http(s)://、mailto: 等）的外部链接生效，
+ * 站内相对链接保持默认行为，避免影响路由内跳转与锚点导航。
+ *
+ * 已通过 `markdown-it-attrs` 等方式显式声明的 `target` / `rel`
+ * 不会被覆盖，保留作者对单个链接的控制权。
+ */
+export function linkPlugin(md: MarkdownIt) {
+  const defaultLinkRender =
+    md.renderer.rules.link_open ||
+    ((tokens, idx, options, _env, self) =>
+      self.renderToken(tokens, idx, options));
+
+  md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
+    const token = tokens[idx]!;
+    const href = token.attrGet("href");
+
+    if (href && EXTERNAL_URL_RE.test(href)) {
+      if (!token.attrGet("target")) token.attrSet("target", "_blank");
+      if (!token.attrGet("rel")) token.attrSet("rel", "noopener noreferrer");
+    }
+
+    return defaultLinkRender(tokens, idx, options, env, self);
+  };
+}


### PR DESCRIPTION
<!-- First of all, thank you for your contribution! 😄 -->

### 🤔 This is a ...

- [x] 📝 Site / documentation improvement

### 🔗 Related Issues

> N/A. Improvement noticed while browsing the docs: clicking the
> "定制主题 / Customize Theme" link at the bottom of each component
> page navigates the current tab away from the docs site.

### 💡 Background and Solution

Each component doc page ends with a "定制主题 / Customize Theme" link
pointing to `https://www.antdv-next.com/docs/vue/customize-theme(-cn)`.
Because these are rendered as plain `<a href>`, clicking them **replaces
the current tab**, forcing visitors to leave the docs site and lose
their reading context.

**Solution:** add a small markdown-it `linkPlugin` that sets
`target="_blank" rel="noopener noreferrer"` on every external link
(one with a protocol such as `https:`, `mailto:`) during render, so
they open in a new tab.

- Site-relative links (e.g. `[Common props](/docs/vue/common-props)`)
  and anchor links (e.g. `#design-token`) keep their default behavior —
  no impact on in-app routing or TOC navigation.
- Explicitly declared `target` / `rel` attributes (via `markdown-it-attrs`,
  e.g. `{target=_self}`) are preserved and not overwritten.

Render verification (markdown-it-async + attrs + link plugin):

```
IN:  查看 [定制主题](https://www.antdv-next.com/docs/vue/customize-theme-cn) 了解。
OUT: 查看 <a href="..." target="_blank" rel="noopener noreferrer">定制主题</a> 了解.

IN:  [Common props](/docs/vue/common-props)
OUT: <a href="/docs/vue/common-props">Common props</a>

IN:  [x](https://example.com){target=_self}
OUT: <a href="https://example.com" target="_self" rel="noopener noreferrer">x</a>
```

### 📝 Change Log

| Language   | Changelog                                                                       |
| ---------- | ------------------------------------------------------------------------------- |
| 🇺🇸 English | External links in docs (e.g. "Customize Theme") now open in a new browser tab.  |
| 🇨🇳 Chinese | 文档中的外部链接（如"定制主题"）现会在新标签页中打开，不再离开当前文档站点。      |