### PR TITLE
docs: unify Semantic DOM headings in Chinese docs

### DIFF
--- a/packages/docs/src/pages/components/file-card/index.zh-CN.md
+++ b/packages/docs/src/pages/components/file-card/index.zh-CN.md
@@ -100,7 +100,7 @@ type PresetIcons =
 
 > 推荐优先使用 `FileCardList` 导出。`FileCard.List` 旧写法仍兼容。
 
-## 语义化 DOM
+## Semantic DOM
 
 <demo src="./demo/semantic.vue" simplify>FileCard 语义结构</demo>
 

--- a/packages/docs/src/pages/components/folder/index.zh-CN.md
+++ b/packages/docs/src/pages/components/folder/index.zh-CN.md
@@ -21,7 +21,7 @@ tag: 1.1.0
 <demo src="./demo/preview-render.vue">自定义预览内容</demo>
 <demo src="./demo/slots.vue">自定义插槽</demo>
 
-## 语义化 DOM
+## Semantic DOM
 
 <demo src="./demo/semantic.vue" simplify>Folder 语义结构</demo>
 


### PR DESCRIPTION
[中文版模板 / Chinese template](./PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- Closes #143
- Syncs ant-design/x#1877 (`3f1aa9fd7f5fea22e1fe6df9276f19eab31bdb7a`)

### 💡 Background and Solution

The Chinese FileCard and Folder documentation still used the translated `语义化 DOM` section heading, while the upstream documentation standardized this section as `Semantic DOM`.

This change updates only those two section headings. The existing Chinese descriptions remain unchanged. The generated documentation search index contains the expected `/components/file-card#semantic-dom` and `/components/folder#semantic-dom` anchors.

Verification:

- `vp check packages/docs/src/pages/components/file-card/index.zh-CN.md packages/docs/src/pages/components/folder/index.zh-CN.md` — passed
- `vp run docs:build` — passed; 398 Chinese and 398 English search documents generated
- generated search index contains both `#semantic-dom` anchors
- `vp test` — 45 files, 442 tests passed
- repository-wide `vp check` formatting passed; lint/type checking is currently blocked by 2 unrelated existing errors in `packages/x-markdown/vite.build.config.ts`

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Standardize the Semantic DOM section heading in the Chinese FileCard and Folder documentation. |
| 🇨🇳 Chinese | 统一 FileCard 和 Folder 中文文档中的 Semantic DOM 章节标题。 |