### PR TITLE
fix(docs): 修复主题变量默认值为 rgba 时颜色标签换行问题

### DIFF
--- a/packages/docs/src/components/color-chunk/index.vue
+++ b/packages/docs/src/components/color-chunk/index.vue
@@ -17,6 +17,9 @@ const dotColor = computed(() => new FastColor(props.value).toHexString());
 
 const styles = computed(() => ({
   codeSpan: {
+    display: "inline-flex",
+    alignItems: "center",
+    whiteSpace: "nowrap",
     padding: "0.2em 0.4em",
     fontSize: "0.9em",
     background: token.value.colorFillQuaternary,


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [x] 🐞 Bug 修复
- [x] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

> 暂无对应 Issue，为文档站点 Token 表格的展示问题。

### 💡 背景与方案

在「主题变量 / 全局 Token」表格的「默认值」列中，颜色 token 会通过 `ColorChunk` 组件渲染为一个带色块圆点 + 颜色值的标签。许多全局颜色 token 的默认值是较长的 `rgba(...)` 字符串（如 `colorText` = `rgba(0, 0, 0, 0.88)`），而标签外层 `<span>` 为 `inline` 元素、色块为 `inline-block`。

当值较长时内容发生换行，由于 `inline` 元素的 `background` / `border` / `padding` 是按行框分别应用的，标签会被拆成两段，呈现「断裂 / 换行」的视觉效果；短十六进制值（如 `#1677ff`）则不受影响。

**方案**：在 `packages/docs/src/components/color-chunk/index.vue` 的 `codeSpan` 样式中新增：

- `display: inline-flex` —— 标签成为原子化的 flex 容器，不再跨行拆分
- `align-items: center` —— 色块圆点与文本垂直居中对齐
- `white-space: nowrap` —— 保证圆点与颜色值始终在同一行

改动仅涉及 `ColorChunk` 一个组件，组件 Token 表与全局 Token 表的「默认值」列均会受益。

### 📝 变更日志

| 语言    | 变更日志 |
| ------- | -------- |
| 🇺🇸 英文 | Fix color token tag wrapping when the default value is an `rgba(...)` string in the theme variable / global token table. |
| 🇨🇳 中文 | 修复主题变量 / 全局 Token 表格中默认值为 `rgba(...)` 时颜色标签换行断裂的问题。 |