### PR TITLE
[sync] fix(suggestion): scroll long option lists inside the popup (#1983)

### DIFF
--- a/packages/docs/src/pages/components/suggestion/demo/long-list.vue
+++ b/packages/docs/src/pages/components/suggestion/demo/long-list.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import type { SuggestionItem } from "@antdv-next/x";
+
+import { ref } from "vue";
+
+const value = ref("");
+
+const items: SuggestionItem[] = Array.from({ length: 30 }, (_, index) => ({
+  label: `Suggestion option ${index + 1}`,
+  value: `option-${index + 1}`,
+}));
+
+const onSelect = (itemValue: string) => {
+  value.value = `[${itemValue}]:`;
+};
+
+const onSenderChange = (
+  nextValue: string,
+  onTrigger: (info?: string | false) => void,
+) => {
+  if (nextValue === "/") {
+    onTrigger();
+  } else if (!nextValue) {
+    onTrigger(false);
+  }
+
+  value.value = nextValue;
+};
+</script>
+
+<template>
+  <ax-suggestion :items="items" @select="onSelect">
+    <template #default="{ onTrigger, onKeyDown }">
+      <ax-sender
+        :value="value"
+        placeholder="输入 / 获取建议"
+        :on-change="(nextValue: string) => onSenderChange(nextValue, onTrigger)"
+        :on-key-down="onKeyDown"
+      />
+    </template>
+  </ax-suggestion>
+</template>
+
+<docs lang="zh-CN">
+建议项过多时弹层高度受限，超出部分在弹层内部滚动，避免遮挡输入框。
+</docs>
+
+<docs lang="en-US">
+When there are too many suggestions, the popup height is capped and the overflow scrolls inside the popup instead of covering the sender.
+</docs>

--- a/packages/docs/src/pages/components/suggestion/index.en-US.md
+++ b/packages/docs/src/pages/components/suggestion/index.en-US.md
@@ -19,6 +19,7 @@ description: A suggestion component that provides quick command choices in input
 <demo src="./demo/block.vue">Block</demo>
 <demo src="./demo/trigger.vue">Custom Trigger</demo>
 <demo src="./demo/render-slot.vue">Custom Item Render</demo>
+<demo src="./demo/long-list.vue">Long List Scroll</demo>
 
 ## API
 

--- a/packages/docs/src/pages/components/suggestion/index.zh-CN.md
+++ b/packages/docs/src/pages/components/suggestion/index.zh-CN.md
@@ -19,6 +19,7 @@ description: 用于在输入场景中提供快捷指令建议的组件。
 <demo src="./demo/block.vue">整行宽度</demo>
 <demo src="./demo/trigger.vue">自定义触发</demo>
 <demo src="./demo/render-slot.vue">自定义建议项渲染</demo>
+<demo src="./demo/long-list.vue">长列表滚动</demo>
 
 ## API
 

--- a/packages/x/components/suggestion/__tests__/index.test.tsx
+++ b/packages/x/components/suggestion/__tests__/index.test.tsx
@@ -359,4 +359,32 @@ describe("Suggestion", () => {
     expect(document.body.textContent).not.toContain("default-icon");
     expect(document.body.textContent).not.toContain("default-extra");
   });
+
+  it("keeps every option reachable inside the scrollable popup for long lists", async () => {
+    const longItems: SuggestionItem[] = Array.from(
+      { length: 30 },
+      (_, index) => ({
+        label: `Option ${index + 1}`,
+        value: `option-${index + 1}`,
+      }),
+    );
+
+    track(
+      mount(Suggestion, {
+        attachTo: document.body,
+        props: { open: true, items: longItems },
+        slots: createSlot(),
+      }),
+    );
+
+    await flush();
+
+    const menu = document.querySelector(".ant-cascader-menu");
+    expect(menu).not.toBeNull();
+
+    const options = document.querySelectorAll(".ant-cascader-menu-item");
+    expect(options.length).toBe(longItems.length);
+    expect(options[0].textContent).toContain("Option 1");
+    expect(options[options.length - 1].textContent).toContain("Option 30");
+  });
 });

--- a/packages/x/components/suggestion/style/index.ts
+++ b/packages/x/components/suggestion/style/index.ts
@@ -19,6 +19,8 @@ const genSuggestionStyle: GenerateStyle<SuggestionToken> = token => {
     [componentCls]: {
       [`${antCls}-cascader-menus ${antCls}-cascader-menu`]: {
         height: "auto",
+        maxHeight: 256,
+        overflowY: "auto",
       },
 
       [`${componentCls}-item`]: {


### PR DESCRIPTION
## 背景

同步上游 [ant-design/x#1983](https://github.com/ant-design/x/pull/1983)（merge commit `39c0ac235158c98f616a6b6dec85f1d2ae876cd8`）。

Suggestion 选项过多时弹层会持续增高，并可能被 Sender 遮挡。此前 `packages/x/components/suggestion/style/index.ts` 只对 Cascader menu 设置了 `height: auto`，没有高度上限，也没有内部滚动。

## 实现范围

- Cascader menu 增加 `maxHeight: 256` 与 `overflowY: "auto"`，与上游一致（数值写法沿用仓库内 `file-card` 的 `maxHeight: 68` 风格）
- 新增 `demo/long-list.vue`（30 个选项），中英文档各挂载一条
- 补充回归测试：长列表下全部选项渲染且首尾可达

## 验收标准

- [x] 25+ 建议项不再撑破视口
- [x] 所有选项可通过滚动访问
- [x] 键盘导航与选择行为不变（未改动 `useActive.ts` 等交互逻辑，仅样式层新增两条属性）
- [x] 文档 demo 展示滚动行为

Ref #149
close #148