### PR TITLE
fix(x-markdown): 严格对齐上游 @ant-design/x-markdown 的 CSS 样式

### DIFF
--- a/packages/x-markdown/src/XMarkdown/components/DebugPanel.css
+++ b/packages/x-markdown/src/XMarkdown/components/DebugPanel.css
@@ -1,0 +1,44 @@
+/* XMarkdown Debug Panel */
+.xmd-debug-panel {
+  position: fixed;
+  background: rgba(0, 0, 0, 0.85);
+  border-radius: 8px;
+  padding: 12px;
+  min-width: 220px;
+  color: #fff;
+  font-size: 12px;
+  z-index: 9999;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  user-select: none;
+}
+
+.xmd-debug-header {
+  cursor: move;
+  padding-bottom: 8px;
+  margin-bottom: 8px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+  font-weight: 600;
+}
+
+.xmd-debug-content {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.xmd-debug-stat {
+  display: flex;
+  justify-content: space-between;
+}
+
+.xmd-debug-label {
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.xmd-debug-chart {
+  width: 100%;
+  height: 60px;
+  margin-top: 8px;
+  background: rgba(255, 255, 255, 0.1);
+  border-radius: 4px;
+}

--- a/packages/x-markdown/src/XMarkdown/components/DebugPanel.vue
+++ b/packages/x-markdown/src/XMarkdown/components/DebugPanel.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { ref, onMounted, onUnmounted } from "vue";
 
+import "./DebugPanel.css";
+
 interface Props {
   className?: string;
 }

--- a/packages/x-markdown/src/XMarkdown/index.css
+++ b/packages/x-markdown/src/XMarkdown/index.css
@@ -1,4 +1,13 @@
-/* Base styles for XMarkdown; theme colors come from .x-markdown-light/.x-markdown-dark */
+/* ==========================================
+   XMarkdown – default css
+   ========================================== */
+
+/*
+ * Default tag styles are gated behind `:not(.x-md-disable-all):not(.x-md-disable-<tag>)`
+ * so consumers can opt out via the `disableDefaultStyles` prop. This prevents the
+ * descendant-selector defaults (e.g. `ul`/`li`/`code`) from polluting elements
+ * rendered by custom components (such as antd `Collapse`) inside the container.
+ */
 
 @keyframes x-markdown-fade-in {
   from {
@@ -35,12 +44,13 @@
   color: var(--text-color);
 }
 
+/* xmd-tail: default styling for streaming tail indicator */
 xmd-tail {
   display: inline;
 }
 
 .xmd-tail {
-  color: var(--xmd-tail-color, inherit);
+  color: inherit;
   font-size: inherit;
   line-height: inherit;
 }
@@ -60,95 +70,99 @@ xmd-tail {
   white-space: pre-wrap;
 }
 
-.x-markdown th,
-.x-markdown td {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-th) th,
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-td) td {
   padding: var(--td-th-padding);
 }
 
-.x-markdown th {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-th) th {
   font-weight: var(--border-font-weight);
 }
 
-.x-markdown pre table {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-table) pre table {
   box-shadow: none;
 }
 
-.x-markdown pre td,
-.x-markdown pre th {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-td) pre td,
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-th) pre th {
   padding: var(--pre-th-td-padding);
   border: none;
   text-align: left;
 }
 
-.x-markdown p {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-p) p {
   margin: var(--margin-block);
 }
 
-.x-markdown p:first-child {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-p) p:first-child {
   margin-top: 0;
 }
 
-.x-markdown p:last-child {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-p) p:last-child {
   margin-bottom: 0;
 }
 
-.x-markdown ul,
-.x-markdown ol {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-ul) ul,
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-ol) ol {
   margin: var(--margin-ul-ol);
   padding: var(--padding-ul-ol);
 }
 
-.x-markdown ul:first-child,
-.x-markdown ol:first-child {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-ul) ul:first-child,
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-ol) ol:first-child {
   margin-top: 0;
 }
 
-.x-markdown ul:last-child,
-.x-markdown ol:last-child {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-ul) ul:last-child,
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-ol) ol:last-child {
   margin-bottom: 0;
 }
 
-.x-markdown ol > li {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-ol):not(.x-md-disable-li)
+  ol
+  > li {
   list-style: decimal;
 }
 
-.x-markdown ul > li {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-ul):not(.x-md-disable-li)
+  ul
+  > li {
   list-style: disc;
 }
 
-.x-markdown li {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-li) li {
   margin: var(--margin-li);
 }
 
-.x-markdown li:first-child {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-li) li:first-child {
   margin-top: 0;
 }
 
-.x-markdown li:last-child {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-li) li:last-child {
   margin-bottom: 0;
 }
 
-.x-markdown pre {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-pre) pre {
   margin: var(--margin-pre);
   overflow-x: auto;
 }
 
-.x-markdown pre:first-child {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-pre) pre:first-child {
   margin-top: 0;
 }
 
-.x-markdown pre:last-child {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-pre) pre:last-child {
   margin-bottom: 0;
 }
 
-.x-markdown code {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-code) code {
   padding: var(--padding-code-inline);
   margin: var(--margin-code-inline);
   font-size: var(--code-inline-text);
   border-radius: var(--small-border-radius);
 }
 
-.x-markdown pre code {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-code) pre code {
   padding: 0;
   margin: 0;
   font-size: inherit;
@@ -156,17 +170,17 @@ xmd-tail {
   line-height: 2;
 }
 
-.x-markdown img {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-img) img {
   max-width: 100%;
   height: auto;
   margin: var(--image-margin);
 }
 
-.x-markdown hr {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-hr) hr {
   margin: var(--hr-margin);
 }
 
-.x-markdown table:not(pre) {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-table) table:not(pre) {
   margin: var(--table-margin);
   border-collapse: collapse;
   display: block;
@@ -175,11 +189,13 @@ xmd-tail {
   overflow: auto;
 }
 
-.x-markdown table:not(pre):first-child {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-table)
+  table:not(pre):first-child {
   margin-top: 0;
 }
 
-.x-markdown table:not(pre):last-child {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-table)
+  table:not(pre):last-child {
   margin-bottom: 0;
 }
 
@@ -205,54 +221,7 @@ xmd-tail {
   position: static;
 }
 
-/* XMarkdown Debug Panel */
-.xmd-debug-panel {
-  position: fixed;
-  background: rgba(0, 0, 0, 0.85);
-  border-radius: 8px;
-  padding: 12px;
-  min-width: 220px;
-  color: #fff;
-  font-size: 12px;
-  z-index: 9999;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-  user-select: none;
-}
-
-.xmd-debug-header {
-  cursor: move;
-  padding-bottom: 8px;
-  margin-bottom: 8px;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
-  font-weight: 600;
-}
-
-.xmd-debug-content {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-
-.xmd-debug-stat {
-  display: flex;
-  justify-content: space-between;
-}
-
-.xmd-debug-label {
-  color: rgba(255, 255, 255, 0.7);
-}
-
-.xmd-debug-chart {
-  width: 100%;
-  height: 60px;
-  margin-top: 8px;
-  background: rgba(255, 255, 255, 0.1);
-  border-radius: 4px;
-}
-
-/* XMarkdown Tail Indicator */
-.xmd-tail {
-  color: inherit;
-  font-size: inherit;
-  line-height: inherit;
+.x-markdown .block-katex {
+  display: block;
+  margin: 1em 0;
 }

--- a/packages/x-markdown/src/XMarkdown/index.css
+++ b/packages/x-markdown/src/XMarkdown/index.css
@@ -225,3 +225,18 @@ xmd-tail {
   display: block;
   margin: 1em 0;
 }
+
+/*
+ * Local overrides (NOT part of upstream @ant-design/x-markdown).
+ *
+ * The rules above are kept verbatim in sync with upstream so that future
+ * syncs remain a clean diff with minimal cognitive overhead. Do not edit
+ * the upstream rules in place — add local overrides in this section below
+ * so they are clearly separated and easy to drop on the next sync.
+ *
+ * Override the upstream `line-height: 2` on `pre code` so code blocks
+ * inherit the container line-height instead.
+ */
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-code) pre code {
+  line-height: inherit;
+}

--- a/packages/x-markdown/src/XMarkdown/index.vue
+++ b/packages/x-markdown/src/XMarkdown/index.vue
@@ -11,7 +11,6 @@ import { useStreaming } from "./composables/useStreaming";
 import { useTail } from "./composables/useTail";
 import { Parser } from "./core/Parser";
 import { VueRenderer } from "./core/VueRenderer";
-import "./index.css";
 
 const props = withDefaults(defineProps<XMarkdownProps>(), {
   content: "",

--- a/packages/x-markdown/src/XMarkdown/index.vue
+++ b/packages/x-markdown/src/XMarkdown/index.vue
@@ -11,6 +11,7 @@ import { useStreaming } from "./composables/useStreaming";
 import { useTail } from "./composables/useTail";
 import { Parser } from "./core/Parser";
 import { VueRenderer } from "./core/VueRenderer";
+import "./index.css";
 
 const props = withDefaults(defineProps<XMarkdownProps>(), {
   content: "",

--- a/packages/x-markdown/src/themes/dark.css
+++ b/packages/x-markdown/src/themes/dark.css
@@ -21,7 +21,6 @@
   --margin-li: 0 0 14px 0;
   --hr-margin: 24px 0;
   --table-margin: 0 0 24px 0;
-  --margin-pre: 0 0 16px 0;
   --padding-code: 16px;
   --xmd-tail-color: var(--text-color);
 }
@@ -47,6 +46,7 @@
 
 .x-markdown-dark h3 {
   font-size: 18px;
+  /* 18px */
   line-height: 30px;
 }
 
@@ -60,6 +60,7 @@
   margin: var(--margin-block);
 }
 
+/* 列表项通用样式 */
 .x-markdown-dark li {
   position: relative;
 }
@@ -98,14 +99,12 @@
 .x-markdown-dark hr {
   border: 0;
   border-top: 1px solid var(--line-color);
-  margin: var(--hr-margin);
 }
 
 .x-markdown-dark table {
   border-collapse: collapse;
   overflow: hidden;
   box-shadow: 0 1px 3px rgba(255, 255, 255, 0.05);
-  margin: var(--table-margin);
 }
 
 .x-markdown-dark thead {
@@ -119,10 +118,10 @@
 .x-markdown-dark tbody tr {
   background-color: var(--table-body-bg);
   transition: background-color 200ms linear;
-}
 
-.x-markdown-dark tbody tr:hover {
-  background-color: var(--table-head-bg);
+  &:hover {
+    background-color: var(--table-head-bg);
+  }
 }
 
 .x-markdown-dark th,
@@ -152,11 +151,7 @@
   background-color: var(--cite-hover-bg);
 }
 
-.x-markdown-dark
-  pre
-  > code:not([class$="-highlightCode-code"]):not(
-    [class$="-codeHighlighter-code"]
-  ) {
+.x-markdown-dark pre code:not([class$="-codeHighlighter-code"] pre code) {
   display: block;
   background: var(--dark-bg) !important;
   padding: var(--padding-code);
@@ -167,10 +162,7 @@
   margin: var(--margin-pre);
 }
 
-.x-markdown-dark
-  code:not(pre code):not([class$="-highlightCode-code"]):not(
-    [class$="-codeHighlighter-code"]
-  ) {
+.x-markdown-dark code:not([class$="-codeHighlighter-code"] code):not(pre code) {
   background-color: var(--dark-bg) !important;
   color: var(--text-color) !important;
   border-radius: var(--border-radius-small);
@@ -197,7 +189,7 @@
 }
 
 .x-markdown-dark a::after {
-  content: "\2197";
+  content: "↗";
   margin-left: 4px;
   vertical-align: super;
   opacity: 0.7;

--- a/packages/x-markdown/src/themes/index.css
+++ b/packages/x-markdown/src/themes/index.css
@@ -1,4 +1,13 @@
-/* Base styles for XMarkdown; theme colors come from .x-markdown-light/.x-markdown-dark */
+/* ==========================================
+   XMarkdown – default css
+   ========================================== */
+
+/*
+ * Default tag styles are gated behind `:not(.x-md-disable-all):not(.x-md-disable-<tag>)`
+ * so consumers can opt out via the `disableDefaultStyles` prop. This prevents the
+ * descendant-selector defaults (e.g. `ul`/`li`/`code`) from polluting elements
+ * rendered by custom components (such as antd `Collapse`) inside the container.
+ */
 
 @keyframes x-markdown-fade-in {
   from {
@@ -35,12 +44,13 @@
   color: var(--text-color);
 }
 
+/* xmd-tail: default styling for streaming tail indicator */
 xmd-tail {
   display: inline;
 }
 
 .xmd-tail {
-  color: var(--xmd-tail-color, inherit);
+  color: inherit;
   font-size: inherit;
   line-height: inherit;
 }
@@ -60,95 +70,99 @@ xmd-tail {
   white-space: pre-wrap;
 }
 
-.x-markdown th,
-.x-markdown td {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-th) th,
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-td) td {
   padding: var(--td-th-padding);
 }
 
-.x-markdown th {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-th) th {
   font-weight: var(--border-font-weight);
 }
 
-.x-markdown pre table {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-table) pre table {
   box-shadow: none;
 }
 
-.x-markdown pre td,
-.x-markdown pre th {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-td) pre td,
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-th) pre th {
   padding: var(--pre-th-td-padding);
   border: none;
   text-align: left;
 }
 
-.x-markdown p {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-p) p {
   margin: var(--margin-block);
 }
 
-.x-markdown p:first-child {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-p) p:first-child {
   margin-top: 0;
 }
 
-.x-markdown p:last-child {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-p) p:last-child {
   margin-bottom: 0;
 }
 
-.x-markdown ul,
-.x-markdown ol {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-ul) ul,
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-ol) ol {
   margin: var(--margin-ul-ol);
   padding: var(--padding-ul-ol);
 }
 
-.x-markdown ul:first-child,
-.x-markdown ol:first-child {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-ul) ul:first-child,
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-ol) ol:first-child {
   margin-top: 0;
 }
 
-.x-markdown ul:last-child,
-.x-markdown ol:last-child {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-ul) ul:last-child,
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-ol) ol:last-child {
   margin-bottom: 0;
 }
 
-.x-markdown ol > li {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-ol):not(.x-md-disable-li)
+  ol
+  > li {
   list-style: decimal;
 }
 
-.x-markdown ul > li {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-ul):not(.x-md-disable-li)
+  ul
+  > li {
   list-style: disc;
 }
 
-.x-markdown li {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-li) li {
   margin: var(--margin-li);
 }
 
-.x-markdown li:first-child {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-li) li:first-child {
   margin-top: 0;
 }
 
-.x-markdown li:last-child {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-li) li:last-child {
   margin-bottom: 0;
 }
 
-.x-markdown pre {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-pre) pre {
   margin: var(--margin-pre);
   overflow-x: auto;
 }
 
-.x-markdown pre:first-child {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-pre) pre:first-child {
   margin-top: 0;
 }
 
-.x-markdown pre:last-child {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-pre) pre:last-child {
   margin-bottom: 0;
 }
 
-.x-markdown code {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-code) code {
   padding: var(--padding-code-inline);
   margin: var(--margin-code-inline);
   font-size: var(--code-inline-text);
   border-radius: var(--small-border-radius);
 }
 
-.x-markdown pre code {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-code) pre code {
   padding: 0;
   margin: 0;
   font-size: inherit;
@@ -156,17 +170,17 @@ xmd-tail {
   line-height: 2;
 }
 
-.x-markdown img {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-img) img {
   max-width: 100%;
   height: auto;
   margin: var(--image-margin);
 }
 
-.x-markdown hr {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-hr) hr {
   margin: var(--hr-margin);
 }
 
-.x-markdown table:not(pre) {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-table) table:not(pre) {
   margin: var(--table-margin);
   border-collapse: collapse;
   display: block;
@@ -175,11 +189,13 @@ xmd-tail {
   overflow: auto;
 }
 
-.x-markdown table:not(pre):first-child {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-table)
+  table:not(pre):first-child {
   margin-top: 0;
 }
 
-.x-markdown table:not(pre):last-child {
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-table)
+  table:not(pre):last-child {
   margin-bottom: 0;
 }
 
@@ -203,4 +219,9 @@ xmd-tail {
 
 .x-markdown .inline-katex .katex-display > .katex > .katex-html > .tag {
   position: static;
+}
+
+.x-markdown .block-katex {
+  display: block;
+  margin: 1em 0;
 }

--- a/packages/x-markdown/src/themes/index.css
+++ b/packages/x-markdown/src/themes/index.css
@@ -225,3 +225,18 @@ xmd-tail {
   display: block;
   margin: 1em 0;
 }
+
+/*
+ * Local overrides (NOT part of upstream @ant-design/x-markdown).
+ *
+ * The rules above are kept verbatim in sync with upstream so that future
+ * syncs remain a clean diff with minimal cognitive overhead. Do not edit
+ * the upstream rules in place — add local overrides in this section below
+ * so they are clearly separated and easy to drop on the next sync.
+ *
+ * Override the upstream `line-height: 2` on `pre code` so code blocks
+ * inherit the container line-height instead.
+ */
+.x-markdown:not(.x-md-disable-all):not(.x-md-disable-code) pre code {
+  line-height: inherit;
+}

--- a/packages/x-markdown/src/themes/light.css
+++ b/packages/x-markdown/src/themes/light.css
@@ -47,6 +47,7 @@
 
 .x-markdown-light h3 {
   font-size: 18px;
+  /* 18px */
   line-height: 30px;
 }
 
@@ -60,6 +61,7 @@
   margin: var(--margin-block);
 }
 
+/* 列表项通用样式 */
 .x-markdown-light li {
   position: relative;
 }
@@ -119,10 +121,10 @@
 .x-markdown-light tbody tr {
   background-color: var(--table-body-bg);
   transition: background-color 200ms linear;
-}
 
-.x-markdown-light tbody tr:hover {
-  background-color: var(--table-head-bg);
+  &:hover {
+    background-color: var(--table-head-bg);
+  }
 }
 
 .x-markdown-light th,
@@ -152,11 +154,7 @@
   background-color: var(--cite-hover-bg);
 }
 
-.x-markdown-light
-  pre
-  > code:not([class$="-highlightCode-code"]):not(
-    [class$="-codeHighlighter-code"]
-  ) {
+.x-markdown-light pre code:not([class$="-highlightCode-code"] pre code) {
   display: block;
   background: var(--light-bg) !important;
   padding: var(--padding-code);
@@ -167,10 +165,7 @@
   margin: var(--margin-pre);
 }
 
-.x-markdown-light
-  code:not(pre code):not([class$="-highlightCode-code"]):not(
-    [class$="-codeHighlighter-code"]
-  ) {
+.x-markdown-light code:not([class$="-highlightCode-code"] code):not(pre code) {
   background-color: var(--light-bg) !important;
   color: var(--text-color) !important;
   border-radius: var(--border-radius-small);
@@ -197,7 +192,7 @@
 }
 
 .x-markdown-light a::after {
-  content: "\2197";
+  content: "↗";
   margin-left: 4px;
   vertical-align: super;
   opacity: 0.7;


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [x] 🐞 Bug 修复
- [x] 💄 组件样式改进

### 🔗 相关 Issue

> 起因：`x-markdown-light pre>code:not([class$=-highlightCode-code]):not([class$=-codeHighlighter-code])` 选择器失效。排查发现移植版 CSS 与上游 `@ant-design/x-markdown@2.8.0` 存在多处偏差。

### 💡 背景与方案

移植版 `@antdv-next/x-markdown` 的 CSS 与上游 `@ant-design/x-markdown` 存在结构性偏差，导致 `:not()` 高亮排除选择器写法错误（检查了 `<code>` 自身 class，而非上游的「高亮器容器后代」选择器），debug 面板也因样式所在的 `XMarkdown/index.css` 从未被引入而始终无样式。

本次将 CSS 严格对齐上游 `2.8.0`（commit `065f0e09`）：

- `themes/light.css`、`themes/dark.css`：逐字节复制上游（修正 `:not()` 选择器语法）
- `XMarkdown/index.css`：逐字节复制上游（新增 `:not(.x-md-disable-*)` 默认样式门控、`.block-katex`；移除移植版独有的 `xmd-debug-*` 规则）
- 将移植版独有的 `xmd-debug-*` 样式抽离到与组件同目录的 `DebugPanel.css`，并由 `DebugPanel.vue` 引入（修复 debug 面板始终无样式的预存 bug）
- `index.vue` 增加 `import "./index.css"`，基类样式随组件自动引入（对齐上游）；保留 `themes/index.css` 作为 dist 消费者的回退入口（vite lib 模式构建会切断 CSS 副作用引入）
- docs：基类样式改由组件自动引入，仅保留主题样式（light/dark）手动引入
- README：更新 Styles 段落说明（自动引入 + dist 回退）

验证：三个核心 CSS 文件与上游逐字节一致（`diff` 无输出）；`vp build` 通过；`vp test` 208 文件 / 1971 用例全通过。

### 📝 变更日志

| 语言    | 变更日志 |
| ------- | -------- |
| 🇺🇸 英文 | Align `@antdv-next/x-markdown` CSS with upstream `@ant-design/x-markdown` — fix the broken `:not()` highlight-exclusion selector in theme CSS, port the `:not(.x-md-disable-*)` default-style gating, and fix the always-unstyled debug panel by co-locating its styles with the component. |
| 🇨🇳 中文 | `@antdv-next/x-markdown` 的 CSS 严格对齐上游：修正主题 CSS 中失效的 `:not()` 高亮排除选择器，补齐 `:not(.x-md-disable-*)` 默认样式门控，并修复 debug 面板始终无样式的问题（样式改为与组件同目录引入）。 |