### PR TITLE
docs: 在 use-with 指南中补充 auto-import-resolver-x 章节

### DIFF
--- a/packages/docs/src/pages/docs/use-with-rsbuild.en-US.md
+++ b/packages/docs/src/pages/docs/use-with-rsbuild.en-US.md
@@ -61,6 +61,73 @@ import { Bubble, XProvider } from "@antdv-next/x";
 
 You should now see the `@antdv-next/x` bubble component on the page. You can continue building your application with other components. For the rest of the development workflow, refer to the [Rsbuild documentation](https://rsbuild.dev/).
 
+## On-demand Auto Import
+
+If you prefer components to be imported on demand without manual `import` statements, use [`@antdv-next/auto-import-resolver-x`](https://github.com/antdv-next/auto-import-resolver-x) together with [`unplugin-vue-components`](https://github.com/unplugin/unplugin-vue-components).
+
+Install the dependencies:
+
+<InstallDependencies npm='$ npm install @antdv-next/auto-import-resolver-x unplugin-vue-components -D' yarn='$ yarn add @antdv-next/auto-import-resolver-x unplugin-vue-components -D' pnpm='$ pnpm install @antdv-next/auto-import-resolver-x unplugin-vue-components -D' bun='$ bun add @antdv-next/auto-import-resolver-x unplugin-vue-components -D'></InstallDependencies>
+
+Configure the resolver through `tools.rspack` in `rsbuild.config.ts`:
+
+```ts
+// rsbuild.config.ts
+import { defineConfig } from "@rsbuild/core";
+import Components from "unplugin-vue-components/rspack";
+import { AntdvNextXResolver } from "@antdv-next/auto-import-resolver-x";
+
+export default defineConfig({
+  tools: {
+    rspack: {
+      plugins: [
+        Components({
+          resolvers: [AntdvNextXResolver()],
+        }),
+      ],
+    },
+  },
+});
+```
+
+Now you can use `Ax`-prefixed components directly in templates without importing them. `src/App.vue` can be simplified to:
+
+```vue
+<template>
+  <AxProvider>
+    <AxBubble content="Hello world!" />
+  </AxProvider>
+</template>
+```
+
+> Note: With auto import, use the `Ax`-prefixed global names in templates (e.g. `AxBubble`, `AxProvider`). The resolver maps them to the corresponding exports of `@antdv-next/x` (`Bubble`, `XProvider`).
+
+Since `@antdv-next/x` is built on top of `antdv-next`, you can register both resolvers together if you also use `antdv-next` components and `@antdv-next/icons` icons:
+
+```ts
+import { AntdvNextResolver } from "@antdv-next/auto-import-resolver";
+import { AntdvNextXResolver } from "@antdv-next/auto-import-resolver-x";
+import Components from "unplugin-vue-components/rspack";
+import { defineConfig } from "@rsbuild/core";
+
+export default defineConfig({
+  tools: {
+    rspack: {
+      plugins: [
+        Components({
+          resolvers: [
+            AntdvNextResolver({ resolveIcons: true }),
+            AntdvNextXResolver(),
+          ],
+        }),
+      ],
+    },
+  },
+});
+```
+
+For more options (such as `exclude` to skip certain components), see the [auto-import-resolver-x documentation](https://github.com/antdv-next/auto-import-resolver-x#options).
+
 ## Custom Theme
 
 Configure theme tokens through `XProvider`.

--- a/packages/docs/src/pages/docs/use-with-rsbuild.zh-CN.md
+++ b/packages/docs/src/pages/docs/use-with-rsbuild.zh-CN.md
@@ -61,6 +61,73 @@ import { Bubble, XProvider } from "@antdv-next/x";
 
 好了，现在你应该能看到页面上已经有了 `@antdv-next/x` 的气泡组件，接下来就可以继续选用其他组件开发应用了。其他开发流程你可以参考 Rsbuild 的[官方文档](https://rsbuild.dev/zh/)。
 
+## 按需自动引入
+
+如果你希望组件按需自动引入、无需手动 `import`，可以使用 [`@antdv-next/auto-import-resolver-x`](https://github.com/antdv-next/auto-import-resolver-x) 配合 [`unplugin-vue-components`](https://github.com/unplugin/unplugin-vue-components)。
+
+安装依赖：
+
+<InstallDependencies npm='$ npm install @antdv-next/auto-import-resolver-x unplugin-vue-components -D' yarn='$ yarn add @antdv-next/auto-import-resolver-x unplugin-vue-components -D' pnpm='$ pnpm install @antdv-next/auto-import-resolver-x unplugin-vue-components -D' bun='$ bun add @antdv-next/auto-import-resolver-x unplugin-vue-components -D'></InstallDependencies>
+
+在 `rsbuild.config.ts` 中通过 `tools.rspack` 配置解析器：
+
+```ts
+// rsbuild.config.ts
+import { defineConfig } from "@rsbuild/core";
+import Components from "unplugin-vue-components/rspack";
+import { AntdvNextXResolver } from "@antdv-next/auto-import-resolver-x";
+
+export default defineConfig({
+  tools: {
+    rspack: {
+      plugins: [
+        Components({
+          resolvers: [AntdvNextXResolver()],
+        }),
+      ],
+    },
+  },
+});
+```
+
+配置完成后，在模板中直接使用 `Ax` 前缀的组件即可，无需手动引入。`src/App.vue` 可以简化为：
+
+```vue
+<template>
+  <AxProvider>
+    <AxBubble content="Hello world!" />
+  </AxProvider>
+</template>
+```
+
+> 注意：自动引入时模板里需使用 `Ax` 前缀的全局名（如 `AxBubble`、`AxProvider`），解析器会自动映射到 `@antdv-next/x` 中对应的导出（`Bubble`、`XProvider`）。
+
+`@antdv-next/x` 基于 `antdv-next` 构建，如果你同时使用 `antdv-next` 组件与 `@antdv-next/icons` 图标，可以把两个解析器一起注册：
+
+```ts
+import { AntdvNextResolver } from "@antdv-next/auto-import-resolver";
+import { AntdvNextXResolver } from "@antdv-next/auto-import-resolver-x";
+import Components from "unplugin-vue-components/rspack";
+import { defineConfig } from "@rsbuild/core";
+
+export default defineConfig({
+  tools: {
+    rspack: {
+      plugins: [
+        Components({
+          resolvers: [
+            AntdvNextResolver({ resolveIcons: true }),
+            AntdvNextXResolver(),
+          ],
+        }),
+      ],
+    },
+  },
+});
+```
+
+更多选项（如 `exclude` 排除某些组件）请参考 [auto-import-resolver-x 文档](https://github.com/antdv-next/auto-import-resolver-x#options)。
+
 ## 自定义主题
 
 可以通过 `XProvider` 配置主题 Token。

--- a/packages/docs/src/pages/docs/use-with-vite.en-US.md
+++ b/packages/docs/src/pages/docs/use-with-vite.en-US.md
@@ -59,6 +59,67 @@ import { Bubble, XProvider } from "@antdv-next/x";
 
 You should now see the `@antdv-next/x` bubble component on the page. You can continue building your application with other components. For the rest of the development workflow, refer to the [Vite documentation](https://vite.dev/).
 
+## On-demand Auto Import
+
+If you prefer components to be imported on demand without manual `import` statements, use [`@antdv-next/auto-import-resolver-x`](https://github.com/antdv-next/auto-import-resolver-x) together with [`unplugin-vue-components`](https://github.com/unplugin/unplugin-vue-components).
+
+Install the dependencies:
+
+<InstallDependencies npm='$ npm install @antdv-next/auto-import-resolver-x unplugin-vue-components -D' yarn='$ yarn add @antdv-next/auto-import-resolver-x unplugin-vue-components -D' pnpm='$ pnpm install @antdv-next/auto-import-resolver-x unplugin-vue-components -D' bun='$ bun add @antdv-next/auto-import-resolver-x unplugin-vue-components -D'></InstallDependencies>
+
+Configure the resolver in `vite.config.ts`:
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import vue from "@vitejs/plugin-vue";
+import Components from "unplugin-vue-components/vite";
+import { AntdvNextXResolver } from "@antdv-next/auto-import-resolver-x";
+
+export default defineConfig({
+  plugins: [
+    vue(),
+    Components({
+      resolvers: [AntdvNextXResolver()],
+    }),
+  ],
+});
+```
+
+Now you can use `Ax`-prefixed components directly in templates without importing them. `src/App.vue` can be simplified to:
+
+```vue
+<template>
+  <AxProvider>
+    <AxBubble content="Hello world!" />
+  </AxProvider>
+</template>
+```
+
+> Note: With auto import, use the `Ax`-prefixed global names in templates (e.g. `AxBubble`, `AxProvider`). The resolver maps them to the corresponding exports of `@antdv-next/x` (`Bubble`, `XProvider`).
+
+Since `@antdv-next/x` is built on top of `antdv-next`, you can register both resolvers together if you also use `antdv-next` components and `@antdv-next/icons` icons:
+
+```ts
+import { AntdvNextResolver } from "@antdv-next/auto-import-resolver";
+import { AntdvNextXResolver } from "@antdv-next/auto-import-resolver-x";
+import Components from "unplugin-vue-components/vite";
+
+export default defineConfig({
+  plugins: [
+    vue(),
+    Components({
+      resolvers: [
+        AntdvNextResolver({ resolveIcons: true }),
+        AntdvNextXResolver(),
+      ],
+    }),
+  ],
+});
+```
+
+For more options (such as `exclude` to skip certain components), see the [auto-import-resolver-x documentation](https://github.com/antdv-next/auto-import-resolver-x#options).
+
 ## Custom Theme
 
 Configure theme tokens through `XProvider`.

--- a/packages/docs/src/pages/docs/use-with-vite.zh-CN.md
+++ b/packages/docs/src/pages/docs/use-with-vite.zh-CN.md
@@ -59,6 +59,67 @@ import { Bubble, XProvider } from "@antdv-next/x";
 
 好了，现在你应该能看到页面上已经有了 `@antdv-next/x` 的气泡组件，接下来就可以继续选用其他组件开发应用了。其他开发流程你可以参考 Vite 的[官方文档](https://cn.vite.dev/)。
 
+## 按需自动引入
+
+如果你希望组件按需自动引入、无需手动 `import`，可以使用 [`@antdv-next/auto-import-resolver-x`](https://github.com/antdv-next/auto-import-resolver-x) 配合 [`unplugin-vue-components`](https://github.com/unplugin/unplugin-vue-components)。
+
+安装依赖：
+
+<InstallDependencies npm='$ npm install @antdv-next/auto-import-resolver-x unplugin-vue-components -D' yarn='$ yarn add @antdv-next/auto-import-resolver-x unplugin-vue-components -D' pnpm='$ pnpm install @antdv-next/auto-import-resolver-x unplugin-vue-components -D' bun='$ bun add @antdv-next/auto-import-resolver-x unplugin-vue-components -D'></InstallDependencies>
+
+在 `vite.config.ts` 中配置解析器：
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import vue from "@vitejs/plugin-vue";
+import Components from "unplugin-vue-components/vite";
+import { AntdvNextXResolver } from "@antdv-next/auto-import-resolver-x";
+
+export default defineConfig({
+  plugins: [
+    vue(),
+    Components({
+      resolvers: [AntdvNextXResolver()],
+    }),
+  ],
+});
+```
+
+配置完成后，在模板中直接使用 `Ax` 前缀的组件即可，无需手动引入。`src/App.vue` 可以简化为：
+
+```vue
+<template>
+  <AxProvider>
+    <AxBubble content="Hello world!" />
+  </AxProvider>
+</template>
+```
+
+> 注意：自动引入时模板里需使用 `Ax` 前缀的全局名（如 `AxBubble`、`AxProvider`），解析器会自动映射到 `@antdv-next/x` 中对应的导出（`Bubble`、`XProvider`）。
+
+`@antdv-next/x` 基于 `antdv-next` 构建，如果你同时使用 `antdv-next` 组件与 `@antdv-next/icons` 图标，可以把两个解析器一起注册：
+
+```ts
+import { AntdvNextResolver } from "@antdv-next/auto-import-resolver";
+import { AntdvNextXResolver } from "@antdv-next/auto-import-resolver-x";
+import Components from "unplugin-vue-components/vite";
+
+export default defineConfig({
+  plugins: [
+    vue(),
+    Components({
+      resolvers: [
+        AntdvNextResolver({ resolveIcons: true }),
+        AntdvNextXResolver(),
+      ],
+    }),
+  ],
+});
+```
+
+更多选项（如 `exclude` 排除某些组件）请参考 [auto-import-resolver-x 文档](https://github.com/antdv-next/auto-import-resolver-x#options)。
+
 ## 自定义主题
 
 可以通过 `XProvider` 配置主题 Token。


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [x] 📝 站点 / 文档改进

### 🔗 相关 Issue

> 无对应 issue。配合已发布到 npm 的 `@antdv-next/auto-import-resolver-x`（v0.0.1）包，补充按需自动引入的使用文档。

### 💡 背景与方案

`@antdv-next/auto-import-resolver-x` 已发布，用于配合 [`unplugin-vue-components`](https://github.com/unplugin/unplugin-vue-components) 实现 `@antdv-next/x` 组件的按需自动引入。此前 use-with 系列文档只展示了手动 `import` 的方式，本次为 Vite / Rsbuild 使用指南（中英各一份，共 4 篇）新增「按需自动引入 / On-demand Auto Import」章节，统一插入在「引入 @antdv-next/x」与「自定义主题」之间，内容包括：

- 安装 `@antdv-next/auto-import-resolver-x` 与 `unplugin-vue-components`（`-D`）
- 构建工具配置：Vite 走 `unplugin-vue-components/vite`，Rsbuild 走 `tools.rspack` + `unplugin-vue-components/rspack`
- 简化后的 `App.vue`：模板直接使用 `<AxProvider>` / `<AxBubble>`，无需 `<script setup>` 手动引入
- 关键提示：自动引入时模板需使用 `Ax` 前缀全局名（如 `AxBubble` → `Bubble`、`AxProvider` → `XProvider`）
- 与 `@antdv-next/auto-import-resolver` 组合使用，同时按需引入 `antdv-next` 组件与 `@antdv-next/icons` 图标
- 链接到 resolver 仓库的 `exclude` 等选项说明

仅修改 `packages/docs/src/pages/docs/` 下的 4 个源文件；`dist/` 与 `public/` 为构建产物（已 gitignore），无需手动维护。

### 📝 变更日志

| 语言    | 变更日志 |
| ------- | -------- |
| 🇺🇸 英文 | Add an "On-demand Auto Import" section to the Vite and Rsbuild use-with guides, covering `@antdv-next/auto-import-resolver-x` with `unplugin-vue-components`. |
| 🇨🇳 中文 | 在 Vite / Rsbuild 使用指南中新增「按需自动引入」章节，介绍通过 `@antdv-next/auto-import-resolver-x` 配合 `unplugin-vue-components` 实现组件按需自动引入。 |