### PR TITLE
fix(docs): token color chunk popover preview sync (#1994)

### DIFF
--- a/packages/docs/src/components/color-chunk/index.vue
+++ b/packages/docs/src/components/color-chunk/index.vue
@@ -42,6 +42,7 @@ const styles = computed(() => ({
 <template>
   <Popover
     v-if="enablePopover"
+    destroyOnHidden
     placement="left"
     :styles="{
       container: {
@@ -52,8 +53,7 @@ const styles = computed(() => ({
         borderRadius: token.borderRadiusLG,
       },
       root: {
-        '--antd-arrow-background-color': dotColor,
-        backgroundColor: 'transparent',
+        '--ant-tooltip-arrow-background-color': dotColor,
       },
     }"
   >


### PR DESCRIPTION
### 🤔 This is a ...
- [x] 🐞 Bug fix
- [x] 📝 Site / documentation improvement

### 🔗 Related Issues
- close #144
- sync upstream ant-design/x#1994

### 💡 Background and Solution
Syncing upstream PR [ant-design/x#1994](https://github.com/ant-design/x/pull/1994) to fix the Token color-chunk Popover preview.

The docs color-chunk component read a non-existent `--antd-arrow-background-color` on its root, while the current antdv-next Popover actually reads `--ant-tooltip-arrow-background-color`. This made the popover arrow default to the theme arrow color instead of the actual Token color.

Changes:
- Use `--ant-tooltip-arrow-background-color` for the Popover arrow so it matches the Token color.
- Add `destroyOnHidden` so the preview DOM is removed after closing.
- Remove the now-unnecessary transparent root background override.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the docs Token color-chunk popover preview so the container and arrow show the actual Token color, and destroy the preview DOM on close. |
| 🇨🇳 Chinese | 修复文档 Token 色块 Popover 预览，容器与箭头显示实际 Token 颜色，并在关闭后销毁预览 DOM。 |