### PR TITLE
feat(docs): 顶栏导航按包显示版本标签

### DIFF
--- a/packages/docs/src/config/header.ts
+++ b/packages/docs/src/config/header.ts
@@ -1,8 +1,15 @@
+import { version as cardVersion } from "../../../x-card/package.json";
+import { version as markdownVersion } from "../../../x-markdown/package.json";
+import { version as sdkVersion } from "../../../x-sdk/package.json";
+import { version as skillVersion } from "../../../x-skill/package.json";
+import { version as xVersion } from "../../../x/package.json";
+
 export interface HeaderItem {
   key: string;
   path: string;
   basePath: string;
   label: Record<"zh-CN" | "en-US", string>;
+  version?: string;
 }
 
 export const headerItems: HeaderItem[] = [
@@ -23,6 +30,7 @@ export const headerItems: HeaderItem[] = [
       "zh-CN": "组件",
       "en-US": "Components",
     },
+    version: xVersion,
   },
   {
     key: "markdown",
@@ -32,6 +40,7 @@ export const headerItems: HeaderItem[] = [
       "zh-CN": "Markdown",
       "en-US": "Markdown",
     },
+    version: markdownVersion,
   },
   {
     key: "card",
@@ -41,6 +50,7 @@ export const headerItems: HeaderItem[] = [
       "zh-CN": "Card",
       "en-US": "Card",
     },
+    version: cardVersion,
   },
   {
     key: "sdk",
@@ -50,6 +60,7 @@ export const headerItems: HeaderItem[] = [
       "zh-CN": "SDK",
       "en-US": "SDK",
     },
+    version: sdkVersion,
   },
   {
     key: "skill",
@@ -59,6 +70,7 @@ export const headerItems: HeaderItem[] = [
       "zh-CN": "Skill",
       "en-US": "Skill",
     },
+    version: skillVersion,
   },
   {
     key: "demo",

--- a/packages/docs/src/layouts/docs/components/header-actions.vue
+++ b/packages/docs/src/layouts/docs/components/header-actions.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { GithubOutlined } from "@antdv-next/icons";
-import { version } from "@antdv-next/x";
 import { createStyles } from "antdv-style";
 import { computed } from "vue";
 import { useRoute, useRouter } from "vue-router";
@@ -73,8 +72,6 @@ function changeLocale(value: 1 | 2) {
       )
     "
   >
-    <span class="text-12px c-text-secondary mr-8px">v{{ version }}</span>
-
     <SwitchBtn
       :value="localeValue"
       :tooltip1="t('ui.localeBtn.tooltip1')"

--- a/packages/docs/src/layouts/docs/components/header-navigation.vue
+++ b/packages/docs/src/layouts/docs/components/header-navigation.vue
@@ -28,6 +28,7 @@ const useStyles = createStyles(({ token, css }) => ({
     align-items: center;
 
     a {
+      min-width: 0;
       font-size: ${token.fontSizeLG}px;
       color: ${token.colorTextSecondary};
       text-decoration: none;
@@ -69,6 +70,41 @@ const useStyles = createStyles(({ token, css }) => ({
     color: ${token.colorText} !important;
     font-weight: 500;
   `,
+  item: css`
+    display: inline-flex;
+    flex-direction: column;
+    align-items: center;
+    line-height: 1;
+    position: relative;
+  `,
+  itemLabel: css`
+    white-space: nowrap;
+  `,
+  versionTag: css`
+    position: absolute;
+    top: calc(100% + 3px);
+    inset-inline-start: 50%;
+    transform: translateX(-50%);
+    margin: 0;
+    font-size: 10px;
+    font-weight: 500;
+    line-height: 14px;
+    color: ${token.colorTextTertiary};
+    transition:
+      color ${token.motionDurationMid},
+      opacity ${token.motionDurationMid};
+
+    a:hover &,
+    &.version-tag-active {
+      color: ${token.colorPrimary};
+    }
+
+    @media only screen and (max-width: 767.99px) {
+      position: static;
+      margin-top: 2px;
+      transform: none;
+    }
+  `,
   searchItem: css`
     display: flex;
     align-items: center;
@@ -107,7 +143,20 @@ function getItemPath(path: string) {
       :to="{ path: getItemPath(item.path), query: route.query }"
       :class="clsx(activeKey === item.key && styleState.styles.itemActive)"
     >
-      {{ item.label[isZhCN ? "zh-CN" : "en-US"] }}
+      <span :class="styleState.styles.item">
+        <span :class="styleState.styles.itemLabel">
+          {{ item.label[isZhCN ? "zh-CN" : "en-US"] }}
+        </span>
+        <span
+          v-if="item.version"
+          :class="[
+            styleState.styles.versionTag,
+            activeKey === item.key && 'version-tag-active',
+          ]"
+        >
+          v{{ item.version }}
+        </span>
+      </span>
     </router-link>
   </nav>
 </template>


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [x] ⭐️ 功能增强
- [x] 📝 站点 / 文档改进

### 🔗 相关 Issue

> 无。

### 💡 背景与方案

原先文档站顶栏右侧只有一个全局版本号 `v{{ version }}`（取自 `@antdv-next/x`），无法区分 Components / Markdown / Card / SDK / Skill 各子包的实际版本。

**方案：** 将全局版本号改为按包展示——在每个导航项正下方渲染对应包的版本标签。

- `header.ts`：从各子包 `package.json` 读取 `version`，`HeaderItem` 新增可选 `version` 字段，并为 components / markdown / card / sdk / skill 五项填充；
- `header-navigation.vue`：导航项改为纵向布局，标签下方渲染版本号，含 hover / active 配色过渡与移动端（≤767.99px）响应式回退为静态排列；
- `header-actions.vue`：移除顶栏右侧原有的全局 `v{{ version }}`。

效果：各包版本一目了然，无需进入页面即可从顶栏感知版本差异。

### 📝 变更日志

| 语言    | 变更日志                                                                                 |
| ------- | ---------------------------------------------------------------------------------------- |
| 🇺🇸 英文 | Show per-package version labels under top nav items instead of a single global version.  |
| 🇨🇳 中文 | 顶栏导航各项下方按包显示版本标签，替代原先单一的全局版本号。                              |