### PR TITLE
chore(deps): bump @v-c/util to 1.0.21

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,8 +163,8 @@ catalogs:
       specifier: ^1.0.6
       version: 1.0.6
     '@v-c/util':
-      specifier: ^1.0.20
-      version: 1.0.20
+      specifier: ^1.0.21
+      version: 1.0.21
     '@vueuse/core':
       specifier: ^14.2.1
       version: 14.2.1
@@ -245,7 +245,7 @@ importers:
         version: 4.0.2
       '@v-c/util':
         specifier: catalog:prod
-        version: 1.0.20(vue@3.5.31(typescript@5.9.3))
+        version: 1.0.21(vue@3.5.31(typescript@5.9.3))
       '@vitejs/plugin-vue':
         specifier: catalog:dev
         version: 6.0.5(@voidzero-dev/vite-plus-core@0.1.14(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(vue@3.5.31(typescript@5.9.3))
@@ -502,7 +502,7 @@ importers:
         version: 1.0.6(vue@3.5.31(typescript@5.9.3))
       '@v-c/util':
         specifier: catalog:prod
-        version: 1.0.20(vue@3.5.31(typescript@5.9.3))
+        version: 1.0.21(vue@3.5.31(typescript@5.9.3))
       '@vueuse/core':
         specifier: catalog:prod
         version: 14.2.1(vue@3.5.31(typescript@5.9.3))
@@ -2182,8 +2182,8 @@ packages:
     peerDependencies:
       vue: ^3.0.0
 
-  '@v-c/util@1.0.20':
-    resolution: {integrity: sha512-IFsS520e1WaJXnZn6l0a+/lxa4CogOyg2heBBcAQSreIqIbPUzwSPes1123ScHCqAoBe8yAtZk3zHf5OVFBAGQ==}
+  '@v-c/util@1.0.21':
+    resolution: {integrity: sha512-OoWD9SHR9E4jHiP4YzQbYlpp4r9cCvR5QXEtLb8iO4xIc86/noR5f98m307kicULdte3MR4uK+O2sEoo5I2f0g==}
     peerDependencies:
       vue: ^3.0.0
 
@@ -4467,7 +4467,7 @@ snapshots:
     dependencies:
       '@emotion/hash': 0.8.0
       '@emotion/unitless': 0.7.5
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       csstype: 3.2.3
       stylis: 4.3.6
       vue: 3.5.31(typescript@5.9.3)
@@ -4476,7 +4476,7 @@ snapshots:
     dependencies:
       '@ant-design/colors': 7.2.1
       '@ant-design/icons-svg': 4.4.2
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@antdv-next/unocss@1.0.2(unocss@66.6.7(@voidzero-dev/vite-plus-core@0.1.14(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0)))':
@@ -5717,59 +5717,59 @@ snapshots:
     dependencies:
       '@v-c/select': 1.0.20(vue@3.5.31(typescript@5.9.3))
       '@v-c/tree': 1.0.5(vue@3.5.31(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/checkbox@1.0.1(vue@3.5.31(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/collapse@1.0.0(vue@3.5.31(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/color-picker@1.0.6(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       '@ant-design/fast-color': 3.0.1
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/dialog@1.0.3(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       '@v-c/portal': 1.0.8(vue@3.5.31(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/drawer@1.0.4(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       '@v-c/portal': 1.0.8(vue@3.5.31(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/dropdown@1.0.2(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       '@v-c/trigger': 1.0.14(vue@3.5.31(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/image@1.0.10(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       '@v-c/portal': 1.0.8(vue@3.5.31(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/input-number@1.0.5(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       '@v-c/input': 1.0.3(vue@3.5.31(typescript@5.9.3))
       '@v-c/mini-decimal': 1.0.1
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/input@1.0.3(vue@3.5.31(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/mentions@1.0.0(vue@3.5.31(typescript@5.9.3))':
@@ -5778,14 +5778,14 @@ snapshots:
       '@v-c/menu': 1.0.13(vue@3.5.31(typescript@5.9.3))
       '@v-c/textarea': 1.0.4(vue@3.5.31(typescript@5.9.3))
       '@v-c/trigger': 1.0.14(vue@3.5.31(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/menu@1.0.13(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       '@v-c/overflow': 1.0.5(vue@3.5.31(typescript@5.9.3))
       '@v-c/trigger': 1.0.14(vue@3.5.31(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/mini-decimal@1.0.1': {}
@@ -5793,23 +5793,23 @@ snapshots:
   '@v-c/mutate-observer@1.0.1(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       '@v-c/resize-observer': 1.0.8(vue@3.5.31(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/notification@1.0.0(vue@3.5.31(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/overflow@1.0.5(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       '@v-c/resize-observer': 1.0.8(vue@3.5.31(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/pagination@1.0.0(vue@3.5.31(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/picker@1.0.4(dayjs@1.11.20)(vue@3.5.31(typescript@5.9.3))':
@@ -5817,34 +5817,34 @@ snapshots:
       '@v-c/overflow': 1.0.5(vue@3.5.31(typescript@5.9.3))
       '@v-c/resize-observer': 1.0.8(vue@3.5.31(typescript@5.9.3))
       '@v-c/trigger': 1.0.14(vue@3.5.31(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
     optionalDependencies:
       dayjs: 1.11.20
 
   '@v-c/portal@1.0.8(vue@3.5.31(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/progress@1.0.0(vue@3.5.31(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/qrcode@1.0.0(vue@3.5.31(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/rate@1.0.1(vue@3.5.31(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/resize-observer@1.0.8(vue@3.5.31(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       resize-observer-polyfill: 1.5.1
       vue: 3.5.31(typescript@5.9.3)
 
@@ -5864,42 +5864,42 @@ snapshots:
 
   '@v-c/segmented@1.0.2(vue@3.5.31(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/select@1.0.20(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       '@v-c/overflow': 1.0.5(vue@3.5.31(typescript@5.9.3))
       '@v-c/trigger': 1.0.14(vue@3.5.31(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       '@v-c/virtual-list': 1.0.7(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/slick@1.0.2(vue@3.5.31(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       es-toolkit: 1.45.1
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/slider@1.0.10(vue@3.5.31(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/steps@1.0.0(vue@3.5.31(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/switch@1.0.0(vue@3.5.31(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/table@1.0.5(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       '@v-c/resize-observer': 1.0.8(vue@3.5.31(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       '@v-c/virtual-list': 1.0.7(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
@@ -5909,39 +5909,39 @@ snapshots:
       '@v-c/menu': 1.0.13(vue@3.5.31(typescript@5.9.3))
       '@v-c/overflow': 1.0.5(vue@3.5.31(typescript@5.9.3))
       '@v-c/resize-observer': 1.0.8(vue@3.5.31(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/textarea@1.0.4(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       '@v-c/input': 1.0.3(vue@3.5.31(typescript@5.9.3))
       '@v-c/resize-observer': 1.0.8(vue@3.5.31(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/tooltip@1.0.3(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       '@v-c/trigger': 1.0.14(vue@3.5.31(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/tour@1.0.3(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       '@v-c/portal': 1.0.8(vue@3.5.31(typescript@5.9.3))
       '@v-c/trigger': 1.0.14(vue@3.5.31(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/tree-select@1.0.3(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       '@v-c/select': 1.0.20(vue@3.5.31(typescript@5.9.3))
       '@v-c/tree': 1.0.5(vue@3.5.31(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/tree@1.0.5(vue@3.5.31(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       '@v-c/virtual-list': 1.0.7(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
@@ -5949,22 +5949,22 @@ snapshots:
     dependencies:
       '@v-c/portal': 1.0.8(vue@3.5.31(typescript@5.9.3))
       '@v-c/resize-observer': 1.0.8(vue@3.5.31(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/upload@1.0.0(vue@3.5.31(typescript@5.9.3))':
     dependencies:
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
-  '@v-c/util@1.0.20(vue@3.5.31(typescript@5.9.3))':
+  '@v-c/util@1.0.21(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       vue: 3.5.31(typescript@5.9.3)
 
   '@v-c/virtual-list@1.0.7(vue@3.5.31(typescript@5.9.3))':
     dependencies:
       '@v-c/resize-observer': 1.0.8(vue@3.5.31(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       vue: 3.5.31(typescript@5.9.3)
 
   '@vitejs/plugin-vue-jsx@5.1.5(@voidzero-dev/vite-plus-core@0.1.14(@types/node@24.12.0)(esbuild@0.27.4)(jiti@2.6.1)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.9.0))(vue@3.5.31(typescript@5.9.3))':
@@ -6365,7 +6365,7 @@ snapshots:
       '@v-c/tree-select': 1.0.3(vue@3.5.31(typescript@5.9.3))
       '@v-c/trigger': 1.0.14(vue@3.5.31(typescript@5.9.3))
       '@v-c/upload': 1.0.0(vue@3.5.31(typescript@5.9.3))
-      '@v-c/util': 1.0.20(vue@3.5.31(typescript@5.9.3))
+      '@v-c/util': 1.0.21(vue@3.5.31(typescript@5.9.3))
       '@v-c/virtual-list': 1.0.7(vue@3.5.31(typescript@5.9.3))
       '@vueuse/core': 14.2.1(vue@3.5.31(typescript@5.9.3))
       dayjs: 1.11.20

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -62,7 +62,7 @@ catalogs:
     "@ant-design/fast-color": ^3.0.1
     "@antdv-next/cssinjs": ^1.0.4
     "@antdv-next/icons": ^1.0.6
-    "@v-c/util": ^1.0.20
+    "@v-c/util": ^1.0.21
     "@vueuse/core": ^14.2.1
     antdv-next: ^1.2.0
     dayjs: ^1.11.19


### PR DESCRIPTION
### 🤔 This is a ...

- [x] ⏩ Workflow
- [x] ❓ Other (dependency upgrade)

### 🔗 Related Issues

> - Ref: antdv-next/vue-components@2ddec4cc (`fix(util): don't guess placeholder sibling when an element contract is exposed`)
> - Ref: antdv-next/antdv-next#623

### 💡 Background and Solution

Bump `@v-c/util` from `^1.0.20` to `^1.0.21` (latest) in the `prod` catalog. Both consumers (`./package.json` and `packages/x/package.json`) reference it via `catalog:prod`, so a single catalog bump covers them.

Upstream 1.0.21 fixes a `createElementRef` / `resolveToElement` issue: it used to fall back to a comment/text `$el`'s `nextElementSibling` for fragment-rooted components, but it also did so when a component exposes an element contract (`nativeElement` / `el` / `getElement`) that hasn't been fulfilled yet (e.g. a trigger's `Popup` while its portal content is still hidden by `getPopupContainer` delay). Under vue `>=3.5.39` function refs are no longer re-invoked reactively, so the stolen element stuck as the trigger's `popupEle` — e.g. a select dropdown inside `Space.Compact` aligned against the adjacent input on first open. 1.0.21 skips the sibling guess when an element contract exists so the ref retries and `onPrepare` seeds the real popup element.

The `x` package consumes `createElementRef` (`BubbleList`), `KeyCode` and `classNames` from `@v-c/util`, so this bump keeps those code paths aligned with the latest upstream behavior. No API signature changes.

Verification:
- `vp run --filter @antdv-next/x type-check` ✅
- `vp test packages/x/components/_utils/__tests__/use-shortcut-keys.test.ts` ✅ (75 passed)
- `vp run --filter @antdv-next/x build` ✅

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Upgrade `@v-c/util` to `1.0.21`. |
| 🇨🇳 中文 | 升级 `@v-c/util` 至 `1.0.21`。 |
