### PR TITLE
fix(docs): hide component overview search focus outline

### DIFF
--- a/packages/docs/src/components/component-overview/index.vue
+++ b/packages/docs/src/components/component-overview/index.vue
@@ -36,6 +36,9 @@ const useStyles = createStyles(({ token }) => ({
       width: "100%",
       fontSize: 18,
       paddingInline: 0,
+      "&:focus-visible, &:has(input:focus-visible)": {
+        outline: "none !important",
+      },
     },
     ".component-overview-search-input input": {
       fontSize: 18,


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [x] 🐞 Bug 修复
- [x] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [x] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

- Fixes #147
- 同步上游 ant-design/x#1987（commit `2241c95ad459d3fd95b345b14558d1c7a9eaaa9f`）

### 💡 背景与方案

组件总览页的 borderless 搜索框在聚焦时会显示与页面设计不一致的蓝色 outline。

本次在 `.component-overview-search-input` 范围内覆盖 wrapper 自身的 `:focus-visible`，以及内部 input 获得 `:focus-visible` 的场景。该选择器由组件总览根样式作用域限定，不影响文档站其他输入框。

验证：

- 键盘与鼠标聚焦时，wrapper 和内部 input 的 computed `outline-style` 均为 `none`
- 搜索、清除与 Affix 状态切换正常
- `vp run docs:build` 通过
- `vp test` 通过（45 files，442 tests）

### 📝 变更日志

| 语言    | 变更日志 |
| ------- | -------- |
| 🇺🇸 英文 | Hide the focus outline on the Components Overview search input. |
| 🇨🇳 中文 | 移除组件总览搜索框聚焦时的额外轮廓。 |