### PR TITLE
fix(thought-chain): make line prop effective

### DIFF
--- a/packages/x/components/thought-chain/Node.tsx
+++ b/packages/x/components/thought-chain/Node.tsx
@@ -28,10 +28,6 @@ export default defineComponent({
       type: Number,
       required: true,
     },
-    isLast: {
-      type: Boolean,
-      default: false,
-    },
     prefixCls: {
       type: String,
       required: true,
@@ -40,7 +36,7 @@ export default defineComponent({
       type: [Boolean, String] as PropType<
         boolean | "solid" | "dashed" | "dotted"
       >,
-      default: "solid",
+      default: true,
     },
     expanded: {
       type: Boolean,
@@ -93,13 +89,6 @@ export default defineComponent({
 
     const nodePrefixCls = computed(() => `${props.prefixCls}-node`);
 
-    // Resolve line border style
-    const resolvedLineStyle = computed(() => {
-      if (props.lineStyle === false || props.isLast) return "none";
-      if (props.lineStyle === true) return "solid";
-      return props.lineStyle;
-    });
-
     const statusCls = computed(() => `${props.prefixCls}-status`);
 
     const createSharedSlotInfo = (collapsible: boolean) => ({
@@ -141,9 +130,9 @@ export default defineComponent({
             props.classes?.itemIcon,
             {
               [`${statusCls.value}-${item.status}`]: item.status,
-              [`${nodePrefixCls.value}-icon-${resolvedLineStyle.value}`]:
-                typeof props.lineStyle !== "boolean" &&
-                resolvedLineStyle.value !== "none",
+              [`${nodePrefixCls.value}-icon-${props.lineStyle}`]:
+                typeof props.lineStyle === "string",
+              [`${nodePrefixCls.value}-icon-none`]: props.lineStyle === false,
             },
           ]}
           style={props.styles?.itemIcon}

--- a/packages/x/components/thought-chain/ThoughtChain.tsx
+++ b/packages/x/components/thought-chain/ThoughtChain.tsx
@@ -63,7 +63,7 @@ export const XThoughtChain = defineComponent({
       type: [Boolean, String] as PropType<
         boolean | "solid" | "dashed" | "dotted"
       >,
-      default: "solid",
+      default: true,
     },
   },
   emits: ["update:expandedKeys", "expand"],
@@ -186,7 +186,6 @@ export const XThoughtChain = defineComponent({
                 key={key}
                 item={item}
                 index={index}
-                isLast={index === items.length - 1}
                 prefixCls={prefixCls.value}
                 lineStyle={props.line}
                 expanded={mergedExpandedKeys.value.includes(key)}

--- a/packages/x/components/thought-chain/__tests__/index.test.tsx
+++ b/packages/x/components/thought-chain/__tests__/index.test.tsx
@@ -20,6 +20,40 @@ describe("ThoughtChain", () => {
     expect(wrapper.findAll(".antd-thought-chain-node").length).toBe(3);
   });
 
+  it.each([
+    ["solid", "antd-thought-chain-node-icon-solid"],
+    ["dashed", "antd-thought-chain-node-icon-dashed"],
+    ["dotted", "antd-thought-chain-node-icon-dotted"],
+  ] as const)("applies the %s line style", (line, expectedClass) => {
+    const wrapper = mount(ThoughtChain, {
+      props: { items: basicItems, line },
+    });
+
+    wrapper.findAll(".antd-thought-chain-node-icon").forEach(icon => {
+      expect(icon.classes()).toContain(expectedClass);
+    });
+  });
+
+  it("uses the base solid style when line is true", () => {
+    const wrapper = mount(ThoughtChain, {
+      props: { items: basicItems, line: true },
+    });
+
+    expect(wrapper.find(".antd-thought-chain-node-icon-solid").exists()).toBe(
+      false,
+    );
+  });
+
+  it("hides connector lines when line is false", () => {
+    const wrapper = mount(ThoughtChain, {
+      props: { items: basicItems, line: false },
+    });
+
+    wrapper.findAll(".antd-thought-chain-node-icon").forEach(icon => {
+      expect(icon.classes()).toContain("antd-thought-chain-node-icon-none");
+    });
+  });
+
   it("renders custom prefixCls, rootClassName, class", () => {
     const wrapper = mount(ThoughtChain, {
       props: {

--- a/packages/x/components/thought-chain/style/thought-chain.ts
+++ b/packages/x/components/thought-chain/style/thought-chain.ts
@@ -105,6 +105,13 @@ const genThoughtChainStyle: GenerateStyle<ThoughtChainToken> = token => {
         },
       },
 
+      // Hidden line
+      [`${componentCls}-node-icon-none`]: {
+        "&:after": {
+          display: "none",
+        },
+      },
+
       // Dashed line
       [`${componentCls}-node-icon-dashed`]: {
         "&:after": {


### PR DESCRIPTION
[English template / 英文模板](./PULL_REQUEST_TEMPLATE.md)

### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [x] 🐞 Bug 修复
- [ ] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [x] 💄 组件样式改进
- [ ] 🤖 TypeScript 类型定义改进
- [ ] 📦 包体积优化
- [ ] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [x] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

暂无。

### 💡 背景与方案

`ThoughtChain` 的 `line` 属性没有完整生效：布尔值 `false` 被解析为无连线状态后，没有生成对应的样式类，而基础伪元素仍会绘制实线。

本次修复对齐上游 `x-ant-design` 的实现方式：

- 使用基础样式表示 `line=true` 的实线状态。
- 为 `solid`、`dashed`、`dotted` 字符串值生成对应的节点图标样式类。
- 为 `line=false` 增加 `node-icon-none` 样式，明确隐藏连接线。
- 继续通过 `:last-of-type` 隐藏最后一个节点的连接线。
- 增加覆盖全部 `line` 取值的单元测试。

验证结果：

- `vp check`：0 errors（仓库现有 8 条无关 warning）
- `vp test`：45 个测试文件、447 个测试通过
- `vp run --filter @antdv-next/x build`：通过

### 📝 变更日志

| 语言    | 变更日志 |
| ------- | -------- |
| 🇺🇸 英文 | Fix ThoughtChain connector line styles not responding to the `line` prop. |
| 🇨🇳 中文 | 修复 ThoughtChain 连接线样式未正确响应 `line` 属性的问题。 |
