### PR TITLE
fix(code-highlighter): preserve builtins with custom loader

### DIFF
--- a/packages/docs/src/pages/components/code-highlighter/demo/lazy-language.vue
+++ b/packages/docs/src/pages/components/code-highlighter/demo/lazy-language.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import type { LanguageInput } from "shiki";
+
 import { setupCodeHighlighter } from "@antdv-next/x";
 import { computed, ref } from "vue";
 
@@ -7,7 +9,7 @@ import { computed, ref } from "vue";
 // 切换时才会按需动态加载对应语法。
 setupCodeHighlighter({
   loadLanguage: async lang => {
-    const loaders: Record<string, () => Promise<{ default: any }>> = {
+    const loaders: Record<string, () => Promise<{ default: LanguageInput }>> = {
       go: () => import("shiki/dist/langs/go.mjs"),
       rust: () => import("shiki/dist/langs/rust.mjs"),
       java: () => import("shiki/dist/langs/java.mjs"),
@@ -80,9 +82,9 @@ const current = computed(() => {
 </template>
 
 <docs lang="zh-CN">
-默认仅内置 6 种常用语言。本 demo 通过 `setupCodeHighlighter` 注入 Go / Rust / Java 的加载器，切换时按需动态加载对应语法；未注册语言（如 Plain Text）则降级为纯文本。
+默认仅内置 6 种常用语言。本 demo 通过 `setupCodeHighlighter` 注入 Go / Rust / Java 的加载器，切换时按需动态加载对应语法；用户 loader 返回 `null` 时仍会回退默认白名单，未注册语言（如 Plain Text）则降级为纯文本。
 </docs>
 
 <docs lang="en-US">
-Only six common languages are built in. This demo injects Go / Rust / Java loaders via `setupCodeHighlighter`, loading each grammar on demand when switched to. Unregistered languages (e.g. Plain Text) fall back to plain text.
+Only six common languages are built in. This demo injects Go / Rust / Java loaders via `setupCodeHighlighter`, loading each grammar on demand when switched to. A `null` result still falls back to the default whitelist, while unregistered languages (e.g. Plain Text) fall back to plain text.
 </docs>

--- a/packages/docs/src/pages/components/code-highlighter/index.en-US.md
+++ b/packages/docs/src/pages/components/code-highlighter/index.en-US.md
@@ -14,15 +14,22 @@ description: Display code blocks in AI conversation scenarios with syntax highli
 
 The component ships with six built-in languages loaded on demand: `typescript` (`ts`), `javascript` (`js`), `python` (`py`), `json`, `html`, and `css`. Other languages safely fall back to plain text.
 
-To support more languages, inject a custom loader via `setupCodeHighlighter` and `import` only the language modules you need (avoids pulling in the full language bundle):
+To support more languages, inject a custom loader via `setupCodeHighlighter` and `import` only the language modules you need (avoids pulling in the full language bundle). The custom loader resolves languages first; when it returns `null`, the component falls back to the default whitelist.
+
+Because the custom loader imports Shiki language modules from application code, declare `shiki` as a direct application dependency:
+
+<InstallDependencies npm='npm install shiki' yarn='yarn add shiki' pnpm='pnpm add shiki' bun='bun add shiki'></InstallDependencies>
+
+Configure the loader before the first `CodeHighlighter` render, typically before `app.mount()`:
 
 ```ts
 import { setupCodeHighlighter } from "@antdv-next/x";
+import type { LanguageInput } from "shiki";
 
 // Load extra languages on demand - only the ones you ship are bundled
 setupCodeHighlighter({
   loadLanguage: async lang => {
-    const loaders: Record<string, () => Promise<{ default: any }>> = {
+    const loaders: Record<string, () => Promise<{ default: LanguageInput }>> = {
       go: () => import("shiki/dist/langs/go.mjs"),
       rust: () => import("shiki/dist/langs/rust.mjs"),
       java: () => import("shiki/dist/langs/java.mjs"),
@@ -51,18 +58,18 @@ setupCodeHighlighter({
 
 ### Props
 
-| Property        | Description                                                        | Type                                                                                         | Default   |
-| --------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- | --------- |
-| content         | Code content                                                       | `string`                                                                                     | -         |
-| language        | Code language; loads bundled Shiki languages and aliases on demand | `string`                                                                                     | `'text'`  |
-| showLineNumbers | Whether to show line numbers                                       | `boolean`                                                                                    | `true`    |
-| showLanguage    | Whether to show language label                                     | `boolean`                                                                                    | `true`    |
-| showThemeToggle | Whether to show theme toggle button                                | `boolean`                                                                                    | `false`   |
-| showCopyButton  | Whether to show copy button                                        | `boolean`                                                                                    | `true`    |
-| theme           | Theme mode                                                         | `'light' \| 'dark'`                                                                          | `'light'` |
-| startLineNumber | Starting line number                                               | `number`                                                                                     | `1`       |
-| classes         | Custom class names                                                 | `Partial<Record<'root' \| 'header' \| 'headerTitle' \| 'code' \| 'content', string>>`        | -         |
-| styles          | Custom styles                                                      | `Partial<Record<'root' \| 'header' \| 'headerTitle' \| 'code' \| 'content', CSSProperties>>` | -         |
+| Property        | Description                                                                           | Type                                                                                         | Default   |
+| --------------- | ------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | --------- |
+| content         | Code content                                                                          | `string`                                                                                     | -         |
+| language        | Code language; loads the default whitelist or languages registered by the user loader | `string`                                                                                     | `'text'`  |
+| showLineNumbers | Whether to show line numbers                                                          | `boolean`                                                                                    | `true`    |
+| showLanguage    | Whether to show language label                                                        | `boolean`                                                                                    | `true`    |
+| showThemeToggle | Whether to show theme toggle button                                                   | `boolean`                                                                                    | `false`   |
+| showCopyButton  | Whether to show copy button                                                           | `boolean`                                                                                    | `true`    |
+| theme           | Theme mode                                                                            | `'light' \| 'dark'`                                                                          | `'light'` |
+| startLineNumber | Starting line number                                                                  | `number`                                                                                     | `1`       |
+| classes         | Custom class names                                                                    | `Partial<Record<'root' \| 'header' \| 'headerTitle' \| 'code' \| 'content', string>>`        | -         |
+| styles          | Custom styles                                                                         | `Partial<Record<'root' \| 'header' \| 'headerTitle' \| 'code' \| 'content', CSSProperties>>` | -         |
 
 ### Events
 
@@ -97,11 +104,11 @@ When the `header` slot is provided, it fully replaces the default header (langua
 
 ### Extending Languages
 
-| Function             | Description                                                               | Params                                                     |
-| -------------------- | ------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| setupCodeHighlighter | Inject a custom language loader, overriding the default builtin whitelist | `{ loadLanguage: (lang: string) => Promise<any \| null> }` |
+| Function             | Description                                                                    | Params                                                               |
+| -------------------- | ------------------------------------------------------------------------------ | -------------------------------------------------------------------- |
+| setupCodeHighlighter | Inject a custom language loader; falls back to the default whitelist on `null` | `{ loadLanguage: (lang: string) => Promise<LanguageInput \| null> }` |
 
-`loadLanguage` receives the language name and returns a Shiki language registration or `null` (falls back to plain text).
+`loadLanguage` receives the language name and returns a Shiki language registration or `null`. The component falls back to plain text when neither the user loader nor the default whitelist can resolve the language. Calling this function again replaces the previous user loader and allows previously failed languages to retry.
 
 ## Semantic DOM
 

--- a/packages/docs/src/pages/components/code-highlighter/index.zh-CN.md
+++ b/packages/docs/src/pages/components/code-highlighter/index.zh-CN.md
@@ -14,15 +14,22 @@ description: 用于 AI 对话场景中展示代码块，提供语法高亮、行
 
 组件默认内置 6 种常用语言并按需加载语法：`typescript`（含 `ts`）、`javascript`（含 `js`）、`python`（含 `py`）、`json`、`html`、`css`。其他语言会安全降级为纯文本显示。
 
-如需支持更多语言，可通过 `setupCodeHighlighter` 注入自定义语言加载器，按需 `import` 对应语言模块（避免引入全量语言包）：
+如需支持更多语言，可通过 `setupCodeHighlighter` 注入自定义语言加载器，按需 `import` 对应语言模块（避免引入全量语言包）。自定义 loader 会优先解析语言；返回 `null` 时，组件会继续尝试默认白名单。
+
+自定义 loader 直接从应用代码导入 Shiki 语言模块，因此应用需要将 `shiki` 声明为直接依赖：
+
+<InstallDependencies npm='npm install shiki' yarn='yarn add shiki' pnpm='pnpm add shiki' bun='bun add shiki'></InstallDependencies>
+
+请在首次渲染 `CodeHighlighter` 前（通常是 `app.mount()` 前）完成配置：
 
 ```ts
 import { setupCodeHighlighter } from "@antdv-next/x";
+import type { LanguageInput } from "shiki";
 
 // 按需加载额外语言，仅打包用到的语言
 setupCodeHighlighter({
   loadLanguage: async lang => {
-    const loaders: Record<string, () => Promise<{ default: any }>> = {
+    const loaders: Record<string, () => Promise<{ default: LanguageInput }>> = {
       go: () => import("shiki/dist/langs/go.mjs"),
       rust: () => import("shiki/dist/langs/rust.mjs"),
       java: () => import("shiki/dist/langs/java.mjs"),
@@ -51,18 +58,18 @@ setupCodeHighlighter({
 
 ### 属性
 
-| 属性            | 说明                                          | 类型                                                                                         | 默认值    |
-| --------------- | --------------------------------------------- | -------------------------------------------------------------------------------------------- | --------- |
-| content         | 代码内容                                      | `string`                                                                                     | -         |
-| language        | 代码语言；按需加载 Shiki 内置语言及其官方别名 | `string`                                                                                     | `'text'`  |
-| showLineNumbers | 是否显示行号                                  | `boolean`                                                                                    | `true`    |
-| showLanguage    | 是否显示语言标识                              | `boolean`                                                                                    | `true`    |
-| showThemeToggle | 是否显示主题切换按钮                          | `boolean`                                                                                    | `false`   |
-| showCopyButton  | 是否显示复制按钮                              | `boolean`                                                                                    | `true`    |
-| theme           | 主题模式                                      | `'light' \| 'dark'`                                                                          | `'light'` |
-| startLineNumber | 起始行号                                      | `number`                                                                                     | `1`       |
-| classes         | 自定义类名                                    | `Partial<Record<'root' \| 'header' \| 'headerTitle' \| 'code' \| 'content', string>>`        | -         |
-| styles          | 自定义样式                                    | `Partial<Record<'root' \| 'header' \| 'headerTitle' \| 'code' \| 'content', CSSProperties>>` | -         |
+| 属性            | 说明                                                 | 类型                                                                                         | 默认值    |
+| --------------- | ---------------------------------------------------- | -------------------------------------------------------------------------------------------- | --------- |
+| content         | 代码内容                                             | `string`                                                                                     | -         |
+| language        | 代码语言；按需加载默认白名单或用户 loader 注册的语言 | `string`                                                                                     | `'text'`  |
+| showLineNumbers | 是否显示行号                                         | `boolean`                                                                                    | `true`    |
+| showLanguage    | 是否显示语言标识                                     | `boolean`                                                                                    | `true`    |
+| showThemeToggle | 是否显示主题切换按钮                                 | `boolean`                                                                                    | `false`   |
+| showCopyButton  | 是否显示复制按钮                                     | `boolean`                                                                                    | `true`    |
+| theme           | 主题模式                                             | `'light' \| 'dark'`                                                                          | `'light'` |
+| startLineNumber | 起始行号                                             | `number`                                                                                     | `1`       |
+| classes         | 自定义类名                                           | `Partial<Record<'root' \| 'header' \| 'headerTitle' \| 'code' \| 'content', string>>`        | -         |
+| styles          | 自定义样式                                           | `Partial<Record<'root' \| 'header' \| 'headerTitle' \| 'code' \| 'content', CSSProperties>>` | -         |
 
 ### 事件
 
@@ -97,11 +104,11 @@ setupCodeHighlighter({
 
 ### 扩展语言
 
-| 函数名               | 说明                                     | 参数                                                       |
-| -------------------- | ---------------------------------------- | ---------------------------------------------------------- |
-| setupCodeHighlighter | 注入自定义语言加载器，覆盖默认内置白名单 | `{ loadLanguage: (lang: string) => Promise<any \| null> }` |
+| 函数名               | 说明                                               | 参数                                                                 |
+| -------------------- | -------------------------------------------------- | -------------------------------------------------------------------- |
+| setupCodeHighlighter | 注入自定义语言加载器；返回 `null` 时回退默认白名单 | `{ loadLanguage: (lang: string) => Promise<LanguageInput \| null> }` |
 
-`loadLanguage` 接收语言名，返回 Shiki 语言注册信息或 `null`（降级为纯文本）。
+`loadLanguage` 接收语言名，返回 Shiki 语言注册信息或 `null`。用户 loader 和默认白名单都无法解析时，组件降级为纯文本。再次调用该函数会替换之前的用户 loader，并允许此前失败的语言重新加载。
 
 ## 语义化 DOM
 

--- a/packages/x/components/code-highlighter/__tests__/shiki.test.ts
+++ b/packages/x/components/code-highlighter/__tests__/shiki.test.ts
@@ -16,6 +16,30 @@ const builtinLanguages = [
   ["css", "a { color: red; }"],
 ] as const;
 
+const builtinAliases = [
+  ["ts", "const x: number = 1;"],
+  ["js", "const x = 1;"],
+  ["py", "x = 1"],
+] as const;
+
+const customLanguages = [
+  {
+    language: "go",
+    code: "package main",
+    load: () => import("shiki/dist/langs/go.mjs"),
+  },
+  {
+    language: "rust",
+    code: "fn main() {}",
+    load: () => import("shiki/dist/langs/rust.mjs"),
+  },
+  {
+    language: "java",
+    code: "class Main {}",
+    load: () => import("shiki/dist/langs/java.mjs"),
+  },
+] as const;
+
 describe("CodeHighlighter Shiki integration", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -37,13 +61,16 @@ describe("CodeHighlighter Shiki integration", () => {
     },
   );
 
-  it("resolves aliases (ts -> typescript)", async () => {
-    const { codeToHtml } = await import("../shiki");
+  it.each(builtinAliases)(
+    "resolves builtin alias %s",
+    async (language, code) => {
+      const { codeToHtml } = await import("../shiki");
 
-    const html = await codeToHtml("const x = 1;", { lang: "ts" });
+      const html = await codeToHtml(code, { lang: language });
 
-    expect(html).toContain('class="shiki vitesse-light"');
-  });
+      expect(html).toContain('class="shiki vitesse-light"');
+    },
+  );
 
   it("falls back to plain text for non-builtin languages without warning", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
@@ -55,29 +82,76 @@ describe("CodeHighlighter Shiki integration", () => {
     expect(warn).not.toHaveBeenCalled();
   });
 
-  it("renders plain text without attempting to load a grammar", async () => {
+  it("renders plain text without calling the custom loader", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const { codeToHtml } = await import("../shiki");
+    const { codeToHtml, setupCodeHighlighter } = await import("../shiki");
+    const loader = vi.fn(async () => null);
+    setupCodeHighlighter({ loadLanguage: loader });
 
     const html = await codeToHtml("value < 10", { lang: "text" });
 
     expect(html).toBe("<pre><code>value &lt; 10</code></pre>");
+    expect(loader).not.toHaveBeenCalled();
     expect(warn).not.toHaveBeenCalled();
   });
 
-  it("loads a non-builtin language via setupCodeHighlighter", async () => {
+  it.each(customLanguages)(
+    "loads custom language $language via setupCodeHighlighter",
+    async ({ language, code, load }) => {
+      const { setupCodeHighlighter, codeToHtml } = await import("../shiki");
+      setupCodeHighlighter({
+        loadLanguage: async lang =>
+          lang === language ? (await load()).default : null,
+      });
+
+      const html = await codeToHtml(code, { lang: language });
+
+      expect(html).toContain('class="shiki vitesse-light"');
+    },
+  );
+
+  it("falls back to the builtin loader when the custom loader returns null", async () => {
     const { setupCodeHighlighter, codeToHtml } = await import("../shiki");
-    setupCodeHighlighter({
-      loadLanguage: async lang => {
-        if (lang !== "go") return null;
-        const mod = await import("shiki/dist/langs/go.mjs");
-        return mod.default;
-      },
+    const loader = vi.fn(async () => null);
+    setupCodeHighlighter({ loadLanguage: loader });
+
+    const html = await codeToHtml("const x: number = 1;", {
+      lang: "typescript",
     });
 
-    const html = await codeToHtml("package main", { lang: "go" });
-
+    expect(loader).toHaveBeenCalledOnce();
     expect(html).toContain('class="shiki vitesse-light"');
+  });
+
+  it("retries a failed language after configuring a new loader", async () => {
+    const { setupCodeHighlighter, codeToHtml } = await import("../shiki");
+
+    const fallback = await codeToHtml("package main", { lang: "go" });
+    expect(fallback).toBe("<pre><code>package main</code></pre>");
+
+    setupCodeHighlighter({
+      loadLanguage: async lang =>
+        lang === "go"
+          ? (await import("shiki/dist/langs/go.mjs")).default
+          : null,
+    });
+    const highlighted = await codeToHtml("package main", { lang: "go" });
+
+    expect(highlighted).toContain('class="shiki vitesse-light"');
+  });
+
+  it("does not reload a language after its first successful load", async () => {
+    const { setupCodeHighlighter, codeToHtml } = await import("../shiki");
+    const loader = vi.fn(async () => {
+      const mod = await import("shiki/dist/langs/go.mjs");
+      return mod.default;
+    });
+    setupCodeHighlighter({ loadLanguage: loader });
+
+    await codeToHtml("package main", { lang: "go" });
+    await codeToHtml("package second", { lang: "go" });
+
+    expect(loader).toHaveBeenCalledOnce();
   });
 
   it("warns and escapes code when a custom loader throws", async () => {
@@ -94,6 +168,22 @@ describe("CodeHighlighter Shiki integration", () => {
     expect(html).toBe("<pre><code>x</code></pre>");
     expect(warn).toHaveBeenCalledWith(
       "[CodeHighlighter] Failed to load language: go",
+      expect.any(Error),
+    );
+  });
+
+  it("warns and escapes code when Shiki rejects a registration", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { setupCodeHighlighter, codeToHtml } = await import("../shiki");
+    setupCodeHighlighter({
+      loadLanguage: async () => ({}) as never,
+    });
+
+    const html = await codeToHtml("x", { lang: "broken" });
+
+    expect(html).toBe("<pre><code>x</code></pre>");
+    expect(warn).toHaveBeenCalledWith(
+      "[CodeHighlighter] Failed to load language: broken",
       expect.any(Error),
     );
   });

--- a/packages/x/components/code-highlighter/index.tsx
+++ b/packages/x/components/code-highlighter/index.tsx
@@ -3,6 +3,11 @@ import CodeHighlighter from "./CodeHighlighter";
 export { setupCodeHighlighter } from "./shiki";
 
 export type {
+  CodeHighlighterLanguageLoader,
+  SetupCodeHighlighterOptions,
+} from "./shiki";
+
+export type {
   CodeHighlighterHeaderSlotScope,
   CodeHighlighterProps,
   CodeHighlighterRef,

--- a/packages/x/components/code-highlighter/shiki.ts
+++ b/packages/x/components/code-highlighter/shiki.ts
@@ -1,10 +1,19 @@
+import type { LanguageInput } from "shiki";
+
 import { createHighlighterCore } from "shiki/core";
 import darkTheme from "shiki/dist/themes/vitesse-dark.mjs";
 import lightTheme from "shiki/dist/themes/vitesse-light.mjs";
 import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
 
 type Highlighter = Awaited<ReturnType<typeof createHighlighterCore>>;
-type LanguageLoader = (lang: string) => Promise<any>;
+
+export type CodeHighlighterLanguageLoader = (
+  lang: string,
+) => Promise<LanguageInput | null>;
+
+export interface SetupCodeHighlighterOptions {
+  loadLanguage?: CodeHighlighterLanguageLoader;
+}
 
 const PLAIN_TEXT_LANGUAGES = new Set(["text", "plaintext", "txt", "plain"]);
 
@@ -12,7 +21,10 @@ const PLAIN_TEXT_LANGUAGES = new Set(["text", "plaintext", "txt", "plain"]);
  * 内置热门语言白名单。
  * 使用静态 import 路径，打包时仅生成这几个语言对应的 chunk。
  */
-const BUILTIN_LANGUAGES: Record<string, () => Promise<{ default: any }>> = {
+const BUILTIN_LANGUAGES: Record<
+  string,
+  () => Promise<{ default: LanguageInput }>
+> = {
   typescript: () => import("shiki/dist/langs/typescript.mjs"),
   javascript: () => import("shiki/dist/langs/javascript.mjs"),
   python: () => import("shiki/dist/langs/python.mjs"),
@@ -28,24 +40,25 @@ const BUILTIN_ALIASES: Record<string, string> = {
   py: "python",
 };
 
-const defaultLoader: LanguageLoader = async lang => {
+const defaultLoader: CodeHighlighterLanguageLoader = async lang => {
   const loader = BUILTIN_LANGUAGES[BUILTIN_ALIASES[lang] ?? lang];
   return loader ? (await loader()).default : null;
 };
 
-let activeLoader: LanguageLoader = defaultLoader;
+let customLoader: CodeHighlighterLanguageLoader | null = null;
 
 /**
- * 注入自定义语言加载器，覆盖默认内置白名单。
+ * 注入自定义语言加载器。返回 `null` 时回退到默认内置白名单。
  * 建议按需 `import` 语言模块，避免引入全量语言包。
  *
  * @example 按需加载额外语言
  * ```ts
  * import { setupCodeHighlighter } from "@antdv-next/x";
+ * import type { LanguageInput } from "shiki";
  *
  * setupCodeHighlighter({
  *   loadLanguage: async (lang) => {
- *     const loaders: Record<string, () => Promise<{ default: any }>> = {
+ *     const loaders: Record<string, () => Promise<{ default: LanguageInput }>> = {
  *       go: () => import("shiki/dist/langs/go.mjs"),
  *       rust: () => import("shiki/dist/langs/rust.mjs"),
  *     };
@@ -55,10 +68,11 @@ let activeLoader: LanguageLoader = defaultLoader;
  * });
  * ```
  */
-export function setupCodeHighlighter(options: {
-  loadLanguage?: LanguageLoader;
-}) {
-  if (options?.loadLanguage) activeLoader = options.loadLanguage;
+export function setupCodeHighlighter(
+  options: SetupCodeHighlighterOptions = {},
+) {
+  customLoader = options.loadLanguage ?? null;
+  failedLangs.clear();
 }
 
 let highlighter: Highlighter | null = null;
@@ -102,7 +116,8 @@ async function loadLang(lang: string) {
 
   const loadPromise = (async () => {
     try {
-      const registration = await activeLoader(lang);
+      const registration =
+        (await customLoader?.(lang)) ?? (await defaultLoader(lang));
       if (!registration) {
         failedLangs.add(lang);
         return false;

--- a/packages/x/components/index.ts
+++ b/packages/x/components/index.ts
@@ -169,9 +169,11 @@ export type {
 export type { SourcesProps } from "./sources";
 export type { WelcomeProps, WelcomeRef } from "./welcome";
 export type {
+  CodeHighlighterLanguageLoader,
   CodeHighlighterProps,
   CodeHighlighterRef,
   CodeHighlighterSemanticType,
+  SetupCodeHighlighterOptions,
 } from "./code-highlighter";
 
 export { setupCodeHighlighter } from "./code-highlighter";


### PR DESCRIPTION
## 背景

收尾 #150 的 CodeHighlighter 白名单 + 用户 loader 方案。#151 已提供扩展入口，但自定义 loader 会完全替换默认白名单，且语言在配置前降级后会被失败缓存永久拦截。

## 改动

- 用户 loader 优先解析语言；返回 `null` 时回退 6 种默认语言白名单
- `setupCodeHighlighter` 重新配置时清除失败缓存，允许此前降级的语言重试
- 使用 Shiki `LanguageInput` 收紧 loader 类型，并导出 `CodeHighlighterLanguageLoader`、`SetupCodeHighlighterOptions`
- 补齐 6 种默认语言、`ts/js/py`、Go/Rust/Java、重复加载、并发加载、纯文本、失败重试及注册异常测试
- 更新中英文文档和 demo，说明初始化时机、fallback 语义及 `shiki` 直接依赖要求

## 验证

- `vp test`：44 个测试文件、428 项测试通过
- `vp run --filter @antdv-next/x type-check`：通过
- 修改文件定向 `vp lint`：0 warnings / 0 errors
- 修改文件定向 `vp fmt --check`：通过
- `vp run build:x`：组件、ESM、UMD 构建通过
- `vp run docs:build`：文档、LLM 文档和站点构建通过
- `vp check`：全仓格式检查通过；仍被 `main` 已有的 docs/x-sdk/x-markdown lint/type 问题阻塞，本 PR 未新增相关问题

Closes #150
