### PR TITLE
perf(docs): reduce initial bundle with on-demand assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "docs:dev": "vp run --filter @antdv-next/x build:token && vp dev packages/docs",
     "docs:preview": "vp preview packages/docs",
     "docs:build": "vp run --filter @antdv-next/docs build",
+    "docs:analyze": "vp run docs:build && vp run --filter @antdv-next/docs analyze",
     "docs:llm": "vp run --filter @antdv-next/docs build:llm",
     "docs:llm:text": "vp run --filter @antdv-next/docs build:llm:text",
     "docs:llm:semantic": "vp run --filter @antdv-next/docs build:llm:semantic",

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vp run --filter @antdv-next/x build:token && node ./scripts/gen-search.mjs && vp dev .",
     "build": "vp run --filter @antdv-next/x build:token && node ./scripts/llm/generate-llms-semantic.mjs && node ./scripts/llm/generate-llms.mjs && node ./scripts/gen-search.mjs && vp build .",
+    "analyze": "node ./scripts/analyze-build.mjs",
     "preview": "vp preview .",
     "build:llm": "node ./scripts/llm/generate-llms-semantic.mjs && node ./scripts/llm/generate-llms.mjs",
     "build:llm:text": "node ./scripts/llm/generate-llms.mjs",
@@ -21,6 +22,7 @@
   },
   "devDependencies": {
     "@antdv-next/auto-import-resolver": "catalog:dev",
+    "@antdv-next/auto-import-resolver-x": "catalog:dev",
     "@mdit-vue/plugin-frontmatter": "catalog:docs",
     "@mdit-vue/plugin-headers": "catalog:docs",
     "@mdit-vue/plugin-title": "catalog:docs",

--- a/packages/docs/plugins/markdown/demo/index.ts
+++ b/packages/docs/plugins/markdown/demo/index.ts
@@ -275,8 +275,14 @@ export default demos
         const normalizedFile = normalizePath(filePath);
         this.addWatchFile(filePath);
 
-        const { locales, sourceCode, jsSourceCode, sourceHtml, jsSourceHtml, extraFiles } =
-          await getParsedDemo(filePath);
+        const {
+          locales,
+          sourceCode,
+          jsSourceCode,
+          sourceHtml,
+          jsSourceHtml,
+          extraFiles,
+        } = await getParsedDemo(filePath);
 
         // Watch extra files so HMR re-runs this loader when they change.
         for (const file of extraFiles) {
@@ -284,17 +290,19 @@ export default demos
         }
 
         const isDev = this.meta?.watchMode === true;
-        // Production: emit highlighted data as a JSON asset for on-demand fetch.
+        // Production: emit source data as a JSON asset for on-demand fetch.
         // getFileName() returns a path relative to outDir root (e.g. "assets/foo.json"),
         // so prefix with BASE_URL to form a root-relative URL that resolves correctly
-        // regardless of deploy base (root "/" or PR-preview "/pr/155/"). Without the
+        // regardless of deploy base (root "/" or a PR-preview subpath). Without the
         // prefix, new URL("assets/foo.json", import.meta.url) doubles the "assets/"
         // segment (chunk already lives under assets/) and 404s.
-        const highlightedUrl = this.getFileName(
+        const sourceUrl = this.getFileName(
           this.emitFile({
             type: "asset",
-            name: `demo-highlighted-${path.basename(filePath, ".vue")}.json`,
+            name: `demo-source-${path.basename(filePath, ".vue")}.json`,
             source: JSON.stringify({
+              source: sourceCode,
+              jsSource: jsSourceCode,
               html: sourceHtml,
               jsHtml: jsSourceHtml,
               extraFiles,
@@ -342,17 +350,15 @@ export default demoData
 import { ref } from 'vue'
 
 const localesRef = ref(${JSON.stringify(locales)})
-const sourceRef = ref(${JSON.stringify(sourceCode)})
-const jsSourceRef = ref(${JSON.stringify(jsSourceCode)})
 
 const demoData = {
   component: () => import(${JSON.stringify(filePath)}),
   get locales() { return localesRef.value },
-  get source() { return sourceRef.value },
-  get jsSource() { return jsSourceRef.value },
-  async loadHighlighted() {
-    const url = new URL(import.meta.env.BASE_URL + ${JSON.stringify(highlightedUrl)}, import.meta.url)
+  async loadSource() {
+    const url = new URL(import.meta.env.BASE_URL + ${JSON.stringify(sourceUrl)}, import.meta.url)
     const res = await fetch(url.href)
+    if (!res.ok)
+      throw new Error(\`Failed to load demo source: \${res.status} \${res.statusText}\`)
     return res.json()
   }
 }
@@ -361,8 +367,6 @@ if (import.meta.hot) {
   import.meta.hot.accept()
   import.meta.hot.on(${JSON.stringify(`demo-update:${normalizedFile}`)}, (data) => {
     if ('locales' in data) localesRef.value = data.locales
-    if ('source' in data) sourceRef.value = data.source
-    if ('jsSource' in data) jsSourceRef.value = data.jsSource
   })
 }
 

--- a/packages/docs/scripts/analyze-build.mjs
+++ b/packages/docs/scripts/analyze-build.mjs
@@ -1,0 +1,129 @@
+import { readFile, readdir, stat } from "node:fs/promises";
+import path from "node:path";
+import { gzipSync } from "node:zlib";
+
+const distDir = path.resolve(
+  process.env.DOCS_DIST_DIR ?? path.join(import.meta.dirname, "../dist"),
+);
+const manifestPath = path.join(distDir, ".vite/manifest.json");
+
+async function collectFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async entry => {
+      const absolutePath = path.join(dir, entry.name);
+      if (entry.isDirectory()) return collectFiles(absolutePath);
+      const fileStat = await stat(absolutePath);
+      const contents = await readFile(absolutePath);
+      return {
+        file: path.relative(distDir, absolutePath),
+        bytes: fileStat.size,
+        gzipBytes: gzipSync(contents).byteLength,
+      };
+    }),
+  );
+  return files.flat();
+}
+
+function formatBytes(bytes) {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 ** 2) return `${(bytes / 1024).toFixed(1)} KiB`;
+  return `${(bytes / 1024 ** 2).toFixed(2)} MiB`;
+}
+
+function summarize(files) {
+  return files.reduce(
+    (summary, file) => ({
+      count: summary.count + 1,
+      bytes: summary.bytes + file.bytes,
+      gzipBytes: summary.gzipBytes + file.gzipBytes,
+    }),
+    { count: 0, bytes: 0, gzipBytes: 0 },
+  );
+}
+
+function printSummaryRow(label, summary) {
+  console.log(
+    `| ${label} | ${summary.count} | ${formatBytes(summary.bytes)} | ${formatBytes(summary.gzipBytes)} |`,
+  );
+}
+
+const files = await collectFiles(distDir);
+const filesByName = new Map(files.map(file => [file.file, file]));
+const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+
+function collectStaticFiles(manifestKey, collected = new Set()) {
+  if (collected.has(manifestKey)) return collected;
+  collected.add(manifestKey);
+  const chunk = manifest[manifestKey];
+  for (const importedKey of chunk?.imports ?? []) {
+    collectStaticFiles(importedKey, collected);
+  }
+  return collected;
+}
+
+function summarizeManifestKeys(keys) {
+  const outputFiles = new Set();
+  for (const key of keys) {
+    const chunk = manifest[key];
+    if (!chunk) continue;
+    if (chunk.file) outputFiles.add(chunk.file);
+    for (const file of chunk.css ?? []) outputFiles.add(file);
+    for (const file of chunk.assets ?? []) outputFiles.add(file);
+  }
+  return summarize(
+    [...outputFiles].map(file => filesByName.get(file)).filter(Boolean),
+  );
+}
+
+const jsFiles = files.filter(file => file.file.endsWith(".js"));
+const cssFiles = files.filter(file => file.file.endsWith(".css"));
+const jsonFiles = files.filter(file => file.file.endsWith(".json"));
+const demoSourceFiles = jsonFiles.filter(file =>
+  path.basename(file.file).startsWith("demo-source-"),
+);
+const entryChunks = Object.entries(manifest).filter(
+  ([, chunk]) => chunk.isEntry,
+);
+
+console.log("# Docs Bundle Report\n");
+console.log("## Totals\n");
+console.log("| Asset | Files | Raw | Gzip |");
+console.log("| --- | ---: | ---: | ---: |");
+printSummaryRow("JavaScript", summarize(jsFiles));
+printSummaryRow("CSS", summarize(cssFiles));
+printSummaryRow("JSON", summarize(jsonFiles));
+printSummaryRow("Demo source JSON", summarize(demoSourceFiles));
+
+console.log("\n## Entry Static Graph\n");
+console.log("| Entry | Files | Raw | Gzip |");
+console.log("| --- | ---: | ---: | ---: |");
+for (const [key, chunk] of entryChunks) {
+  const summary = summarizeManifestKeys(collectStaticFiles(key));
+  printSummaryRow(chunk.file, summary);
+}
+
+console.log("\n## Largest JavaScript Files\n");
+console.log("| File | Raw | Gzip |");
+console.log("| --- | ---: | ---: |");
+for (const file of [...jsFiles]
+  .sort((left, right) => right.bytes - left.bytes)
+  .slice(0, 15)) {
+  console.log(
+    `| ${file.file} | ${formatBytes(file.bytes)} | ${formatBytes(file.gzipBytes)} |`,
+  );
+}
+
+const dynamicEntries = Object.entries(manifest)
+  .filter(([, chunk]) => chunk.isDynamicEntry)
+  .map(([key, chunk]) => ({
+    file: chunk.file,
+    summary: summarizeManifestKeys(collectStaticFiles(key)),
+  }))
+  .sort((left, right) => right.summary.bytes - left.summary.bytes)
+  .slice(0, 15);
+
+console.log("\n## Largest Dynamic Entry Graphs\n");
+console.log("| Entry | Files | Raw | Gzip |");
+console.log("| --- | ---: | ---: | ---: |");
+for (const entry of dynamicEntries) printSummaryRow(entry.file, entry.summary);

--- a/packages/docs/src/components/doc-demo/demo.vue
+++ b/packages/docs/src/components/doc-demo/demo.vue
@@ -168,31 +168,57 @@ const router = useRouter();
 const showCode = shallowRef(false);
 const codeType = shallowRef<string>("ts");
 const demo = shallowRef<any>(null);
-const highlighted = shallowRef<any>(null);
+const sourceData = shallowRef<any>(null);
+const sourceLoading = shallowRef(false);
+const sourceLoadError = shallowRef<Error | null>(null);
 const demoLoading = shallowRef(true);
 let demoLoadVersion = 0;
+let sourceLoadPromise: Promise<void> | null = null;
 
-// When user clicks "show code", load the highlighted source code on demand.
-// In build mode, highlighted data is loaded via loadHighlighted().
-// In dev mode, highlighted data is already embedded in the demo object.
-watch(showCode, async (val) => {
-  if (val && !highlighted.value) {
-    if (demo.value?.loadHighlighted) {
-      try {
-        highlighted.value = await demo.value.loadHighlighted();
-      } catch {
-        // ignore load failures
+async function ensureSourceLoaded() {
+  if (sourceData.value || !demo.value) return;
+  if (sourceLoadPromise) return sourceLoadPromise;
+
+  const currentDemo = demo.value;
+  sourceLoading.value = true;
+  sourceLoadError.value = null;
+
+  const request = Promise.resolve(
+    currentDemo.loadSource ? currentDemo.loadSource() : currentDemo,
+  )
+    .then(data => {
+      if (demo.value === currentDemo) sourceData.value = data;
+    })
+    .catch(error => {
+      const loadError =
+        error instanceof Error ? error : new Error(String(error));
+      if (demo.value === currentDemo) sourceLoadError.value = loadError;
+      throw loadError;
+    })
+    .finally(() => {
+      if (sourceLoadPromise === request) {
+        sourceLoadPromise = null;
+        sourceLoading.value = false;
       }
-    } else {
-      // Dev mode: data is already embedded directly.
-      highlighted.value = demo.value;
-    }
-  }
-});
+    });
 
-// Reset highlighted when demo changes.
-watch(demo, () => {
-  highlighted.value = null;
+  sourceLoadPromise = request;
+  return request;
+}
+
+watch(
+  demo,
+  () => {
+    sourceData.value = null;
+    sourceLoadError.value = null;
+    sourceLoadPromise = null;
+    sourceLoading.value = false;
+  },
+  { flush: "sync" },
+);
+
+watch([showCode, demo], ([visible, currentDemo]) => {
+  if (visible && currentDemo) void ensureSourceLoaded().catch(() => {});
 });
 
 watch(
@@ -239,10 +265,10 @@ const component = computed<Component | undefined>(() => {
 });
 
 const id = computed(() => getDemoId(props.src));
-const hasJsSource = computed(() => Boolean(demo.value?.jsSource?.trim()));
+const hasJsSource = computed(() => Boolean(sourceData.value?.jsSource?.trim()));
 const extraFiles = computed<
   { name: string; lang: string; code: string; html: string }[]
->(() => highlighted.value?.extraFiles ?? []);
+>(() => sourceData.value?.extraFiles ?? []);
 const hasExtraFiles = computed(() => extraFiles.value.length > 0);
 const hasCodeTabs = computed(() => hasJsSource.value || hasExtraFiles.value);
 const codeTabKeys = computed(() => {
@@ -266,14 +292,14 @@ const activeExtraFile = computed(() =>
 const sourceCode = computed(() => {
   if (activeExtraFile.value) return activeExtraFile.value.code;
   if (activeCodeType.value === "js")
-    return demo.value?.jsSource || demo.value?.source || "";
-  return demo.value?.source || "";
+    return sourceData.value?.jsSource || sourceData.value?.source || "";
+  return sourceData.value?.source || "";
 });
 const sourceHtml = computed(() => {
   if (activeExtraFile.value) return activeExtraFile.value.html;
   if (activeCodeType.value === "js")
-    return highlighted.value?.jsHtml || highlighted.value?.html || "";
-  return highlighted.value?.html || "";
+    return sourceData.value?.jsHtml || sourceData.value?.html || "";
+  return sourceData.value?.html || "";
 });
 
 const { copied, copy } = useClipboard({
@@ -306,12 +332,28 @@ function navigateToAnchor(event: MouseEvent) {
   });
 }
 
-function openPlayground() {
-  window.open(
-    loadPlaygroundUrl(demo.value?.source || ""),
-    "_blank",
-    "noopener,noreferrer",
-  );
+async function copySource() {
+  try {
+    await ensureSourceLoaded();
+    await copy();
+  } catch {
+    showCode.value = true;
+  }
+}
+
+async function openPlayground() {
+  const playgroundWindow = window.open("about:blank", "_blank");
+  if (playgroundWindow) playgroundWindow.opener = null;
+
+  try {
+    await ensureSourceLoaded();
+    const url = loadPlaygroundUrl(sourceData.value?.source || "");
+    if (playgroundWindow) playgroundWindow.location.replace(url);
+    else window.open(url, "_blank", "noopener,noreferrer");
+  } catch {
+    playgroundWindow?.close();
+    showCode.value = true;
+  }
 }
 </script>
 
@@ -362,7 +404,7 @@ function openPlayground() {
             <button
               class="ant-doc-demo-box-code-action"
               type="button"
-              @click="copy()"
+              @click="copySource"
             >
               <CheckOutlined v-if="copied" />
               <CopyOutlined v-else />
@@ -401,13 +443,26 @@ function openPlayground() {
             />
           </a-tabs>
         </div>
-        <div class="ant-doc-demo-box-code">
+        <div v-if="sourceLoading" class="ant-doc-demo-box-code">
+          <a-spin />
+        </div>
+        <div v-else-if="sourceLoadError" class="ant-doc-demo-box-code">
+          <a-alert
+            type="error"
+            :message="
+              preferredLocale === 'en-US'
+                ? 'Failed to load source code'
+                : '源码加载失败'
+            "
+          />
+        </div>
+        <div v-else class="ant-doc-demo-box-code">
           <a-tooltip :title="copied ? '已复制' : '复制代码'">
             <button
               class="ant-doc-demo-box-code-copy"
               :class="{ 'ant-doc-demo-box-code-copied': copied }"
               type="button"
-              @click="copy()"
+              @click="copySource"
             >
               <CopyOutlined v-if="!copied" />
               <CheckOutlined v-else />

--- a/packages/docs/src/main.ts
+++ b/packages/docs/src/main.ts
@@ -1,4 +1,3 @@
-import Antdx from "@antdv-next/x";
 import "@antdv-next/x-markdown/themes/index.css";
 import dayjs from "dayjs";
 import advancedFormat from "dayjs/plugin/advancedFormat";
@@ -32,7 +31,6 @@ const app = createApp(App);
 app.use(createPinia());
 app.use(router);
 app.use(i18n);
-app.use(Antdx);
 app.component("Demo", Demo);
 app.component("DemoGroup", DemoGroup);
 app.component("ComponentOverview", ComponentOverview);

--- a/packages/docs/vite.config.ts
+++ b/packages/docs/vite.config.ts
@@ -1,4 +1,5 @@
 import { AntdvNextResolver } from "@antdv-next/auto-import-resolver";
+import { AntdvNextXResolver } from "@antdv-next/auto-import-resolver-x";
 import vue from "@vitejs/plugin-vue";
 import vueJsx from "@vitejs/plugin-vue-jsx";
 import { fileURLToPath, URL } from "node:url";
@@ -34,10 +35,18 @@ export default defineConfig({
     components({
       dts: "types/components.d.ts",
       dirs: [],
-      resolvers: [AntdvNextResolver()],
+      resolvers: [
+        AntdvNextResolver(),
+        AntdvNextXResolver(),
+        name =>
+          name === "AxFolder"
+            ? { name: "Folder", from: "@antdv-next/x" }
+            : undefined,
+      ],
     }),
   ],
   build: {
+    manifest: true,
     modulePreload: false,
   },
   resolve: {

--- a/packages/x/components/code-highlighter/shiki-runtime.ts
+++ b/packages/x/components/code-highlighter/shiki-runtime.ts
@@ -1,0 +1,16 @@
+import { createHighlighterCore } from "shiki/core";
+import darkTheme from "shiki/dist/themes/vitesse-dark.mjs";
+import lightTheme from "shiki/dist/themes/vitesse-light.mjs";
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
+
+export type CodeHighlighterInstance = Awaited<
+  ReturnType<typeof createHighlighterCore>
+>;
+
+export function createHighlighter() {
+  return createHighlighterCore({
+    themes: [lightTheme, darkTheme],
+    langs: [],
+    engine: createJavaScriptRegexEngine(),
+  });
+}

--- a/packages/x/components/code-highlighter/shiki.ts
+++ b/packages/x/components/code-highlighter/shiki.ts
@@ -1,11 +1,6 @@
 import type { LanguageInput } from "shiki";
 
-import { createHighlighterCore } from "shiki/core";
-import darkTheme from "shiki/dist/themes/vitesse-dark.mjs";
-import lightTheme from "shiki/dist/themes/vitesse-light.mjs";
-import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
-
-type Highlighter = Awaited<ReturnType<typeof createHighlighterCore>>;
+import type { CodeHighlighterInstance } from "./shiki-runtime";
 
 export type CodeHighlighterLanguageLoader = (
   lang: string,
@@ -75,8 +70,8 @@ export function setupCodeHighlighter(
   failedLangs.clear();
 }
 
-let highlighter: Highlighter | null = null;
-let highlighterPromise: Promise<Highlighter> | null = null;
+let highlighter: CodeHighlighterInstance | null = null;
+let highlighterPromise: Promise<CodeHighlighterInstance> | null = null;
 const loadedLangs = new Set<string>();
 const failedLangs = new Set<string>();
 const languageLoadPromises = new Map<string, Promise<boolean>>();
@@ -97,11 +92,9 @@ function escapeHtml(str: string): string {
 async function getHighlighter() {
   if (highlighter) return highlighter;
   if (!highlighterPromise) {
-    highlighterPromise = createHighlighterCore({
-      themes: [lightTheme, darkTheme],
-      langs: [],
-      engine: createJavaScriptRegexEngine(),
-    });
+    highlighterPromise = import("./shiki-runtime").then(
+      ({ createHighlighter }) => createHighlighter(),
+    );
   }
   highlighter = await highlighterPromise;
   return highlighter;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,9 @@ catalogs:
     '@antdv-next/auto-import-resolver':
       specifier: ^1.0.5
       version: 1.0.7
+    '@antdv-next/auto-import-resolver-x':
+      specifier: ^0.0.1
+      version: 0.0.1
     '@tsconfig/node24':
       specifier: ^24.0.4
       version: 24.0.4
@@ -385,6 +388,9 @@ importers:
       '@antdv-next/auto-import-resolver':
         specifier: catalog:dev
         version: 1.0.7(unplugin-vue-components@31.1.0(vue@3.5.31(typescript@5.9.3)))
+      '@antdv-next/auto-import-resolver-x':
+        specifier: catalog:dev
+        version: 0.0.1(unplugin-vue-components@31.1.0(vue@3.5.31(typescript@5.9.3)))
       '@mdit-vue/plugin-frontmatter':
         specifier: catalog:docs
         version: 2.1.4
@@ -609,6 +615,12 @@ packages:
 
   '@ant-design/icons-svg@4.4.2':
     resolution: {integrity: sha512-vHbT+zJEVzllwP+CM+ul7reTEfBR0vgxFe7+lREAsAA7YGsYpboiq2sQNeQeRvh09GfQgs/GyFEvZpJ9cLXpXA==}
+
+  '@antdv-next/auto-import-resolver-x@0.0.1':
+    resolution: {integrity: sha512-d+lkZVkmzkB8135jdDRal717eVqapamhUvxlsjx8VIBq3pcDsaIf8a+WbcCa1jO3m+EUnwgVrJvSP8Hvo2nzKg==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      unplugin-vue-components: '>=28.0.0'
 
   '@antdv-next/auto-import-resolver@1.0.7':
     resolution: {integrity: sha512-ae//2gWonFNZiw94DdHvi+2LJCitPaTCn8jeyS9yHUzlS2PWKTTEPsjMZ8u65GzFehlE5YnAbgSn2vH+wd+usA==}
@@ -4470,6 +4482,10 @@ snapshots:
   '@ant-design/fast-color@3.0.1': {}
 
   '@ant-design/icons-svg@4.4.2': {}
+
+  '@antdv-next/auto-import-resolver-x@0.0.1(unplugin-vue-components@31.1.0(vue@3.5.31(typescript@5.9.3)))':
+    dependencies:
+      unplugin-vue-components: 31.1.0(vue@3.5.31(typescript@5.9.3))
 
   '@antdv-next/auto-import-resolver@1.0.7(unplugin-vue-components@31.1.0(vue@3.5.31(typescript@5.9.3)))':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,7 @@ catalog:
 catalogs:
   dev:
     "@antdv-next/auto-import-resolver": ^1.0.5
+    "@antdv-next/auto-import-resolver-x": ^0.0.1
     typedoc: ^0.28.19
     "@tsconfig/node24": ^24.0.4
     bumpp: ^11.1.0


### PR DESCRIPTION
## Summary

- auto-import `@antdv-next/x` components in the docs site instead of installing the full component plugin
- lazy-load the Shiki runtime and demo source/highlight payloads when source code is requested
- emit a Vite manifest and add a reusable docs bundle analyzer
- keep route-level splitting intact instead of forcing shared `manualChunks`

## Bundle impact

| Metric | `origin/main` | This PR |
| --- | ---: | ---: |
| JavaScript raw | 11.12 MiB | 9.32 MiB |
| JavaScript gzip | 2.99 MiB | 2.70 MiB |
| Entry raw | 1.24 MiB | 679.0 KiB |
| Entry gzip | 352.7 KiB | 186.5 KiB |
| Entry static graph raw | 2.82 MiB | 2.24 MiB |
| Entry static graph gzip | 700.5 KiB | 533.2 KiB |

The Shiki regex engine is now a dynamic chunk (184.6 KiB raw / 55.8 KiB gzip).

## Validation

- `vp test` (44 files, 428 tests passed)
- `vp run --filter @antdv-next/x type-check`
- targeted `vp lint` for changed source files
- `vp run docs:build`
- `vp run --filter @antdv-next/docs analyze`
- production HTTP checks for `/components/bubble`, demo source JSON, and the Shiki runtime chunk

Full `vp check` remains blocked by pre-existing docs optional-chain, x-sdk lint, and x-markdown TypeScript stack-depth errors.

Part of #152.