### PR TITLE
refactor(code-highlighter): builtin language whitelist + setupCodeHighlighter DI loader

### DIFF
--- a/packages/docs/src/pages/components/code-highlighter/demo/basic.vue
+++ b/packages/docs/src/pages/components/code-highlighter/demo/basic.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const code = `function greet(name: string) {
+const typescriptCode = `function greet(name: string) {
   console.log(\`Hello, \${name}!\`);
   return {
     message: \`Welcome, \${name}\`,
@@ -7,19 +7,29 @@ const code = `function greet(name: string) {
   };
 }
 
-// Call the function
 const result = greet("World");
 console.log(result);`;
+
+const goCode = `package main
+
+import "fmt"
+
+func main() {
+  fmt.Println("Hello from Go")
+}`;
 </script>
 
 <template>
-  <ax-code-highlighter :content="code" language="typescript" />
+  <a-flex vertical :gap="16">
+    <ax-code-highlighter :content="typescriptCode" language="typescript" />
+    <ax-code-highlighter :content="goCode" language="go" />
+  </a-flex>
 </template>
 
 <docs lang="zh-CN">
-基础用法，展示代码高亮组件的基本功能。
+基础用法，展示 TypeScript 与按需加载的 Go 代码高亮。
 </docs>
 
 <docs lang="en-US">
-Basic usage of the code highlighter component.
+Basic usage with TypeScript and lazily loaded Go syntax highlighting.
 </docs>

--- a/packages/docs/src/pages/components/code-highlighter/demo/basic.vue
+++ b/packages/docs/src/pages/components/code-highlighter/demo/basic.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const typescriptCode = `function greet(name: string) {
+const code = `function greet(name: string) {
   console.log(\`Hello, \${name}!\`);
   return {
     message: \`Welcome, \${name}\`,
@@ -7,29 +7,19 @@ const typescriptCode = `function greet(name: string) {
   };
 }
 
+// Call the function
 const result = greet("World");
 console.log(result);`;
-
-const goCode = `package main
-
-import "fmt"
-
-func main() {
-  fmt.Println("Hello from Go")
-}`;
 </script>
 
 <template>
-  <a-flex vertical :gap="16">
-    <ax-code-highlighter :content="typescriptCode" language="typescript" />
-    <ax-code-highlighter :content="goCode" language="go" />
-  </a-flex>
+  <ax-code-highlighter :content="code" language="typescript" />
 </template>
 
 <docs lang="zh-CN">
-基础用法，展示 TypeScript 与按需加载的 Go 代码高亮。
+基础用法，展示代码高亮组件的基本功能。
 </docs>
 
 <docs lang="en-US">
-Basic usage with TypeScript and lazily loaded Go syntax highlighting.
+Basic usage of the code highlighter component.
 </docs>

--- a/packages/docs/src/pages/components/code-highlighter/demo/lazy-language.vue
+++ b/packages/docs/src/pages/components/code-highlighter/demo/lazy-language.vue
@@ -12,23 +12,15 @@ const snippets = {
 const result = greet("World");
 console.log(result);`,
   },
-  go: {
-    label: "Go",
-    code: `package main
+  javascript: {
+    label: "JavaScript",
+    code: `function greet(name) {
+  console.log(\`Hello, \${name}!\`);
+  return { message: \`Welcome, \${name}\`, timestamp: Date.now() };
+}
 
-import "fmt"
-
-func main() {
-  fmt.Println("Hello from Go")
-}`,
-  },
-  rust: {
-    label: "Rust",
-    code: `fn main() {
-    let numbers = vec![1, 2, 3, 4, 5];
-    let sum: i32 = numbers.iter().sum();
-    println!("Sum: {}", sum);
-}`,
+const result = greet("World");
+console.log(result);`,
   },
   python: {
     label: "Python",
@@ -39,11 +31,37 @@ func main() {
 
 print([fibonacci(i) for i in range(10)])`,
   },
-  bash: {
-    label: "Bash",
-    code: `#!/bin/bash
-count=$(ls *.txt 2>/dev/null | wc -l)
-echo "Found $count text files"`,
+  json: {
+    label: "JSON",
+    code: `{
+  "name": "antdv-next",
+  "version": "1.1.3",
+  "dependencies": {
+    "vue": "^3.5.0",
+    "antdv-next": "catalog:latest"
+  }
+}`,
+  },
+  html: {
+    label: "HTML",
+    code: `<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <h1 id="title">Hello World</h1>
+    <button onclick="alert('hi')">Click</button>
+  </body>
+</html>`,
+  },
+  css: {
+    label: "CSS",
+    code: `.card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 8px;
+  color: var(--text-color);
+}`,
   },
 } as const;
 
@@ -52,7 +70,7 @@ const options = [
   { value: "text", label: "Plain Text" },
 ];
 
-const language = ref<string>("go");
+const language = ref<string>("typescript");
 
 const current = computed(() => {
   if (language.value === "text") {
@@ -74,9 +92,9 @@ const current = computed(() => {
 </template>
 
 <docs lang="zh-CN">
-组件根据 `language` 按需加载 Shiki 内置语言及其官方别名（如 `go`、`rust`、`rs`、`c++`），切换语言时自动加载对应语法；无法识别的语言会安全降级为纯文本显示。
+组件内置 `typescript`、`javascript`、`python`、`json`、`html`、`css` 六种常用语言，切换时按需加载对应语法；其他语言可通过 `setupCodeHighlighter` 注入自定义加载器扩展。
 </docs>
 
 <docs lang="en-US">
-The component loads bundled Shiki languages and their official aliases (e.g. `go`, `rust`, `rs`, `c++`) on demand based on `language`. Switching languages automatically loads the matching grammar, while unrecognized languages safely fall back to plain text.
+The component ships with six built-in languages: `typescript`, `javascript`, `python`, `json`, `html`, and `css`, loading each grammar on demand. Additional languages can be added via `setupCodeHighlighter`.
 </docs>

--- a/packages/docs/src/pages/components/code-highlighter/demo/lazy-language.vue
+++ b/packages/docs/src/pages/components/code-highlighter/demo/lazy-language.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+
+const snippets = {
+  typescript: {
+    label: "TypeScript",
+    code: `function greet(name: string) {
+  console.log(\`Hello, \${name}!\`);
+  return { message: \`Welcome, \${name}\`, timestamp: Date.now() };
+}
+
+const result = greet("World");
+console.log(result);`,
+  },
+  go: {
+    label: "Go",
+    code: `package main
+
+import "fmt"
+
+func main() {
+  fmt.Println("Hello from Go")
+}`,
+  },
+  rust: {
+    label: "Rust",
+    code: `fn main() {
+    let numbers = vec![1, 2, 3, 4, 5];
+    let sum: i32 = numbers.iter().sum();
+    println!("Sum: {}", sum);
+}`,
+  },
+  python: {
+    label: "Python",
+    code: `def fibonacci(n):
+    if n <= 1:
+        return n
+    return fibonacci(n - 1) + fibonacci(n - 2)
+
+print([fibonacci(i) for i in range(10)])`,
+  },
+  bash: {
+    label: "Bash",
+    code: `#!/bin/bash
+count=$(ls *.txt 2>/dev/null | wc -l)
+echo "Found $count text files"`,
+  },
+} as const;
+
+const options = [
+  ...Object.entries(snippets).map(([value, { label }]) => ({ value, label })),
+  { value: "text", label: "Plain Text" },
+];
+
+const language = ref<string>("go");
+
+const current = computed(() => {
+  if (language.value === "text") {
+    return {
+      code: "This is plain text without a recognized grammar, so no syntax highlighting is applied.",
+      language: "text",
+    };
+  }
+  const key = language.value as keyof typeof snippets;
+  return { code: snippets[key].code, language: key };
+});
+</script>
+
+<template>
+  <a-flex vertical :gap="16">
+    <a-segmented v-model:value="language" :options="options" />
+    <ax-code-highlighter :content="current.code" :language="current.language" />
+  </a-flex>
+</template>
+
+<docs lang="zh-CN">
+组件根据 `language` 按需加载 Shiki 内置语言及其官方别名（如 `go`、`rust`、`rs`、`c++`），切换语言时自动加载对应语法；无法识别的语言会安全降级为纯文本显示。
+</docs>
+
+<docs lang="en-US">
+The component loads bundled Shiki languages and their official aliases (e.g. `go`, `rust`, `rs`, `c++`) on demand based on `language`. Switching languages automatically loads the matching grammar, while unrecognized languages safely fall back to plain text.
+</docs>

--- a/packages/docs/src/pages/components/code-highlighter/index.en-US.md
+++ b/packages/docs/src/pages/components/code-highlighter/index.en-US.md
@@ -18,6 +18,8 @@ The component loads bundled Shiki languages and their official aliases on demand
 
 <demo src="./demo/basic.vue">Basic Usage</demo>
 
+<demo src="./demo/lazy-language.vue">Lazy Language Loading</demo>
+
 <demo src="./demo/theme.vue">Theme Switching</demo>
 
 <demo src="./demo/line-numbers.vue">Line Numbers</demo>

--- a/packages/docs/src/pages/components/code-highlighter/index.en-US.md
+++ b/packages/docs/src/pages/components/code-highlighter/index.en-US.md
@@ -12,7 +12,22 @@ description: Display code blocks in AI conversation scenarios with syntax highli
 
 ## Language Support
 
-The component loads bundled Shiki languages and their official aliases on demand based on `language`, including `go`, `rust`, `rs`, and `c++`. Unknown languages safely fall back to plain text.
+The component ships with six built-in languages loaded on demand: `typescript` (`ts`), `javascript` (`js`), `python` (`py`), `json`, `html`, and `css`. Other languages safely fall back to plain text.
+
+To support more languages, inject a custom loader via `setupCodeHighlighter` — backed by Shiki's full `bundledLanguages`, a CDN, or any other source:
+
+```ts
+import { bundledLanguages } from "shiki/langs";
+import { setupCodeHighlighter } from "@antdv-next/x";
+
+// Load every bundled Shiki language
+setupCodeHighlighter({
+  loadLanguage: async lang => {
+    const loader = bundledLanguages[lang as keyof typeof bundledLanguages];
+    return loader ? (await loader()).default : null;
+  },
+});
+```
 
 ## Examples
 
@@ -75,6 +90,14 @@ When the `header` slot is provided, it fully replaces the default header (langua
 | Property      | Description            | Type             |
 | ------------- | ---------------------- | ---------------- |
 | nativeElement | Get native DOM element | `HTMLDivElement` |
+
+### Extending Languages
+
+| Function             | Description                                                               | Params                                                     |
+| -------------------- | ------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| setupCodeHighlighter | Inject a custom language loader, overriding the default builtin whitelist | `{ loadLanguage: (lang: string) => Promise<any \| null> }` |
+
+`loadLanguage` receives the language name and returns a Shiki language registration or `null` (falls back to plain text).
 
 ## Semantic DOM
 

--- a/packages/docs/src/pages/components/code-highlighter/index.en-US.md
+++ b/packages/docs/src/pages/components/code-highlighter/index.en-US.md
@@ -10,6 +10,10 @@ description: Display code blocks in AI conversation scenarios with syntax highli
 - Code examples in technical documentation
 - Code snippets in chat messages
 
+## Language Support
+
+The component loads bundled Shiki languages and their official aliases on demand based on `language`, including `go`, `rust`, `rs`, and `c++`. Unknown languages safely fall back to plain text.
+
 ## Examples
 
 <demo src="./demo/basic.vue">Basic Usage</demo>
@@ -26,18 +30,18 @@ description: Display code blocks in AI conversation scenarios with syntax highli
 
 ### Props
 
-| Property        | Description                         | Type                                                                                         | Default   |
-| --------------- | ----------------------------------- | -------------------------------------------------------------------------------------------- | --------- |
-| content         | Code content                        | `string`                                                                                     | -         |
-| language        | Code language                       | `string`                                                                                     | `'text'`  |
-| showLineNumbers | Whether to show line numbers        | `boolean`                                                                                    | `true`    |
-| showLanguage    | Whether to show language label      | `boolean`                                                                                    | `true`    |
-| showThemeToggle | Whether to show theme toggle button | `boolean`                                                                                    | `false`   |
-| showCopyButton  | Whether to show copy button         | `boolean`                                                                                    | `true`    |
-| theme           | Theme mode                          | `'light' \| 'dark'`                                                                          | `'light'` |
-| startLineNumber | Starting line number                | `number`                                                                                     | `1`       |
-| classes         | Custom class names                  | `Partial<Record<'root' \| 'header' \| 'headerTitle' \| 'code' \| 'content', string>>`        | -         |
-| styles          | Custom styles                       | `Partial<Record<'root' \| 'header' \| 'headerTitle' \| 'code' \| 'content', CSSProperties>>` | -         |
+| Property        | Description                                                        | Type                                                                                         | Default   |
+| --------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- | --------- |
+| content         | Code content                                                       | `string`                                                                                     | -         |
+| language        | Code language; loads bundled Shiki languages and aliases on demand | `string`                                                                                     | `'text'`  |
+| showLineNumbers | Whether to show line numbers                                       | `boolean`                                                                                    | `true`    |
+| showLanguage    | Whether to show language label                                     | `boolean`                                                                                    | `true`    |
+| showThemeToggle | Whether to show theme toggle button                                | `boolean`                                                                                    | `false`   |
+| showCopyButton  | Whether to show copy button                                        | `boolean`                                                                                    | `true`    |
+| theme           | Theme mode                                                         | `'light' \| 'dark'`                                                                          | `'light'` |
+| startLineNumber | Starting line number                                               | `number`                                                                                     | `1`       |
+| classes         | Custom class names                                                 | `Partial<Record<'root' \| 'header' \| 'headerTitle' \| 'code' \| 'content', string>>`        | -         |
+| styles          | Custom styles                                                      | `Partial<Record<'root' \| 'header' \| 'headerTitle' \| 'code' \| 'content', CSSProperties>>` | -         |
 
 ### Events
 

--- a/packages/docs/src/pages/components/code-highlighter/index.en-US.md
+++ b/packages/docs/src/pages/components/code-highlighter/index.en-US.md
@@ -14,16 +14,20 @@ description: Display code blocks in AI conversation scenarios with syntax highli
 
 The component ships with six built-in languages loaded on demand: `typescript` (`ts`), `javascript` (`js`), `python` (`py`), `json`, `html`, and `css`. Other languages safely fall back to plain text.
 
-To support more languages, inject a custom loader via `setupCodeHighlighter` — backed by Shiki's full `bundledLanguages`, a CDN, or any other source:
+To support more languages, inject a custom loader via `setupCodeHighlighter` and `import` only the language modules you need (avoids pulling in the full language bundle):
 
 ```ts
-import { bundledLanguages } from "shiki/langs";
 import { setupCodeHighlighter } from "@antdv-next/x";
 
-// Load every bundled Shiki language
+// Load extra languages on demand - only the ones you ship are bundled
 setupCodeHighlighter({
   loadLanguage: async lang => {
-    const loader = bundledLanguages[lang as keyof typeof bundledLanguages];
+    const loaders: Record<string, () => Promise<{ default: any }>> = {
+      go: () => import("shiki/dist/langs/go.mjs"),
+      rust: () => import("shiki/dist/langs/rust.mjs"),
+      java: () => import("shiki/dist/langs/java.mjs"),
+    };
+    const loader = loaders[lang];
     return loader ? (await loader()).default : null;
   },
 });

--- a/packages/docs/src/pages/components/code-highlighter/index.zh-CN.md
+++ b/packages/docs/src/pages/components/code-highlighter/index.zh-CN.md
@@ -12,7 +12,22 @@ description: 用于 AI 对话场景中展示代码块，提供语法高亮、行
 
 ## 语言支持
 
-组件会根据 `language` 按需加载 Shiki 内置语言及其官方别名，例如 `go`、`rust`、`rs` 和 `c++`。无法识别的语言会安全降级为纯文本显示。
+组件默认内置 6 种常用语言并按需加载语法：`typescript`（含 `ts`）、`javascript`（含 `js`）、`python`（含 `py`）、`json`、`html`、`css`。其他语言会安全降级为纯文本显示。
+
+如需支持更多语言，可通过 `setupCodeHighlighter` 注入自定义语言加载器，接入 Shiki 全量 `bundledLanguages` 或 CDN 等任意来源：
+
+```ts
+import { bundledLanguages } from "shiki/langs";
+import { setupCodeHighlighter } from "@antdv-next/x";
+
+// 接入 Shiki 全量内置语言
+setupCodeHighlighter({
+  loadLanguage: async lang => {
+    const loader = bundledLanguages[lang as keyof typeof bundledLanguages];
+    return loader ? (await loader()).default : null;
+  },
+});
+```
 
 ## 代码演示
 
@@ -75,6 +90,14 @@ description: 用于 AI 对话场景中展示代码块，提供语法高亮、行
 | 属性          | 说明              | 类型             |
 | ------------- | ----------------- | ---------------- |
 | nativeElement | 获取原生 DOM 元素 | `HTMLDivElement` |
+
+### 扩展语言
+
+| 函数名               | 说明                                     | 参数                                                       |
+| -------------------- | ---------------------------------------- | ---------------------------------------------------------- |
+| setupCodeHighlighter | 注入自定义语言加载器，覆盖默认内置白名单 | `{ loadLanguage: (lang: string) => Promise<any \| null> }` |
+
+`loadLanguage` 接收语言名，返回 Shiki 语言注册信息或 `null`（降级为纯文本）。
 
 ## 语义化 DOM
 

--- a/packages/docs/src/pages/components/code-highlighter/index.zh-CN.md
+++ b/packages/docs/src/pages/components/code-highlighter/index.zh-CN.md
@@ -14,16 +14,20 @@ description: 用于 AI 对话场景中展示代码块，提供语法高亮、行
 
 组件默认内置 6 种常用语言并按需加载语法：`typescript`（含 `ts`）、`javascript`（含 `js`）、`python`（含 `py`）、`json`、`html`、`css`。其他语言会安全降级为纯文本显示。
 
-如需支持更多语言，可通过 `setupCodeHighlighter` 注入自定义语言加载器，接入 Shiki 全量 `bundledLanguages` 或 CDN 等任意来源：
+如需支持更多语言，可通过 `setupCodeHighlighter` 注入自定义语言加载器，按需 `import` 对应语言模块（避免引入全量语言包）：
 
 ```ts
-import { bundledLanguages } from "shiki/langs";
 import { setupCodeHighlighter } from "@antdv-next/x";
 
-// 接入 Shiki 全量内置语言
+// 按需加载额外语言，仅打包用到的语言
 setupCodeHighlighter({
   loadLanguage: async lang => {
-    const loader = bundledLanguages[lang as keyof typeof bundledLanguages];
+    const loaders: Record<string, () => Promise<{ default: any }>> = {
+      go: () => import("shiki/dist/langs/go.mjs"),
+      rust: () => import("shiki/dist/langs/rust.mjs"),
+      java: () => import("shiki/dist/langs/java.mjs"),
+    };
+    const loader = loaders[lang];
     return loader ? (await loader()).default : null;
   },
 });

--- a/packages/docs/src/pages/components/code-highlighter/index.zh-CN.md
+++ b/packages/docs/src/pages/components/code-highlighter/index.zh-CN.md
@@ -18,6 +18,8 @@ description: 用于 AI 对话场景中展示代码块，提供语法高亮、行
 
 <demo src="./demo/basic.vue">基本用法</demo>
 
+<demo src="./demo/lazy-language.vue">动态加载语言高亮</demo>
+
 <demo src="./demo/theme.vue">主题切换</demo>
 
 <demo src="./demo/line-numbers.vue">行号控制</demo>

--- a/packages/docs/src/pages/components/code-highlighter/index.zh-CN.md
+++ b/packages/docs/src/pages/components/code-highlighter/index.zh-CN.md
@@ -10,6 +10,10 @@ description: 用于 AI 对话场景中展示代码块，提供语法高亮、行
 - 技术文档中的代码示例
 - 聊天消息中的代码片段
 
+## 语言支持
+
+组件会根据 `language` 按需加载 Shiki 内置语言及其官方别名，例如 `go`、`rust`、`rs` 和 `c++`。无法识别的语言会安全降级为纯文本显示。
+
 ## 代码演示
 
 <demo src="./demo/basic.vue">基本用法</demo>
@@ -26,18 +30,18 @@ description: 用于 AI 对话场景中展示代码块，提供语法高亮、行
 
 ### 属性
 
-| 属性            | 说明                 | 类型                                                                                         | 默认值    |
-| --------------- | -------------------- | -------------------------------------------------------------------------------------------- | --------- |
-| content         | 代码内容             | `string`                                                                                     | -         |
-| language        | 代码语言类型         | `string`                                                                                     | `'text'`  |
-| showLineNumbers | 是否显示行号         | `boolean`                                                                                    | `true`    |
-| showLanguage    | 是否显示语言标识     | `boolean`                                                                                    | `true`    |
-| showThemeToggle | 是否显示主题切换按钮 | `boolean`                                                                                    | `false`   |
-| showCopyButton  | 是否显示复制按钮     | `boolean`                                                                                    | `true`    |
-| theme           | 主题模式             | `'light' \| 'dark'`                                                                          | `'light'` |
-| startLineNumber | 起始行号             | `number`                                                                                     | `1`       |
-| classes         | 自定义类名           | `Partial<Record<'root' \| 'header' \| 'headerTitle' \| 'code' \| 'content', string>>`        | -         |
-| styles          | 自定义样式           | `Partial<Record<'root' \| 'header' \| 'headerTitle' \| 'code' \| 'content', CSSProperties>>` | -         |
+| 属性            | 说明                                          | 类型                                                                                         | 默认值    |
+| --------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------- | --------- |
+| content         | 代码内容                                      | `string`                                                                                     | -         |
+| language        | 代码语言；按需加载 Shiki 内置语言及其官方别名 | `string`                                                                                     | `'text'`  |
+| showLineNumbers | 是否显示行号                                  | `boolean`                                                                                    | `true`    |
+| showLanguage    | 是否显示语言标识                              | `boolean`                                                                                    | `true`    |
+| showThemeToggle | 是否显示主题切换按钮                          | `boolean`                                                                                    | `false`   |
+| showCopyButton  | 是否显示复制按钮                              | `boolean`                                                                                    | `true`    |
+| theme           | 主题模式                                      | `'light' \| 'dark'`                                                                          | `'light'` |
+| startLineNumber | 起始行号                                      | `number`                                                                                     | `1`       |
+| classes         | 自定义类名                                    | `Partial<Record<'root' \| 'header' \| 'headerTitle' \| 'code' \| 'content', string>>`        | -         |
+| styles          | 自定义样式                                    | `Partial<Record<'root' \| 'header' \| 'headerTitle' \| 'code' \| 'content', CSSProperties>>` | -         |
 
 ### 事件
 

--- a/packages/x/components/code-highlighter/__tests__/shiki.test.ts
+++ b/packages/x/components/code-highlighter/__tests__/shiki.test.ts
@@ -7,11 +7,13 @@ import {
   vi,
 } from "vite-plus/test";
 
-const highlightedLanguages = [
-  ["go", "package main\nfunc main() {}"],
-  ["rust", "fn main() {}"],
-  ["rs", "fn main() {}"],
-  ["c++", "int main() {}"],
+const builtinLanguages = [
+  ["typescript", "const x: number = 1;"],
+  ["javascript", "const x = 1;"],
+  ["python", "x = 1"],
+  ["json", '{"a":1}'],
+  ["html", "<div>hi</div>"],
+  ["css", "a { color: red; }"],
 ] as const;
 
 describe("CodeHighlighter Shiki integration", () => {
@@ -23,8 +25,8 @@ describe("CodeHighlighter Shiki integration", () => {
     vi.restoreAllMocks();
   });
 
-  it.each(highlightedLanguages)(
-    "loads the bundled %s grammar on demand",
+  it.each(builtinLanguages)(
+    "highlights builtin %s on demand",
     async (language, code) => {
       const { codeToHtml } = await import("../shiki");
 
@@ -35,21 +37,22 @@ describe("CodeHighlighter Shiki integration", () => {
     },
   );
 
-  it("warns and escapes code when a language cannot be loaded", async () => {
+  it("resolves aliases (ts -> typescript)", async () => {
+    const { codeToHtml } = await import("../shiki");
+
+    const html = await codeToHtml("const x = 1;", { lang: "ts" });
+
+    expect(html).toContain('class="shiki vitesse-light"');
+  });
+
+  it("falls back to plain text for non-builtin languages without warning", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
     const { codeToHtml } = await import("../shiki");
 
-    const html = await codeToHtml('<unknown data-value="a&b">', {
-      lang: "not-a-language",
-    });
+    const html = await codeToHtml('x = "a&b"', { lang: "go" });
 
-    expect(html).toBe(
-      "<pre><code>&lt;unknown data-value=&quot;a&amp;b&quot;&gt;</code></pre>",
-    );
-    expect(warn).toHaveBeenCalledWith(
-      "[CodeHighlighter] Failed to load language: not-a-language",
-      expect.any(Error),
-    );
+    expect(html).toBe("<pre><code>x = &quot;a&amp;b&quot;</code></pre>");
+    expect(warn).not.toHaveBeenCalled();
   });
 
   it("renders plain text without attempting to load a grammar", async () => {
@@ -62,35 +65,62 @@ describe("CodeHighlighter Shiki integration", () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
+  it("loads a non-builtin language via setupCodeHighlighter", async () => {
+    const { setupCodeHighlighter, codeToHtml } = await import("../shiki");
+    setupCodeHighlighter({
+      loadLanguage: async lang => {
+        if (lang !== "go") return null;
+        const mod = await import("shiki/dist/langs/go.mjs");
+        return mod.default;
+      },
+    });
+
+    const html = await codeToHtml("package main", { lang: "go" });
+
+    expect(html).toContain('class="shiki vitesse-light"');
+  });
+
+  it("warns and escapes code when a custom loader throws", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { setupCodeHighlighter, codeToHtml } = await import("../shiki");
+    setupCodeHighlighter({
+      loadLanguage: async () => {
+        throw new Error("boom");
+      },
+    });
+
+    const html = await codeToHtml("x", { lang: "go" });
+
+    expect(html).toBe("<pre><code>x</code></pre>");
+    expect(warn).toHaveBeenCalledWith(
+      "[CodeHighlighter] Failed to load language: go",
+      expect.any(Error),
+    );
+  });
+
   it("shares an in-flight language load between concurrent calls", async () => {
-    const { bundledLanguages } = await import("shiki/langs");
-    const originalLoader = bundledLanguages.go;
-    let releaseLoader!: () => void;
-    const loaderGate = new Promise<void>(resolve => {
-      releaseLoader = resolve;
+    const { setupCodeHighlighter, codeToHtml } = await import("../shiki");
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => {
+      release = resolve;
     });
     const loader = vi.fn(async () => {
-      await loaderGate;
-      return originalLoader();
+      await gate;
+      const mod = await import("shiki/dist/langs/typescript.mjs");
+      return mod.default;
     });
-    bundledLanguages.go = loader;
+    setupCodeHighlighter({ loadLanguage: loader });
 
-    try {
-      const { codeToHtml } = await import("../shiki");
-      const first = codeToHtml("package main", { lang: "go" });
-      const second = codeToHtml("package example", { lang: "go" });
+    const first = codeToHtml("const a = 1", { lang: "typescript" });
+    const second = codeToHtml("const b = 2", { lang: "typescript" });
 
-      await vi.waitFor(() => {
-        expect(loader).toHaveBeenCalledTimes(1);
-      });
-      releaseLoader();
-
-      const results = await Promise.all([first, second]);
+    await vi.waitFor(() => {
       expect(loader).toHaveBeenCalledTimes(1);
-      expect(results.every(html => html.includes('class="shiki'))).toBe(true);
-    } finally {
-      releaseLoader();
-      bundledLanguages.go = originalLoader;
-    }
+    });
+    release();
+
+    const results = await Promise.all([first, second]);
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(results.every(html => html.includes('class="shiki'))).toBe(true);
   });
 });

--- a/packages/x/components/code-highlighter/__tests__/shiki.test.ts
+++ b/packages/x/components/code-highlighter/__tests__/shiki.test.ts
@@ -1,0 +1,96 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vite-plus/test";
+
+const highlightedLanguages = [
+  ["go", "package main\nfunc main() {}"],
+  ["rust", "fn main() {}"],
+  ["rs", "fn main() {}"],
+  ["c++", "int main() {}"],
+] as const;
+
+describe("CodeHighlighter Shiki integration", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each(highlightedLanguages)(
+    "loads the bundled %s grammar on demand",
+    async (language, code) => {
+      const { codeToHtml } = await import("../shiki");
+
+      const html = await codeToHtml(code, { lang: language });
+
+      expect(html).toContain('class="shiki vitesse-light"');
+      expect(html).toContain("<span");
+    },
+  );
+
+  it("warns and escapes code when a language cannot be loaded", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { codeToHtml } = await import("../shiki");
+
+    const html = await codeToHtml('<unknown data-value="a&b">', {
+      lang: "not-a-language",
+    });
+
+    expect(html).toBe(
+      "<pre><code>&lt;unknown data-value=&quot;a&amp;b&quot;&gt;</code></pre>",
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "[CodeHighlighter] Failed to load language: not-a-language",
+      expect.any(Error),
+    );
+  });
+
+  it("renders plain text without attempting to load a grammar", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { codeToHtml } = await import("../shiki");
+
+    const html = await codeToHtml("value < 10", { lang: "text" });
+
+    expect(html).toBe("<pre><code>value &lt; 10</code></pre>");
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("shares an in-flight language load between concurrent calls", async () => {
+    const { bundledLanguages } = await import("shiki/langs");
+    const originalLoader = bundledLanguages.go;
+    let releaseLoader!: () => void;
+    const loaderGate = new Promise<void>(resolve => {
+      releaseLoader = resolve;
+    });
+    const loader = vi.fn(async () => {
+      await loaderGate;
+      return originalLoader();
+    });
+    bundledLanguages.go = loader;
+
+    try {
+      const { codeToHtml } = await import("../shiki");
+      const first = codeToHtml("package main", { lang: "go" });
+      const second = codeToHtml("package example", { lang: "go" });
+
+      await vi.waitFor(() => {
+        expect(loader).toHaveBeenCalledTimes(1);
+      });
+      releaseLoader();
+
+      const results = await Promise.all([first, second]);
+      expect(loader).toHaveBeenCalledTimes(1);
+      expect(results.every(html => html.includes('class="shiki'))).toBe(true);
+    } finally {
+      releaseLoader();
+      bundledLanguages.go = originalLoader;
+    }
+  });
+});

--- a/packages/x/components/code-highlighter/index.tsx
+++ b/packages/x/components/code-highlighter/index.tsx
@@ -1,5 +1,7 @@
 import CodeHighlighter from "./CodeHighlighter";
 
+export { setupCodeHighlighter } from "./shiki";
+
 export type {
   CodeHighlighterHeaderSlotScope,
   CodeHighlighterProps,

--- a/packages/x/components/code-highlighter/shiki.ts
+++ b/packages/x/components/code-highlighter/shiki.ts
@@ -2,46 +2,20 @@ import { createHighlighterCore } from "shiki/core";
 import darkTheme from "shiki/dist/themes/vitesse-dark.mjs";
 import lightTheme from "shiki/dist/themes/vitesse-light.mjs";
 import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
+import { bundledLanguages } from "shiki/langs";
 
 type Highlighter = Awaited<ReturnType<typeof createHighlighterCore>>;
 
-const SUPPORTED_LANG_ALIASES: Record<string, string> = {
-  ts: "typescript",
-  js: "javascript",
-  py: "python",
-  md: "markdown",
-  yml: "yaml",
-  shell: "bash",
-  zsh: "bash",
-  sh: "bash",
-  vue: "vue",
-};
-
-const LANG_LOADERS: Record<string, () => Promise<{ default: any }>> = {
-  javascript: () => import("shiki/dist/langs/javascript.mjs"),
-  typescript: () => import("shiki/dist/langs/typescript.mjs"),
-  jsx: () => import("shiki/dist/langs/jsx.mjs"),
-  tsx: () => import("shiki/dist/langs/tsx.mjs"),
-  json: () => import("shiki/dist/langs/json.mjs"),
-  bash: () => import("shiki/dist/langs/bash.mjs"),
-  markdown: () => import("shiki/dist/langs/markdown.mjs"),
-  html: () => import("shiki/dist/langs/html.mjs"),
-  css: () => import("shiki/dist/langs/css.mjs"),
-  vue: () => import("shiki/dist/langs/vue.mjs"),
-  "vue-html": () => import("shiki/dist/langs/vue-html.mjs"),
-  python: () => import("shiki/dist/langs/python.mjs"),
-  mermaid: () => import("shiki/dist/langs/mermaid.mjs"),
-  yaml: () => import("shiki/dist/langs/yaml.mjs"),
-  diff: () => import("shiki/dist/langs/diff.mjs"),
-};
+const PLAIN_TEXT_LANGUAGES = new Set(["text", "plaintext", "txt", "plain"]);
 
 let highlighter: Highlighter | null = null;
 let highlighterPromise: Promise<Highlighter> | null = null;
 const loadedLangs = new Set<string>();
+const failedLangs = new Set<string>();
+const languageLoadPromises = new Map<string, Promise<boolean>>();
 
 function normalizeLanguage(language: string | undefined): string {
-  const input = (language || "text").toLowerCase();
-  return SUPPORTED_LANG_ALIASES[input] || input;
+  return (language || "text").toLowerCase();
 }
 
 function escapeHtml(str: string): string {
@@ -67,15 +41,43 @@ async function getHighlighter() {
 }
 
 async function loadLang(lang: string) {
-  const loader = LANG_LOADERS[lang];
-  if (!loader) return false;
   if (loadedLangs.has(lang)) return true;
+  if (failedLangs.has(lang) || PLAIN_TEXT_LANGUAGES.has(lang)) return false;
 
-  const instance = await getHighlighter();
-  const mod = await loader();
-  await instance.loadLanguage(mod.default);
-  loadedLangs.add(lang);
-  return true;
+  const pendingLoad = languageLoadPromises.get(lang);
+  if (pendingLoad) return pendingLoad;
+
+  const loader = bundledLanguages[lang as keyof typeof bundledLanguages];
+  if (!loader) {
+    const error = new Error(`Unknown language: ${lang}`);
+    failedLangs.add(lang);
+    console.warn(`[CodeHighlighter] Failed to load language: ${lang}`, error);
+    return false;
+  }
+
+  const loadPromise = (async () => {
+    try {
+      const mod = await loader();
+      const instance = await getHighlighter();
+      await instance.loadLanguage(mod.default);
+      loadedLangs.add(lang);
+      return true;
+    } catch (error) {
+      const loadError =
+        error instanceof Error ? error : new Error(String(error));
+      failedLangs.add(lang);
+      console.warn(
+        `[CodeHighlighter] Failed to load language: ${lang}`,
+        loadError,
+      );
+      return false;
+    } finally {
+      languageLoadPromises.delete(lang);
+    }
+  })();
+
+  languageLoadPromises.set(lang, loadPromise);
+  return loadPromise;
 }
 
 export async function codeToHtml(

--- a/packages/x/components/code-highlighter/shiki.ts
+++ b/packages/x/components/code-highlighter/shiki.ts
@@ -2,11 +2,61 @@ import { createHighlighterCore } from "shiki/core";
 import darkTheme from "shiki/dist/themes/vitesse-dark.mjs";
 import lightTheme from "shiki/dist/themes/vitesse-light.mjs";
 import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
-import { bundledLanguages } from "shiki/langs";
 
 type Highlighter = Awaited<ReturnType<typeof createHighlighterCore>>;
+type LanguageLoader = (lang: string) => Promise<any>;
 
 const PLAIN_TEXT_LANGUAGES = new Set(["text", "plaintext", "txt", "plain"]);
+
+/**
+ * 内置热门语言白名单。
+ * 使用静态 import 路径，打包时仅生成这几个语言对应的 chunk。
+ */
+const BUILTIN_LANGUAGES: Record<string, () => Promise<{ default: any }>> = {
+  typescript: () => import("shiki/dist/langs/typescript.mjs"),
+  javascript: () => import("shiki/dist/langs/javascript.mjs"),
+  python: () => import("shiki/dist/langs/python.mjs"),
+  json: () => import("shiki/dist/langs/json.mjs"),
+  html: () => import("shiki/dist/langs/html.mjs"),
+  css: () => import("shiki/dist/langs/css.mjs"),
+};
+
+/** 常用别名 -> 基础语言 */
+const BUILTIN_ALIASES: Record<string, string> = {
+  ts: "typescript",
+  js: "javascript",
+  py: "python",
+};
+
+const defaultLoader: LanguageLoader = async lang => {
+  const loader = BUILTIN_LANGUAGES[BUILTIN_ALIASES[lang] ?? lang];
+  return loader ? (await loader()).default : null;
+};
+
+let activeLoader: LanguageLoader = defaultLoader;
+
+/**
+ * 注入自定义语言加载器，覆盖默认内置白名单。
+ * 可接入 Shiki 全量 `bundledLanguages`、CDN 等任意来源。
+ *
+ * @example 接入全量 Shiki 语言
+ * ```ts
+ * import { bundledLanguages } from "shiki/langs";
+ * import { setupCodeHighlighter } from "@antdv-next/x";
+ *
+ * setupCodeHighlighter({
+ *   loadLanguage: async (lang) => {
+ *     const loader = bundledLanguages[lang as keyof typeof bundledLanguages];
+ *     return loader ? (await loader()).default : null;
+ *   },
+ * });
+ * ```
+ */
+export function setupCodeHighlighter(options: {
+  loadLanguage?: LanguageLoader;
+}) {
+  if (options?.loadLanguage) activeLoader = options.loadLanguage;
+}
 
 let highlighter: Highlighter | null = null;
 let highlighterPromise: Promise<Highlighter> | null = null;
@@ -47,19 +97,15 @@ async function loadLang(lang: string) {
   const pendingLoad = languageLoadPromises.get(lang);
   if (pendingLoad) return pendingLoad;
 
-  const loader = bundledLanguages[lang as keyof typeof bundledLanguages];
-  if (!loader) {
-    const error = new Error(`Unknown language: ${lang}`);
-    failedLangs.add(lang);
-    console.warn(`[CodeHighlighter] Failed to load language: ${lang}`, error);
-    return false;
-  }
-
   const loadPromise = (async () => {
     try {
-      const mod = await loader();
+      const registration = await activeLoader(lang);
+      if (!registration) {
+        failedLangs.add(lang);
+        return false;
+      }
       const instance = await getHighlighter();
-      await instance.loadLanguage(mod.default);
+      await instance.loadLanguage(registration);
       loadedLangs.add(lang);
       return true;
     } catch (error) {

--- a/packages/x/components/code-highlighter/shiki.ts
+++ b/packages/x/components/code-highlighter/shiki.ts
@@ -37,16 +37,19 @@ let activeLoader: LanguageLoader = defaultLoader;
 
 /**
  * 注入自定义语言加载器，覆盖默认内置白名单。
- * 可接入 Shiki 全量 `bundledLanguages`、CDN 等任意来源。
+ * 建议按需 `import` 语言模块，避免引入全量语言包。
  *
- * @example 接入全量 Shiki 语言
+ * @example 按需加载额外语言
  * ```ts
- * import { bundledLanguages } from "shiki/langs";
  * import { setupCodeHighlighter } from "@antdv-next/x";
  *
  * setupCodeHighlighter({
  *   loadLanguage: async (lang) => {
- *     const loader = bundledLanguages[lang as keyof typeof bundledLanguages];
+ *     const loaders: Record<string, () => Promise<{ default: any }>> = {
+ *       go: () => import("shiki/dist/langs/go.mjs"),
+ *       rust: () => import("shiki/dist/langs/rust.mjs"),
+ *     };
+ *     const loader = loaders[lang];
  *     return loader ? (await loader()).default : null;
  *   },
  * });

--- a/packages/x/components/index.ts
+++ b/packages/x/components/index.ts
@@ -174,6 +174,8 @@ export type {
   CodeHighlighterSemanticType,
 } from "./code-highlighter";
 
+export { setupCodeHighlighter } from "./code-highlighter";
+
 export type { SenderProps, SenderRef } from "./sender";
 export type {
   RenderChildrenProps,


### PR DESCRIPTION
## 背景

`code-highlighter` 之前通过 `bundledLanguages` 引入 Shiki 全量 235 种语言，导致消费方打包产生 235 个 lazy chunk（约 7.7 MB）。

## 改动

- 移除 `bundledLanguages`，改为 **6 种内置语言白名单**（静态 `import("shiki/dist/langs/xxx.mjs")`）：`typescript/ts`、`javascript/js`、`python/py`、`json`、`html`、`css`
- 新增 `setupCodeHighlighter({ loadLanguage })` DI 扩展口，消费者可按需注入任意语言加载器
- 从 `@antdv-next/x` 主入口导出 `setupCodeHighlighter`
- 未知语言安全降级为纯文本（不 warn）；仅 loader 抛异常时 warn
- 文档示例改为按需 `import`，避免引导消费者引入全量语言包

## 实测效果（docs 构建）

| 指标 | 改造前 | 改造后 |
| --- | --- | --- |
| code-highlighter 语言 chunk | 235 | 6 |
| docs/dist .js 文件数 | 1139 | 914 |
| docs/dist 总体积 | 43.4 MB | 36.9 MB |

## Breaking Change

默认语言支持从 235 降至 6。使用非内置语言（go/rust/java 等）需调用 `setupCodeHighlighter` 注入加载器，否则降级为纯文本：

```ts
import { setupCodeHighlighter } from "@antdv-next/x";

setupCodeHighlighter({
  loadLanguage: async lang => {
    const loaders = {
      go: () => import("shiki/dist/langs/go.mjs"),
      rust: () => import("shiki/dist/langs/rust.mjs"),
    };
    const loader = loaders[lang];
    return loader ? (await loader()).default : null;
  },
});
```

## 测试

- `vp test`：12 项全过（内置高亮 / 别名 / 降级 / 纯文本 / DI / 异常 / 并发锁）
- `vp check`：0 errors
- 文档站构建通过
