### PR TITLE
fix(x-sdk): release XStream reader on early exit

### DIFF
--- a/packages/x-sdk/src/x-stream/__tests__/index.test.ts
+++ b/packages/x-sdk/src/x-stream/__tests__/index.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+
+import XStream from "../index";
+
+const encoder = new TextEncoder();
+
+describe("XStream", () => {
+  it("cancels the source and releases the reader lock on early exit", async () => {
+    const cancel = vi.fn();
+    const stream = XStream({
+      readableStream: new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode("data: first\n\n"));
+        },
+        cancel,
+      }),
+    });
+
+    for await (const value of stream) {
+      expect(value).toEqual({ data: "first" });
+      break;
+    }
+
+    expect(stream.locked).toBe(false);
+    await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce());
+
+    const reader = stream.getReader();
+    await expect(reader.read()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+    reader.releaseLock();
+  });
+
+  it("preserves the consumer error when cancellation fails", async () => {
+    const consumerError = new Error("consumer failed");
+    const cancelError = new Error("cancel failed");
+    const cancel = vi.fn(() => Promise.reject(cancelError));
+    const stream = XStream({
+      readableStream: new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode("data: first\n\n"));
+        },
+        cancel,
+      }),
+    });
+
+    const consume = async () => {
+      for await (const _value of stream) {
+        throw consumerError;
+      }
+    };
+
+    await expect(consume()).rejects.toBe(consumerError);
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(stream.locked).toBe(false);
+  });
+
+  it("releases the reader lock without cancellation after normal completion", async () => {
+    const cancel = vi.fn();
+    const stream = XStream({
+      readableStream: new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode("data: first\n\n"));
+          controller.enqueue(encoder.encode("data: second\n\n"));
+          controller.close();
+        },
+        cancel,
+      }),
+    });
+    const values = [];
+
+    for await (const value of stream) {
+      values.push(value);
+    }
+
+    expect(values).toEqual([{ data: "first" }, { data: "second" }]);
+    expect(cancel).not.toHaveBeenCalled();
+    expect(stream.locked).toBe(false);
+  });
+});

--- a/packages/x-sdk/src/x-stream/index.ts
+++ b/packages/x-sdk/src/x-stream/index.ts
@@ -213,16 +213,32 @@ function XStream<Output = SSEOutput>(options: XStreamOptions<Output>) {
   // @ts-ignore ReadableStream async iterator signature conflicts with AsyncGenerator in this cross-runtime typing.
   stream[Symbol.asyncIterator] = async function* () {
     const reader = this.getReader();
+    let completed = false;
 
-    while (true) {
-      const { done, value } = await reader.read();
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
 
-      if (done) break;
+        if (done) {
+          completed = true;
+          break;
+        }
 
-      if (!value) continue;
+        if (!value) continue;
 
-      // Transformed data through all transform pipes
-      yield value;
+        // Transformed data through all transform pipes
+        yield value;
+      }
+    } finally {
+      if (!completed) {
+        try {
+          await reader.cancel();
+        } catch {
+          // Cancellation must not replace the consumer's original error.
+        }
+      }
+
+      reader.releaseLock();
     }
   };
 


### PR DESCRIPTION
[中文版模板 / Chinese template](./PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- Closes #142
- Syncs ant-design/x#1970 (`028b7436a23f0433a635de0dfa3777dbf56515ff`)

### 💡 Background and Solution

`XStream` acquired a reader for its async iterator without releasing it when a consumer exited a `for await...of` loop early. This left the stream locked and allowed the underlying source to continue buffering.

This change:

- wraps the read loop in `try/finally` and distinguishes normal completion from early exit
- cancels unfinished streams on `break`, `return`, or consumer errors
- suppresses cancellation failures so they do not replace the consumer's original error
- always releases the reader lock
- covers early exit, cancellation failure, and normal completion with tests

Verification:

- `vp test packages/x-sdk/src/x-stream/__tests__/index.test.ts` — 3 passed
- `vp test` — 46 files, 445 tests passed
- `vp check packages/x-sdk/src/x-stream/index.ts packages/x-sdk/src/x-stream/__tests__/index.test.ts` — passed
- repository-wide `vp check` formatting passed; lint/type checking is currently blocked by 43 unrelated existing errors outside this change

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Release the XStream reader lock and cancel the underlying stream when async iteration exits early. |
| 🇨🇳 Chinese | 修复 XStream 异步迭代提前退出时 reader lock 未释放且底层流继续缓冲的问题。 |