### PR TITLE
fix(docs): 移除 SDK 文档数据提供与工具分组下多余的 2.0.0 tag

### DIFF
--- a/packages/docs/src/pages/sdk/chat-provider-custom.en-US.md
+++ b/packages/docs/src/pages/sdk/chat-provider-custom.en-US.md
@@ -5,7 +5,6 @@ group:
   order: 2
 title: Custom Chat Provider
 order: 4
-tag: 2.0.0
 packageName: x-sdk
 ---
 

--- a/packages/docs/src/pages/sdk/chat-provider-custom.zh-CN.md
+++ b/packages/docs/src/pages/sdk/chat-provider-custom.zh-CN.md
@@ -6,7 +6,6 @@ group:
 title: Custom Chat Provider
 order: 4
 subtitle: 自定义
-tag: 2.0.0
 packageName: x-sdk
 ---
 

--- a/packages/docs/src/pages/sdk/chat-provider-deepseek.en-US.md
+++ b/packages/docs/src/pages/sdk/chat-provider-deepseek.en-US.md
@@ -5,7 +5,6 @@ group:
   order: 2
 title: DeepSeekChatProvider
 order: 3
-tag: 2.0.0
 packageName: x-sdk
 ---
 

--- a/packages/docs/src/pages/sdk/chat-provider-deepseek.zh-CN.md
+++ b/packages/docs/src/pages/sdk/chat-provider-deepseek.zh-CN.md
@@ -5,7 +5,6 @@ group:
   order: 2
 title: DeepSeekChatProvider
 order: 3
-tag: 2.0.0
 packageName: x-sdk
 ---
 

--- a/packages/docs/src/pages/sdk/chat-provider-open-ai.en-US.md
+++ b/packages/docs/src/pages/sdk/chat-provider-open-ai.en-US.md
@@ -5,7 +5,6 @@ group:
   order: 2
 title: OpenAIChatProvider
 order: 2
-tag: 2.0.0
 packageName: x-sdk
 ---
 

--- a/packages/docs/src/pages/sdk/chat-provider-open-ai.zh-CN.md
+++ b/packages/docs/src/pages/sdk/chat-provider-open-ai.zh-CN.md
@@ -4,7 +4,6 @@ group:
   title: 数据提供
   order: 2
 title: OpenAIChatProvider
-tag: 2.0.0
 packageName: x-sdk
 order: 2
 ---

--- a/packages/docs/src/pages/sdk/chat-provider.en-US.md
+++ b/packages/docs/src/pages/sdk/chat-provider.en-US.md
@@ -7,7 +7,6 @@ title: Chat Provider
 description: Data transformation for sending and receiving.
 order: 1
 packageName: x-sdk
-tag: 2.0.0
 ---
 
 `Chat Provider` is used to provide unified request management and data format conversion for `useXChat`. Currently, it includes built-in `Chat Provider` implementations for `OpenAI` and `DeepSeek` model service providers that you can use directly.

--- a/packages/docs/src/pages/sdk/chat-provider.zh-CN.md
+++ b/packages/docs/src/pages/sdk/chat-provider.zh-CN.md
@@ -8,7 +8,6 @@ subtitle: 数据提供
 description: 发送和接收的数据转换。
 order: 1
 packageName: x-sdk
-tag: 2.0.0
 ---
 
 `Chat Provider` 用于为 `useXChat` 提供统一的请求管理和数据格式转换，目前内置了 `OpenAI` 和 `DeepSeek` 两种模型服务商的 `Chat Provider`，你可以直接使用。

--- a/packages/docs/src/pages/sdk/x-request.en-US.md
+++ b/packages/docs/src/pages/sdk/x-request.en-US.md
@@ -6,8 +6,6 @@ title: XRequest
 subtitle: Request
 description: Universal streaming request utility for AI chat and SSE scenarios.
 order: 1
-tag: 2.0.0
-
 packageName: x-sdk
 ---
 

--- a/packages/docs/src/pages/sdk/x-request.zh-CN.md
+++ b/packages/docs/src/pages/sdk/x-request.zh-CN.md
@@ -6,8 +6,6 @@ title: XRequest
 subtitle: 请求
 description: 通用流式请求工具，适用于 AI 对话与 SSE 场景。
 order: 1
-tag: 2.0.0
-
 packageName: x-sdk
 ---
 

--- a/packages/docs/src/pages/sdk/x-stream.en-US.md
+++ b/packages/docs/src/pages/sdk/x-stream.en-US.md
@@ -6,8 +6,6 @@ title: XStream
 subtitle: Stream
 description: Transform readable data streams.
 order: 2
-tag: 2.0.0
-
 packageName: x-sdk
 ---
 

--- a/packages/docs/src/pages/sdk/x-stream.zh-CN.md
+++ b/packages/docs/src/pages/sdk/x-stream.zh-CN.md
@@ -6,8 +6,6 @@ title: XStream
 subtitle: 流
 description: 转换可读数据流。
 order: 2
-tag: 2.0.0
-
 packageName: x-sdk
 ---
 


### PR DESCRIPTION
## 背景

SDK 文档中「数据提供」（Chat Provider）与「工具」（Utilities）两个分组下的页面 frontmatter 里都带有 `tag: 2.0.0`，该版本标签不应展示在这些页面上，属于误加。

## 改动

移除以下 12 个文件 frontmatter 中的 `tag: 2.0.0` 字段（zh-CN 与 en-US 同步处理）：

- `chat-provider` / `chat-provider-custom` / `chat-provider-open-ai` / `chat-provider-deepseek`（数据提供）
- `x-request` / `x-stream`（工具）

## 验证

- `grep -rn "tag: 2.0.0" packages/docs/src/` 已无任何匹配
- 各文件 frontmatter 结构保持整洁，无残留空行