### PR TITLE
perf(docs): report long-tail manifest ownership

### DIFF
--- a/packages/docs/scripts/analyze-build.mjs
+++ b/packages/docs/scripts/analyze-build.mjs
@@ -51,6 +51,7 @@ function printSummaryRow(label, summary) {
 const files = await collectFiles(distDir);
 const filesByName = new Map(files.map(file => [file.file, file]));
 const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+const docsRoot = path.resolve(distDir, "..");
 
 function collectStaticFiles(manifestKey, collected = new Set()) {
   if (collected.has(manifestKey)) return collected;
@@ -74,6 +75,85 @@ function summarizeManifestKeys(keys) {
   return summarize(
     [...outputFiles].map(file => filesByName.get(file)).filter(Boolean),
   );
+}
+
+function classifyLongTail(key, chunk) {
+  const source = `${key} ${chunk.file ?? ""}`.toLowerCase();
+  const outputName = path.basename(chunk.file ?? "").toLowerCase();
+
+  if (source.includes("node_modules/@antv/infographic"))
+    return "infographic runtime";
+  if (
+    source.includes("node_modules/mermaid/") ||
+    source.includes("node_modules/@mermaid-js/")
+  )
+    return "mermaid runtime";
+  if (outputName.startsWith("chunk-")) return "chunk-* shared";
+  if (
+    source.includes("locale") ||
+    source.includes("defaultlocale") ||
+    source.includes("uselocale")
+  )
+    return "locale";
+  if (source.includes("infographic")) return "infographic route";
+  if (source.includes("mermaid")) return "mermaid route";
+  return null;
+}
+
+function formatManifestKey(key) {
+  if (key.startsWith(`${docsRoot}${path.sep}`))
+    return path.relative(docsRoot, key);
+  return key;
+}
+
+function formatImporterSamples(importers) {
+  if (!importers) return "-";
+  const owners = [
+    ...[...importers.static].map(key => `S:${formatManifestKey(key)}`),
+    ...[...importers.dynamic].map(key => `D:${formatManifestKey(key)}`),
+  ];
+  const visibleOwners = owners.slice(0, 3).join("<br>");
+  return owners.length > 3
+    ? `${visibleOwners}<br>+${owners.length - 3} more`
+    : visibleOwners;
+}
+
+const manifestImporters = new Map();
+for (const [key, chunk] of Object.entries(manifest)) {
+  for (const importedKey of chunk.imports ?? []) {
+    const importers = manifestImporters.get(importedKey) ?? {
+      static: new Set(),
+      dynamic: new Set(),
+    };
+    importers.static.add(key);
+    manifestImporters.set(importedKey, importers);
+  }
+  for (const importedKey of chunk.dynamicImports ?? []) {
+    const importers = manifestImporters.get(importedKey) ?? {
+      static: new Set(),
+      dynamic: new Set(),
+    };
+    importers.dynamic.add(key);
+    manifestImporters.set(importedKey, importers);
+  }
+}
+
+const longTailGroups = new Map();
+for (const [key, chunk] of Object.entries(manifest)) {
+  if (!chunk.file?.endsWith(".js")) continue;
+  const category = classifyLongTail(key, chunk);
+  const file = filesByName.get(chunk.file);
+  if (!category || !file) continue;
+
+  const entries = longTailGroups.get(category) ?? new Map();
+  if (!entries.has(chunk.file)) {
+    entries.set(chunk.file, {
+      key,
+      file,
+      importers: manifestImporters.get(key),
+    });
+  }
+  longTailGroups.set(category, entries);
 }
 
 const jsFiles = files.filter(file => file.file.endsWith(".js"));
@@ -127,3 +207,28 @@ console.log("\n## Largest Dynamic Entry Graphs\n");
 console.log("| Entry | Files | Raw | Gzip |");
 console.log("| --- | ---: | ---: | ---: |");
 for (const entry of dynamicEntries) printSummaryRow(entry.file, entry.summary);
+
+console.log("\n## Long-tail Ownership\n");
+console.log("| Category | Files | Raw | Gzip |");
+console.log("| --- | ---: | ---: | ---: |");
+for (const [category, entries] of longTailGroups) {
+  printSummaryRow(
+    category,
+    summarize([...entries.values()].map(entry => entry.file)),
+  );
+}
+
+console.log("\n### Largest Long-tail Outputs\n");
+console.log(
+  "| Category | Output | Manifest owner | Raw | Gzip | Static refs | Dynamic refs | Importer samples |",
+);
+console.log("| --- | --- | --- | ---: | ---: | ---: | ---: | --- |");
+for (const [category, entries] of longTailGroups) {
+  for (const [output, entry] of [...entries]
+    .sort(([, left], [, right]) => right.file.bytes - left.file.bytes)
+    .slice(0, 5)) {
+    console.log(
+      `| ${category} | ${output} | ${formatManifestKey(entry.key)} | ${formatBytes(entry.file.bytes)} | ${formatBytes(entry.file.gzipBytes)} | ${entry.importers?.static.size ?? 0} | ${entry.importers?.dynamic.size ?? 0} | ${formatImporterSamples(entry.importers)} |`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- classify manifest entries for shared `chunk-*`, locale, infographic, and Mermaid long-tail assets
- report unique file counts, raw/gzip sizes, and static/dynamic importer samples
- keep the existing entry and dynamic graph reports while making long-tail ownership reproducible

## Validation

- `vp test` (44 files, 428 tests passed)
- `vp run docs:build`
- `vp run --filter @antdv-next/docs analyze`
- `vp run --filter @antdv-next/x type-check`
- `vp check` still reports the repository's pre-existing docs/x-sdk/x-markdown issues

Refs #152
