### PR TITLE
fix(docs): add missing resolveComponent import in code-highlighter demo

### DIFF
--- a/packages/docs/src/pages/markdown/demo/code-highlighter.vue
+++ b/packages/docs/src/pages/markdown/demo/code-highlighter.vue
@@ -8,6 +8,7 @@ import {
   nextTick,
   onBeforeUnmount,
   ref,
+  resolveComponent,
   watch,
   type VNode,
 } from "vue";


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - N/A. Found during a docs demo code audit.

### 💡 Background and Solution

The `code-highlighter` demo (`packages/docs/src/pages/markdown/demo/code-highlighter.vue`) called `resolveComponent("ax-code-highlighter")` without importing `resolveComponent` from `vue`.

It only worked inside the docs app because `unplugin-auto-import` is configured with `imports: ["vue", ...]`, which auto-imports `resolveComponent` globally. However, the demo code is displayed to users as a copyable example, so anyone copying it would hit `resolveComponent is not defined`.

This is inconsistent with the sibling `gpt-vis` demo (`packages/docs/src/pages/components/bubble/demo/gpt-vis.vue`), which imports `resolveComponent` explicitly.

**Solution:** Add `resolveComponent` to the `from "vue"` import block, placed after `ref` to match the `gpt-vis` demo convention. The displayed demo source (generated into `public/markdown/*.md`) regenerates from this `.vue` file, so a single source fix covers all rendered examples (`examples.md`, `rich-text.md` and their `-en` variants).

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Add the missing `resolveComponent` import to the `code-highlighter` demo so the copyable example runs without the docs app's auto-import setup. |
| 🇨🇳 Chinese | 为 `code-highlighter` demo 补充缺失的 `resolveComponent` 导入，使展示的可复制示例在脱离文档站点的 auto-import 配置时也能正常运行。 |
