### PR TITLE
fix(sender): suppress borderless focus outline

### DIFF
--- a/packages/x/components/sender/style/index.ts
+++ b/packages/x/components/sender/style/index.ts
@@ -85,6 +85,12 @@ const genSenderStyle: GenerateStyle<SenderToken> = token => {
         alignSelf: "center",
         caretColor: token.colorPrimary,
         fontSize: token.fontSize,
+        [`&${antCls}-input-borderless`]: {
+          "&:focus-visible, &:has(input:focus-visible), &:has(textarea:focus-visible)":
+            {
+              outline: "none",
+            },
+        },
       },
       [`${componentCls}-actions-list`]: {
         flex: "none",

--- a/packages/x/components/sender/style/slot-textarea.ts
+++ b/packages/x/components/sender/style/slot-textarea.ts
@@ -7,6 +7,7 @@ const genSlotTextAreaStyle: GenerateStyle<SenderToken> = token => {
   const { componentCls, antCls, calc } = token;
   const slotCls = `${componentCls}-slot`;
   const antInputCls = `${antCls}-input`;
+  const antInputBorderlessCls = `${antInputCls}-borderless`;
   const antDropdownCls = `${antCls}-dropdown-trigger`;
   const slotInputCls = `${componentCls}-slot-input`;
   const slotSelectCls = `${componentCls}-slot-select`;
@@ -48,6 +49,12 @@ const genSlotTextAreaStyle: GenerateStyle<SenderToken> = token => {
         fontSize: "inherit",
         lineHeight: "inherit",
         position: "relative",
+        [`&${antInputBorderlessCls}`]: {
+          "&:focus-visible, &:has(input:focus-visible), &:has(textarea:focus-visible)":
+            {
+              outline: "none",
+            },
+        },
         [`&::placeholder`]: {
           color: token.colorTextSlotPlaceholder,
           fontSize: "inherit",


### PR DESCRIPTION
### 背景

Sender 内部使用 antd 的 `Input.TextArea` 和词槽 `Input`，并统一设置为 `variant="borderless"`。antd 为 borderless 输入类组件补充了 focus-visible outline 后，Sender 内部输入在聚焦时会出现一条蓝色内部描边，和 Sender 本身独立的容器、阴影和输入区域视觉不一致。

### 修改

- 在 Sender 主输入 `.ant-sender-input.ant-input-borderless` 范围内去掉 antd 新增的 focus outline
- 在 Sender 词槽输入 `.ant-sender-slot-input.ant-input-borderless` 范围内同步去掉该 focus outline
- 覆盖只限定在 Sender 私有 class 下，不影响项目中其他 antd borderless 输入组件

### 影响

恢复 Sender 现有视觉表现，避免 antd borderless focus outline 穿透到 Sender 内部输入区域。普通 antd Input/Select 等 borderless 场景仍保留 antd 侧的无障碍焦点样式。

### 验证

- `vp lint` / `vp fmt` / `type-check` 通过
- `vp test packages/x/components/sender` 全部 43 个用例通过

Resolves #136