### PR TITLE
fix(docs): 修复 docs:dev 全新 checkout 无法启动

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "type": "module",
   "scripts": {
     "dev:play": "vp dev packages/playground",
-    "docs:dev": "vp dev packages/docs",
+    "docs:dev": "vp run --filter @antdv-next/x build:token && vp dev packages/docs",
     "docs:preview": "vp preview packages/docs",
     "docs:build": "vp run --filter @antdv-next/docs build",
     "docs:llm": "vp run --filter @antdv-next/docs build:llm",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vp dev .",
+    "dev": "vp run --filter @antdv-next/x build:token && vp dev .",
     "build": "vp run --filter @antdv-next/x build:token && node ./scripts/llm/generate-llms-semantic.mjs && node ./scripts/llm/generate-llms.mjs && node ./scripts/gen-search.mjs && vp build .",
     "preview": "vp preview .",
     "build:llm": "node ./scripts/llm/generate-llms-semantic.mjs && node ./scripts/llm/generate-llms.mjs",


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [x] 🐞 Bug 修复
- [ ] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

无对应 Issue。复现：在全新 checkout 上执行 `vp run docs:dev`（或 `pnpm docs:dev`）会因缺失 token 资源而崩溃（测试 #129 时发现，但该问题在 main 上早已存在，与搜索功能无关）。

### 💡 背景与方案

**问题：** `token-meta.json` 与 `token.json` 是 `.gitignore` 忽略的构建产物，分别由 `@antdv-next/x` 的 `build:token-meta`（typedoc 解析源码）与 `build:token-statistic`（依赖 `build:comp` 产物做 SSR 收集）生成。docs 的 `build` 脚本已前置 `build:token`，但 `docs:dev` 没有，导致全新 checkout / 切分支后 `component-token-table.vue` import 这两个文件报错、dev 无法启动：

```
[plugin:vite:import-analysis] Failed to resolve import "../../assets/token-meta.json"
from "packages/docs/src/components/token/component-token-table.vue".
```

**方案：** 在 `docs:dev` 的两个入口（根 `package.json` 与 `packages/docs/package.json`）前置 `vp run --filter @antdv-next/x build:token`，与 build 脚本保持一致。`build:token` 失败则 `&&` 中止，不会带病启动。

```diff
- "docs:dev": "vp dev packages/docs",
+ "docs:dev": "vp run --filter @antdv-next/x build:token && vp dev packages/docs",
```
```diff
- "dev": "vp dev .",
+ "dev": "vp run --filter @antdv-next/x build:token && vp dev .",
```

**验证：** 删除两个 token 文件后执行 `vp run docs:dev`，确认先自动执行 `build:token` 重新生成 `token-meta.json` / `token.json`，随后 dev server 正常启动，无 import 报错。

**代价：** 每次 dev 启动多约 8s（增量）/ 15-40s（冷启动）用于构建 token，换取 token 数据始终与当前 x 源码一致。

### 📝 变更日志

| 语言    | 变更日志 |
| ------- | -------- |
| 🇺🇸 英文 | Fix `docs:dev` failing to start on fresh checkout by generating token assets first |
| 🇨🇳 中文 | 修复全新 checkout 后 `docs:dev` 因缺失 token 资源无法启动的问题 |
