### PR TITLE
style(docs): add dividers to overview search

### DIFF
--- a/packages/docs/src/components/component-overview/index.vue
+++ b/packages/docs/src/components/component-overview/index.vue
@@ -179,6 +179,7 @@ function handleAffixChange(affixed?: boolean) {
 
 <template>
   <section class="component-overview" :class="styleState.styles.root">
+    <a-divider />
     <a-affix :offset-top="80" @change="handleAffixChange">
       <div
         class="component-overview-search-affix"
@@ -198,6 +199,7 @@ function handleAffixChange(affixed?: boolean) {
         </a-input>
       </div>
     </a-affix>
+    <a-divider />
 
     <template v-if="groupedItems.length">
       <section


### PR DESCRIPTION
[English template / 英文模板](./PULL_REQUEST_TEMPLATE.md)

### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [ ] 🐞 Bug 修复
- [x] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [x] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

无。

### 💡 背景与方案

组件总览页的搜索区域缺少上下分隔线，与主组件站的展示不一致。

在搜索栏的 Affix 区域前后增加 Divider，使非吸顶状态下的视觉层级更清晰，同时保留现有筛选、暗色模式和吸顶样式。

验证：

- 单文件 vp check 通过
- vp test 通过（43 个测试文件，408 项测试）

### 📝 变更日志

| 语言 | 变更日志 |
| --- | --- |
| 🇺🇸 英文 | Add top and bottom dividers to the component overview search area. |
| 🇨🇳 中文 | 为组件总览搜索区域增加上下分隔线。 |