### PR TITLE
feat(docs): 配置国内镜像站 x.antdv-next.cn 自动跳转

### DIFF
--- a/packages/docs/src/components/geo-redirect-handler.vue
+++ b/packages/docs/src/components/geo-redirect-handler.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import { onMounted } from "vue";
+
+import { useAppContext } from "@/composables/use-app-context";
+import { useLocale } from "@/composables/use-locale";
+import {
+  getChinaMainlandRedirectDecision,
+  redirectToCnSite,
+  setGeoRedirectPreference,
+} from "@/utils/geo-redirect";
+
+defineOptions({
+  name: "GeoRedirectHandler",
+});
+
+const { modal } = useAppContext();
+const { t } = useLocale();
+
+async function handleGeoRedirect() {
+  const decision = await getChinaMainlandRedirectDecision();
+
+  if (decision === "redirect") {
+    redirectToCnSite();
+    return;
+  }
+
+  if (decision !== "prompt") {
+    return;
+  }
+
+  const confirmed = await modal.confirm({
+    title: t("ui.geoRedirect.title"),
+    content: t("ui.geoRedirect.content"),
+    okText: t("ui.geoRedirect.okText"),
+    cancelText: t("ui.geoRedirect.cancelText"),
+  });
+
+  if (confirmed) {
+    setGeoRedirectPreference("accepted");
+    redirectToCnSite();
+    return;
+  }
+
+  setGeoRedirectPreference("rejected");
+}
+
+onMounted(() => {
+  // 延迟一帧执行，避免阻塞首次渲染；geo-redirect 仅依赖 window.location，无需等待路由就绪。
+  window.setTimeout(() => {
+    void handleGeoRedirect();
+  }, 0);
+});
+</script>
+
+<template>
+  <slot />
+</template>

--- a/packages/docs/src/components/providers/app-provider.vue
+++ b/packages/docs/src/components/providers/app-provider.vue
@@ -4,6 +4,7 @@ import type { Locale } from "antdv-next/locale/index";
 import { ThemeProvider } from "antdv-style";
 import dayjs from "dayjs";
 
+import GeoRedirectHandler from "@/components/geo-redirect-handler.vue";
 import { useCodeCopy } from "@/composables/use-code-copy";
 import { useProviderTheme } from "@/composables/use-provider-theme";
 import { useResolvedDarkMode } from "@/composables/use-resolved-dark-mode";
@@ -48,7 +49,9 @@ watch(
       <ThemeProvider :theme-mode="themeMode">
         <a-app>
           <AppContextRegister>
-            <slot />
+            <GeoRedirectHandler>
+              <slot />
+            </GeoRedirectHandler>
           </AppContextRegister>
         </a-app>
       </ThemeProvider>

--- a/packages/docs/src/locales/en-US/index.ts
+++ b/packages/docs/src/locales/en-US/index.ts
@@ -25,6 +25,13 @@ export default {
         blog: "Blog",
       },
     },
+    geoRedirect: {
+      title: "Use China optimized site?",
+      content:
+        "We detected you are visiting from China. Would you like to switch to the China-optimized channel on x.antdv-next.cn?",
+      okText: "Switch Now",
+      cancelText: "Stay Here",
+    },
   },
   components: {
     semanticPreview: {

--- a/packages/docs/src/locales/zh-CN/index.ts
+++ b/packages/docs/src/locales/zh-CN/index.ts
@@ -25,6 +25,13 @@ export default {
         blog: "博客",
       },
     },
+    geoRedirect: {
+      title: "访问国内优化通道",
+      content:
+        "检测到你正在中国访问，是否切换到 x.antdv-next.cn 国内优化通道？",
+      okText: "立即切换",
+      cancelText: "继续访问当前站点",
+    },
   },
   components: {
     semanticPreview: {

--- a/packages/docs/src/utils/geo-redirect.ts
+++ b/packages/docs/src/utils/geo-redirect.ts
@@ -1,0 +1,131 @@
+interface IpAddrResponse {
+  code?: number;
+  message?: string;
+  data?: {
+    from?: string;
+    ip?: string;
+  };
+}
+
+const CN_SITE_ORIGIN = "https://x.antdv-next.cn";
+const GEO_IP_API_URL = "https://v4_dx.boce.com:44433/ipaddr";
+const GEO_IP_TIMEOUT = 1200;
+const GEO_REDIRECT_PREFERENCE_KEY = "cn-site-redirect-preference";
+
+export type GeoRedirectPreference = "accepted" | "rejected";
+export type GeoRedirectDecision = "redirect" | "prompt" | "skip";
+
+function isComHost(hostname: string): boolean {
+  const normalizedHostname = hostname.trim().toLowerCase().replace(/\.$/, "");
+
+  return (
+    normalizedHostname === "x.antdv-next.com" ||
+    normalizedHostname === "www.x.antdv-next.com"
+  );
+}
+
+function isChinaMainlandVisit(from: string | undefined): boolean {
+  if (!from) {
+    return false;
+  }
+
+  return from === "中国" || from.startsWith("中国/");
+}
+
+export function getGeoRedirectPreference(): GeoRedirectPreference | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const preference = window.localStorage.getItem(GEO_REDIRECT_PREFERENCE_KEY);
+
+  return preference === "accepted" || preference === "rejected"
+    ? preference
+    : null;
+}
+
+export function setGeoRedirectPreference(
+  preference: GeoRedirectPreference,
+): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  window.localStorage.setItem(GEO_REDIRECT_PREFERENCE_KEY, preference);
+}
+
+export function buildCnRedirectUrl(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const { location } = window;
+
+  if (
+    !isComHost(location.hostname) ||
+    location.pathname.startsWith("/~demos")
+  ) {
+    return null;
+  }
+
+  // .com 与 .cn 部署相同产物、路由规则一致（zh-CN 默认无后缀，en-US 使用 -en 后缀），
+  // 因此跳转时仅替换站点 origin，保持当前 pathname/search/hash，以尊重用户当前的语言选择。
+  const targetUrl = new URL(CN_SITE_ORIGIN);
+  targetUrl.pathname = location.pathname;
+  targetUrl.search = location.search;
+  targetUrl.hash = location.hash;
+
+  return targetUrl.href === location.href ? null : targetUrl.href;
+}
+
+export function redirectToCnSite(): void {
+  const targetUrl = buildCnRedirectUrl();
+
+  if (targetUrl) {
+    window.location.replace(targetUrl);
+  }
+}
+
+export async function getChinaMainlandRedirectDecision(): Promise<GeoRedirectDecision> {
+  if (typeof window === "undefined") {
+    return "skip";
+  }
+
+  const targetUrl = buildCnRedirectUrl();
+
+  if (!targetUrl) {
+    return "skip";
+  }
+
+  const preference = getGeoRedirectPreference();
+
+  if (preference === "accepted") {
+    return "redirect";
+  }
+
+  if (preference === "rejected") {
+    return "skip";
+  }
+
+  const controller = new AbortController();
+  const timeoutId = window.setTimeout(() => controller.abort(), GEO_IP_TIMEOUT);
+
+  try {
+    const response = await fetch(GEO_IP_API_URL, {
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      return "skip";
+    }
+
+    const result = (await response.json()) as IpAddrResponse;
+
+    return isChinaMainlandVisit(result.data?.from) ? "prompt" : "skip";
+  } catch {
+    // Ignore network and CORS failures to avoid blocking normal page usage.
+    return "skip";
+  } finally {
+    window.clearTimeout(timeoutId);
+  }
+}


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [x] 🆕 新功能
- [x] 🌐 国际化

### 🔗 相关 Issue

> 参考上游 antdv-next 主站镜像站实现，为 antdv-next-x 站点配置国内镜像 `x.antdv-next.cn`。

### 💡 背景与方案

#### 背景

主站 antdv-next 已具备国内镜像站（www.antdv-next.cn）能力：访问 `.com` 时检测中国大陆用户并提示跳转 `.cn`。antdv-next-x 站点（x.antdv-next.com）尚未配置国内镜像，国内访问体验欠佳。本次为 antdv-next-x 配置国内镜像站 `https://x.antdv-next.cn`。

#### 方案

参考主站 `docs/src/utils/geo-redirect.ts` 实现并适配当前项目：

1. **检测与跳转**（`utils/geo-redirect.ts`）：访问 `x.antdv-next.com` 时，通过 `v4_dx.boce.com` IP 接口（1.2s 超时）检测地理位置；若为中国大陆且用户未做过选择，返回 `prompt` 决策；用户曾选「切换」则自动跳转（`redirect`），曾选「留下」则跳过（`skip`）。网络/CORS 失败静默放行，不阻塞正常使用。
2. **弹窗确认**（`components/geo-redirect-handler.vue`）：在 `app-provider` 内接入，`onMounted` 延迟一帧调用，用项目统一的 `useAppContext().modal` 弹窗确认，选择结果写入 `localStorage`（`cn-site-redirect-preference`）。
3. **文案**：locales 补充 `ui.geoRedirect` 中英文。

#### 与主站实现的适配差异

- **域名**：`CN_SITE_ORIGIN = https://x.antdv-next.cn`，`isComHost` 判断 `x.antdv-next.com` / `www.x.antdv-next.com`。
- **路径处理**：主站 en-US 默认、zh-CN 用 `-cn` 后缀，故用 `toCnPathname` 强制转中文；**本项目 zh-CN 默认无后缀、en-US 用 `-en` 后缀**，且 `.com`/`.cn` 部署相同产物、路由规则一致，因此跳转时**仅替换 origin、保持 pathname/search/hash**，尊重用户当前语言选择（无需 `toCnPathname`）。
- **Modal**：用本项目统一的 `useAppContext().modal`，而非 `Modal.useModal()`。

#### CI

`.github/workflows/deploy.yml` 的 `deploy-cn` job 已就绪（使用 `DEPLOY_HOST_CN` 等 secrets），无需改动。

### 📝 变更日志

| 语言    | 变更日志 |
| ------- | -------- |
| 🇺🇸 英文 | Add China mirror site `x.antdv-next.cn` geo-redirect: visitors on `x.antdv-next.com` detected from mainland China are prompted to switch to the China-optimized mirror. |
| 🇨🇳 中文 | 新增国内镜像站 `x.antdv-next.cn` 地理位置跳转：访问 `x.antdv-next.com` 时检测到中国大陆访问会提示切换到国内优化通道。 |
