### PR TITLE
feat(mermaid): expose header slot controls

### DIFF
--- a/packages/docs/src/pages/components/mermaid/demo/custom-header.vue
+++ b/packages/docs/src/pages/components/mermaid/demo/custom-header.vue
@@ -10,12 +10,37 @@ const content = `flowchart LR
 <template>
   <div class="demo-wrapper">
     <ax-mermaid :content="content">
-      <template #header>
+      <template
+        #header="{
+          renderType,
+          setRenderType,
+          zoomIn,
+          zoomOut,
+          resetZoom,
+          download,
+          copy,
+        }"
+      >
         <div class="custom-header">
-          <a-space :size="16">
-            <span class="custom-title">Login Flow</span>
-            <a-button type="primary" size="small">Export</a-button>
-            <a-button size="small">Reset</a-button>
+          <span class="custom-title">Login Flow</span>
+          <a-space>
+            <a-button
+              size="small"
+              @click="setRenderType(renderType === 'image' ? 'code' : 'image')"
+            >
+              {{ renderType === "image" ? "Code" : "Diagram" }}
+            </a-button>
+            <template v-if="renderType === 'image'">
+              <a-button size="small" @click="zoomOut">-</a-button>
+              <a-button size="small" @click="zoomIn">+</a-button>
+              <a-button size="small" @click="resetZoom">Reset</a-button>
+              <a-button type="primary" size="small" @click="download">
+                Download
+              </a-button>
+            </template>
+            <a-button v-else type="primary" size="small" @click="copy">
+              Copy
+            </a-button>
           </a-space>
         </div>
       </template>
@@ -29,6 +54,10 @@ const content = `flowchart LR
 }
 
 .custom-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
   padding: 12px 16px;
   border: 1px solid var(--ant-color-border-secondary, #f0f0f0);
   border-bottom: none;
@@ -43,9 +72,9 @@ const content = `flowchart LR
 </style>
 
 <docs lang="zh-CN">
-自定义头部内容。
+自定义头部内容，并通过插槽作用域复用内置的视图切换、缩放、下载与复制操作。
 </docs>
 
 <docs lang="en-US">
-Customize header content.
+Customize header content and reuse the built-in view switching, zoom, download, and copy actions from the slot scope.
 </docs>

--- a/packages/docs/src/pages/components/mermaid/index.en-US.md
+++ b/packages/docs/src/pages/components/mermaid/index.en-US.md
@@ -33,7 +33,7 @@ group:
 | defaultRenderType    | Initial render type (uncontrolled)                      | `'image' \| 'code'`                                                                                    | `'image'`                                                      |
 | header               | Custom header node, set `null` to hide header           | `VNodeChild \| null`                                                                                   | -                                                              |
 | config               | Mermaid initialize config                               | `MermaidConfig`                                                                                        | -                                                              |
-| actions              | Header action config                                    | `{ enableZoom?: boolean; enableDownload?: boolean; enableCopy?: boolean; customActions?: ItemType[] }` | `{ enableZoom: true, enableDownload: true, enableCopy: true }` |
+| actions              | Default header action config                            | `{ enableZoom?: boolean; enableDownload?: boolean; enableCopy?: boolean; customActions?: ItemType[] }` | `{ enableZoom: true, enableDownload: true, enableCopy: true }` |
 | codeHighlighterProps | Extra props for built-in `CodeHighlighter` in code mode | `Partial<Omit<CodeHighlighterProps, 'content' \| 'language'>>`                                         | -                                                              |
 | classes              | Semantic class overrides                                | `Partial<Record<'root' \| 'header' \| 'graph' \| 'code', string>>`                                     | -                                                              |
 | styles               | Semantic style overrides                                | `Partial<Record<'root' \| 'header' \| 'graph' \| 'code', CSSProperties>>`                              | -                                                              |
@@ -60,11 +60,23 @@ type ItemType = {
 
 ### Slots
 
-| Slot Name | Description        | Type               |
-| --------- | ------------------ | ------------------ |
-| `header`  | Custom header area | `() => VNodeChild` |
+| Slot Name | Description        | Type                                            |
+| --------- | ------------------ | ----------------------------------------------- |
+| `header`  | Custom header area | `(scope: MermaidHeaderSlotScope) => VNodeChild` |
 
-The `header` slot takes precedence over the `header` prop. Passing `header={null}` hides the default header.
+`MermaidHeaderSlotScope` provides the following properties:
+
+| Property      | Description                                  | Type                                |
+| ------------- | -------------------------------------------- | ----------------------------------- |
+| renderType    | Current render type                          | `'image' \| 'code'`                 |
+| setRenderType | Switches the render type                     | `(type: MermaidRenderType) => void` |
+| zoomIn        | Increases the diagram scale in image mode    | `() => void`                        |
+| zoomOut       | Decreases the diagram scale in image mode    | `() => void`                        |
+| resetZoom     | Restores the diagram scale and position      | `() => void`                        |
+| download      | Downloads the diagram as a PNG in image mode | `() => void`                        |
+| copy          | Copies the Mermaid source                    | `() => Promise<void>`               |
+
+The `header` slot takes precedence over the `header` prop. Passing `header={null}` hides the default header. The `actions` prop only configures actions in the default header.
 
 ### Events
 

--- a/packages/docs/src/pages/components/mermaid/index.zh-CN.md
+++ b/packages/docs/src/pages/components/mermaid/index.zh-CN.md
@@ -34,7 +34,7 @@ group:
 | defaultRenderType    | 初始渲染模式（非受控）                      | `'image' \| 'code'`                                                                                    | `'image'`                                                      |
 | header               | 自定义头部内容，传 `null` 可隐藏头部        | `VNodeChild \| null`                                                                                   | -                                                              |
 | config               | Mermaid 初始化配置                          | `MermaidConfig`                                                                                        | -                                                              |
-| actions              | 头部操作配置                                | `{ enableZoom?: boolean; enableDownload?: boolean; enableCopy?: boolean; customActions?: ItemType[] }` | `{ enableZoom: true, enableDownload: true, enableCopy: true }` |
+| actions              | 默认头部操作配置                            | `{ enableZoom?: boolean; enableDownload?: boolean; enableCopy?: boolean; customActions?: ItemType[] }` | `{ enableZoom: true, enableDownload: true, enableCopy: true }` |
 | codeHighlighterProps | 代码模式下内置 `CodeHighlighter` 的额外参数 | `Partial<Omit<CodeHighlighterProps, 'content' \| 'language'>>`                                         | -                                                              |
 | classes              | 语义化类名覆写                              | `Partial<Record<'root' \| 'header' \| 'graph' \| 'code', string>>`                                     | -                                                              |
 | styles               | 语义化样式覆写                              | `Partial<Record<'root' \| 'header' \| 'graph' \| 'code', CSSProperties>>`                              | -                                                              |
@@ -61,11 +61,23 @@ type ItemType = {
 
 ### 插槽
 
-| 插槽名   | 说明         | 类型               |
-| -------- | ------------ | ------------------ |
-| `header` | 自定义头部区 | `() => VNodeChild` |
+| 插槽名   | 说明         | 类型                                            |
+| -------- | ------------ | ----------------------------------------------- |
+| `header` | 自定义头部区 | `(scope: MermaidHeaderSlotScope) => VNodeChild` |
 
-`header` 插槽优先级高于 `header` 属性；传入 `header={null}` 时可隐藏默认头部。
+`MermaidHeaderSlotScope` 提供以下属性：
+
+| 属性          | 说明                      | 类型                                |
+| ------------- | ------------------------- | ----------------------------------- |
+| renderType    | 当前渲染模式              | `'image' \| 'code'`                 |
+| setRenderType | 切换渲染模式              | `(type: MermaidRenderType) => void` |
+| zoomIn        | 在图形模式下放大          | `() => void`                        |
+| zoomOut       | 在图形模式下缩小          | `() => void`                        |
+| resetZoom     | 还原图形缩放比例与位置    | `() => void`                        |
+| download      | 在图形模式下下载 PNG 图表 | `() => void`                        |
+| copy          | 复制 Mermaid 源码         | `() => Promise<void>`               |
+
+`header` 插槽优先级高于 `header` 属性；传入 `header={null}` 时可隐藏默认头部。`actions` 属性仅配置默认头部中的操作。
 
 ### 事件
 

--- a/packages/x/components/mermaid/Mermaid.tsx
+++ b/packages/x/components/mermaid/Mermaid.tsx
@@ -72,11 +72,21 @@ export interface MermaidRef {
   nativeElement: HTMLDivElement;
 }
 
+export interface MermaidHeaderSlotScope {
+  renderType: MermaidRenderType;
+  setRenderType: (type: MermaidRenderType) => void;
+  zoomIn: () => void;
+  zoomOut: () => void;
+  resetZoom: () => void;
+  download: () => void;
+  copy: () => Promise<void>;
+}
+
 export interface MermaidSlots {
   /**
    * 自定义头部区，优先级高于 `header` 属性
    */
-  header?: () => VNodeChild;
+  header?: (scope: MermaidHeaderSlotScope) => VNodeChild;
 }
 
 enum RenderType {
@@ -339,19 +349,32 @@ const XMermaid = defineComponent({
     }
 
     function handleZoomIn() {
+      if (mergedRenderType.value !== RenderType.Image) return;
       scale.value = Math.min(scale.value + 0.2, 3);
     }
 
     function handleZoomOut() {
+      if (mergedRenderType.value !== RenderType.Image) return;
       scale.value = Math.max(scale.value - 0.2, 0.5);
     }
 
     function handleReset() {
+      if (mergedRenderType.value !== RenderType.Image) return;
       scale.value = 1;
       position.value = { x: 0, y: 0 };
     }
 
+    async function handleCopy() {
+      try {
+        await navigator.clipboard.writeText(props.content);
+      } catch (error) {
+        warning(false, "Mermaid", `Copy failed: ${String(error)}`);
+      }
+    }
+
     function handleDownload() {
+      if (mergedRenderType.value !== RenderType.Image) return;
+
       const svgElement = graphRef.value?.querySelector(
         "svg",
       ) as SVGSVGElement | null;
@@ -437,7 +460,17 @@ const XMermaid = defineComponent({
 
     function renderHeader() {
       if (props.header === null) return null;
-      if (slots.header) return slots.header();
+      if (slots.header) {
+        return slots.header({
+          renderType: mergedRenderType.value,
+          setRenderType: switchRenderType,
+          zoomIn: handleZoomIn,
+          zoomOut: handleZoomOut,
+          resetZoom: handleReset,
+          download: handleDownload,
+          copy: handleCopy,
+        });
+      }
       if (props.header !== undefined) return props.header;
 
       return (

--- a/packages/x/components/mermaid/__tests__/index.test.tsx
+++ b/packages/x/components/mermaid/__tests__/index.test.tsx
@@ -2,7 +2,7 @@ import { mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vite-plus/test";
 import { nextTick } from "vue";
 
-import Mermaid from "../Mermaid";
+import Mermaid, { type MermaidHeaderSlotScope } from "../Mermaid";
 
 const mermaidMock = vi.hoisted(() => ({
   initialize: vi.fn(),
@@ -131,6 +131,54 @@ describe("Mermaid", () => {
 
     expect(wrapper.find(".slot-header").exists()).toBe(true);
     expect(wrapper.find(".prop-header").exists()).toBe(false);
+  });
+
+  it("exposes diagram controls through the header slot scope", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, {
+      clipboard: { writeText },
+    });
+
+    const wrapper = mount(Mermaid, {
+      props: {
+        content,
+      },
+      slots: {
+        header: (scope: MermaidHeaderSlotScope) => (
+          <div class="slot-header">
+            <span class="slot-render-type">{scope.renderType}</span>
+            <button class="slot-zoom-in" onClick={scope.zoomIn} />
+            <button class="slot-reset-zoom" onClick={scope.resetZoom} />
+            <button
+              class="slot-set-code"
+              onClick={() => scope.setRenderType("code")}
+            />
+            <button class="slot-download" onClick={scope.download} />
+            <button class="slot-copy" onClick={scope.copy} />
+          </div>
+        ),
+      },
+    });
+
+    await flushPromises();
+
+    await wrapper.find(".slot-zoom-in").trigger("click");
+    await nextTick();
+    const svgEl = wrapper.find(".antd-mermaid-graph svg").element as SVGElement;
+    expect(readScale(svgEl.style.transform)).toBe(1.2);
+
+    await wrapper.find(".slot-reset-zoom").trigger("click");
+    await nextTick();
+    expect(readScale(svgEl.style.transform)).toBe(1);
+
+    await wrapper.find(".slot-set-code").trigger("click");
+    await nextTick();
+    expect(wrapper.find(".slot-render-type").text()).toBe("code");
+    expect(wrapper.emitted("update:renderType")?.[0]).toEqual(["code"]);
+
+    await wrapper.find(".slot-copy").trigger("click");
+    expect(writeText).toHaveBeenCalledWith(content);
+    expect(wrapper.find(".slot-download").exists()).toBe(true);
   });
 
   it("clamps zoom scale between 0.5 and 3", async () => {

--- a/packages/x/components/mermaid/index.tsx
+++ b/packages/x/components/mermaid/index.tsx
@@ -2,6 +2,7 @@ import Mermaid from "./Mermaid";
 
 export type {
   MermaidActions,
+  MermaidHeaderSlotScope,
   MermaidProps,
   MermaidRef,
   MermaidRenderType,


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [x] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [x] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

N/A

### 💡 Background and Solution

Custom Mermaid headers fully replace the default controls, leaving custom header implementations unable to reuse render-type switching, zooming, reset, download, or source-copy behavior.

Expose a typed `MermaidHeaderSlotScope` to the `header` slot with `renderType`, `setRenderType`, `zoomIn`, `zoomOut`, `resetZoom`, `download`, and `copy`. The existing default header remains unchanged, and image-only controls are no-ops in code mode.

The custom header demo now uses the slot scope, and the API documentation describes the full contract in English and Chinese.

### 📝 Change Log

| Language   | Changelog                                                                        |
| ---------- | -------------------------------------------------------------------------------- |
| 🇺🇸 English | Mermaid: expose built-in controls through the `header` slot scope.              |
| 🇨🇳 Chinese | Mermaid：通过 `header` 插槽作用域暴露内置操作能力。                              |
