### PR TITLE
refactor(docs): use Flex for sender agent file label

### DIFF
--- a/packages/docs/src/pages/components/sender/demo/agent.vue
+++ b/packages/docs/src/pages/components/sender/demo/agent.vue
@@ -13,7 +13,7 @@ import {
   ProfileOutlined,
   SearchOutlined,
 } from "@antdv-next/icons";
-import { App } from "antdv-next";
+import { App, Flex } from "antdv-next";
 import { h, ref, useTemplateRef, watch } from "vue";
 const { message } = App.useApp();
 
@@ -241,7 +241,7 @@ const fileItemClick = (item: { key: string }, type?: string) => {
       type: "tag",
       key: `${item.key}_${Date.now()}`,
       props: {
-        label: h("div", { style: { display: "flex", gap: "8px" } }, [
+        label: h(Flex, { gap: 8, style: { display: "inline-flex" } }, () => [
           h(icon),
           label,
         ]),


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [x] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

N/A

### 💡 Background and Solution

The Sender agent demo manually created a `div` with flex styles for inserted file tag labels. Use the `Flex` component instead so the demo follows the component library's layout conventions, while preserving inline layout through `display: inline-flex`.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Use `Flex` for file tag labels in the Sender agent demo. |
| 🇨🇳 Chinese | Sender Agent 示例中的文件标签改用 `Flex` 布局。 |
