### PR TITLE
feat(docs): 顶栏右侧按模块动态切换版本

### DIFF
--- a/packages/docs/src/composables/use-header-active.ts
+++ b/packages/docs/src/composables/use-header-active.ts
@@ -1,0 +1,25 @@
+import { computed } from "vue";
+import { useRoute } from "vue-router";
+
+import { type HeaderItem, headerItems } from "@/config/header";
+
+/**
+ * 根据当前路由解析顶栏激活的导航项。
+ *
+ * 不同模块（Components / Markdown / Card / SDK / Skill）对应不同的子包，
+ * 其 `version` 字段用于顶栏右侧的版本切换器展示当前模块版本，
+ * 并为后续多版本列表（versionList）切换做铺垫。
+ */
+export function useActiveHeaderItem() {
+  const route = useRoute();
+
+  const activeItem = computed<HeaderItem | undefined>(() =>
+    headerItems.find(item => route.path.includes(item.basePath)),
+  );
+
+  const activeKey = computed(() => activeItem.value?.key);
+
+  const activeVersion = computed(() => activeItem.value?.version);
+
+  return { activeItem, activeKey, activeVersion };
+}

--- a/packages/docs/src/layouts/docs/components/header-actions.vue
+++ b/packages/docs/src/layouts/docs/components/header-actions.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
 import { GithubOutlined } from "@antdv-next/icons";
 import { createStyles } from "antdv-style";
-import { computed } from "vue";
+import { computed, shallowRef, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
+import { useActiveHeaderItem } from "@/composables/use-header-active";
 import { useLocale } from "@/composables/use-locale";
 import { resolveDocRoutePath } from "@/router/docs";
 import { useAppStore } from "@/stores/app";
@@ -31,6 +32,10 @@ const useStyles = createStyles(({ token, css }) => ({
     align-items: center;
     margin: 0 ${token.margin}px;
   `,
+  versionSelect: css`
+    min-width: 86px;
+    margin-inline-end: ${token.marginXXS}px;
+  `,
   mobile: css`
     width: 100%;
     justify-content: center;
@@ -41,6 +46,19 @@ const useStyles = createStyles(({ token, css }) => ({
 }));
 
 const styleState = useStyles();
+
+const { activeVersion } = useActiveHeaderItem();
+
+// 当前模块对应子包的版本切换，options 暂时只包含当前版本，为后续 versionList 铺垫
+const versionOptions = computed(() =>
+  activeVersion.value
+    ? [{ label: `v${activeVersion.value}`, value: activeVersion.value }]
+    : [],
+);
+const currentVersion = shallowRef<string | undefined>(activeVersion.value);
+watch(activeVersion, next => {
+  currentVersion.value = next;
+});
 
 const localeValue = computed(() => (props.isZhCN ? 1 : 2));
 
@@ -72,6 +90,16 @@ function changeLocale(value: 1 | 2) {
       )
     "
   >
+    <a-select
+      v-if="currentVersion"
+      v-model:value="currentVersion"
+      :options="versionOptions"
+      size="small"
+      variant="filled"
+      :class="styleState.styles.versionSelect"
+      :popup-match-select-width="false"
+    />
+
     <SwitchBtn
       :value="localeValue"
       :tooltip1="t('ui.localeBtn.tooltip1')"

--- a/packages/docs/src/layouts/docs/components/header-actions.vue
+++ b/packages/docs/src/layouts/docs/components/header-actions.vue
@@ -33,7 +33,7 @@ const useStyles = createStyles(({ token, css }) => ({
     margin: 0 ${token.margin}px;
   `,
   versionSelect: css`
-    min-width: 86px;
+    min-width: 70px;
     margin-inline-end: ${token.marginXXS}px;
   `,
   mobile: css`
@@ -96,7 +96,7 @@ function changeLocale(value: 1 | 2) {
       :options="versionOptions"
       size="small"
       variant="filled"
-      :class="styleState.styles.versionSelect"
+      :class="[styleState.styles.versionSelect]"
       :popup-match-select-width="false"
     />
 

--- a/packages/docs/src/layouts/docs/components/header-actions.vue
+++ b/packages/docs/src/layouts/docs/components/header-actions.vue
@@ -52,7 +52,7 @@ const { activeVersion } = useActiveHeaderItem();
 // 当前模块对应子包的版本切换，options 暂时只包含当前版本，为后续 versionList 铺垫
 const versionOptions = computed(() =>
   activeVersion.value
-    ? [{ label: `v${activeVersion.value}`, value: activeVersion.value }]
+    ? [{ label: activeVersion.value, value: activeVersion.value }]
     : [],
 );
 const currentVersion = shallowRef<string | undefined>(activeVersion.value);

--- a/packages/docs/src/layouts/docs/components/header-navigation.vue
+++ b/packages/docs/src/layouts/docs/components/header-navigation.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import { createStyles } from "antdv-style";
-import { computed } from "vue";
 import { useRoute } from "vue-router";
 
 import DocSearch from "@/components/doc-search/index.vue";
+import { useActiveHeaderItem } from "@/composables/use-header-active";
 import { headerItems } from "@/config/header";
 import { resolveDocRoutePath } from "@/router/docs";
 import { clsx } from "@/utils";
@@ -70,40 +70,8 @@ const useStyles = createStyles(({ token, css }) => ({
     color: ${token.colorText} !important;
     font-weight: 500;
   `,
-  item: css`
-    display: inline-flex;
-    flex-direction: column;
-    align-items: center;
-    line-height: 1;
-    position: relative;
-  `,
   itemLabel: css`
     white-space: nowrap;
-  `,
-  versionTag: css`
-    position: absolute;
-    top: calc(100% + 3px);
-    inset-inline-start: 50%;
-    transform: translateX(-50%);
-    margin: 0;
-    font-size: 10px;
-    font-weight: 500;
-    line-height: 14px;
-    color: ${token.colorTextTertiary};
-    transition:
-      color ${token.motionDurationMid},
-      opacity ${token.motionDurationMid};
-
-    a:hover &,
-    &.version-tag-active {
-      color: ${token.colorPrimary};
-    }
-
-    @media only screen and (max-width: 767.99px) {
-      position: static;
-      margin-top: 2px;
-      transform: none;
-    }
   `,
   searchItem: css`
     display: flex;
@@ -113,9 +81,7 @@ const useStyles = createStyles(({ token, css }) => ({
 
 const styleState = useStyles();
 
-const activeKey = computed(
-  () => headerItems.find(item => route.path.includes(item.basePath))?.key,
-);
+const { activeKey } = useActiveHeaderItem();
 
 function getItemPath(path: string) {
   return resolveDocRoutePath(path, props.isZhCN ? "zh-CN" : "en-US") ?? path;
@@ -143,19 +109,8 @@ function getItemPath(path: string) {
       :to="{ path: getItemPath(item.path), query: route.query }"
       :class="clsx(activeKey === item.key && styleState.styles.itemActive)"
     >
-      <span :class="styleState.styles.item">
-        <span :class="styleState.styles.itemLabel">
-          {{ item.label[isZhCN ? "zh-CN" : "en-US"] }}
-        </span>
-        <span
-          v-if="item.version"
-          :class="[
-            styleState.styles.versionTag,
-            activeKey === item.key && 'version-tag-active',
-          ]"
-        >
-          v{{ item.version }}
-        </span>
+      <span :class="styleState.styles.itemLabel">
+        {{ item.label[isZhCN ? "zh-CN" : "en-US"] }}
       </span>
     </router-link>
   </nav>


### PR DESCRIPTION
## 背景

#132 将版本以小标签形式展示在每个顶栏导航项下方。现希望对齐 antdv-next 主站风格，改为顶栏右侧的版本切换器，并且**切换到不同模块时展示该模块对应子包的版本**，同时为后续的多版本列表（versionList）切换做铺垫。

## 改动

### 1. 新增 `useActiveHeaderItem` composable
`packages/docs/src/composables/use-header-active.ts`

按当前路由解析激活的导航项，暴露 `activeItem` / `activeKey` / `activeVersion`，供顶栏导航与右侧版本切换器共用，避免重复计算。

### 2. `header-navigation.vue`
移除 #132 在每个导航项下方渲染的 `versionTag`（含绝对定位样式与移动端响应式），恢复为简洁的横向导航；`activeKey` 改由 composable 提供。

### 3. `header-actions.vue`（右侧动作区）
新增 `a-select` 版本切换器，参考 antdv-next 主站：

- `currentVersion` 跟随激活模块的 `activeVersion` 变化（`watch` 同步），切换模块即自动切换显示的包版本
- 当前模块无版本（研发 / 演示）时自动隐藏（`v-if="currentVersion"`）
- `versionOptions` 暂时只包含当前版本，**为后续 versionList 多版本切换铺垫**（替换为历史版本列表即可生效）
- 样式：`size="small"` `variant="filled"` `min-width: 86px`，对齐主站

## 模块 → 版本映射

| 模块 | 子包 | 版本来源 |
|------|------|----------|
| 组件 | `@antdv-next/x` | `x/package.json` |
| Markdown | `@antdv-next/x-markdown` | `x-markdown/package.json` |
| Card | `@antdv-next/x-card` | `x-card/package.json` |
| SDK | `@antdv-next/x-sdk` | `x-sdk/package.json` |
| Skill | `@antdv-next/x-skill` | `x-skill/package.json` |
| 研发 / 演示 | — | 隐藏切换器 |

版本数据仍由 `config/header.ts` 的 `version` 字段统一维护。

## 验证

- `vp lint` ✅ 0 warnings / 0 errors
- `vp check --fix` ✅ 格式已规范；既有 2 个 `x-markdown/vite.build.config.ts` 类型错误为 main 上已存在（与本 PR 无关，CI 仅跑 `vp test`）
- `vp test` ✅ 43 files / 407 tests passed

## 后续

`versionOptions` 替换为各包的历史版本列表 + 切换跳转逻辑即可完成 versionList 多版本切换。