### PR TITLE
[sync] feat(x): support destroyOnHidden on Think and ThoughtChain (#1985)

### DIFF
--- a/packages/docs/src/pages/components/think/demo/destroy-on-hidden.vue
+++ b/packages/docs/src/pages/components/think/demo/destroy-on-hidden.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { onBeforeUnmount, ref } from "vue";
+
+const destroyOnHidden = ref(false);
+const seconds = ref(0);
+
+const timer = setInterval(() => {
+  seconds.value += 1;
+}, 1000);
+
+onBeforeUnmount(() => clearInterval(timer));
+</script>
+
+<template>
+  <div>
+    <a-switch
+      v-model:checked="destroyOnHidden"
+      checked-children="destroyOnHidden: true"
+      un-checked-children="destroyOnHidden: false"
+    />
+    <br />
+    <br />
+    <ax-think :destroy-on-hidden="destroyOnHidden" title="deep thinking">
+      <p>Streaming for {{ seconds }}s.</p>
+      <input placeholder="Type something, then collapse" />
+    </ax-think>
+  </div>
+</template>
+
+<docs lang="zh-CN">
+`destroyOnHidden` 默认为 `true`，折叠时销毁内容节点。设为 `false` 时内容节点保留在 DOM 中，仅隐藏，可以保留流式输出与内部组件状态（例如上面输入框中已输入的内容）。
+</docs>
+
+<docs lang="en-US">
+`destroyOnHidden` defaults to `true`, which destroys the content node on collapse. Set it to `false` to keep the node mounted and merely hidden, preserving streaming output and inner component state (such as the text typed into the input above).
+</docs>

--- a/packages/docs/src/pages/components/think/demo/destroy-on-hidden.vue
+++ b/packages/docs/src/pages/components/think/demo/destroy-on-hidden.vue
@@ -1,36 +1,38 @@
 <script setup lang="ts">
-import { onBeforeUnmount, ref } from "vue";
+import { ref } from "vue";
 
-const destroyOnHidden = ref(false);
-const seconds = ref(0);
-
-const timer = setInterval(() => {
-  seconds.value += 1;
-}, 1000);
-
-onBeforeUnmount(() => clearInterval(timer));
+const expanded = ref(true);
+const destroyOnHidden = ref(true);
 </script>
 
 <template>
-  <div>
-    <a-switch
-      v-model:checked="destroyOnHidden"
-      checked-children="destroyOnHidden: true"
-      un-checked-children="destroyOnHidden: false"
-    />
-    <br />
-    <br />
-    <ax-think :destroy-on-hidden="destroyOnHidden" title="deep thinking">
-      <p>Streaming for {{ seconds }}s.</p>
-      <input placeholder="Type something, then collapse" />
+  <a-space direction="vertical" :size="16">
+    <a-space>
+      <a-button @click="expanded = !expanded">
+        {{ expanded ? "Collapse" : "Expand" }}
+      </a-button>
+      <a-switch
+        v-model:checked="destroyOnHidden"
+        checked-children="destroyOnHidden"
+        un-checked-children="keep"
+      />
+    </a-space>
+    <ax-think
+      title="Deep Thinking"
+      :expanded="expanded"
+      :destroy-on-hidden="destroyOnHidden"
+      @expand="expanded = $event"
+    >
+      This content will be removed from DOM when collapsed and
+      destroyOnHidden is true.
     </ax-think>
-  </div>
+  </a-space>
 </template>
 
 <docs lang="zh-CN">
-`destroyOnHidden` 默认为 `true`，折叠时销毁内容节点。设为 `false` 时内容节点保留在 DOM 中，仅隐藏，可以保留流式输出与内部组件状态（例如上面输入框中已输入的内容）。
+通过外部按钮控制展开状态，并切换 `destroyOnHidden` 对折叠内容的处理方式。
 </docs>
 
 <docs lang="en-US">
-`destroyOnHidden` defaults to `true`, which destroys the content node on collapse. Set it to `false` to keep the node mounted and merely hidden, preserving streaming output and inner component state (such as the text typed into the input above).
+Control the expanded state externally and switch how collapsed content is handled with `destroyOnHidden`.
 </docs>

--- a/packages/docs/src/pages/components/think/index.en-US.md
+++ b/packages/docs/src/pages/components/think/index.en-US.md
@@ -13,23 +13,25 @@ Used to show deep thinking process.
 <demo src="./demo/status.vue">Status</demo>
 <demo src="./demo/expand.vue">Expand</demo>
 <demo src="./demo/slot.vue">Slots</demo>
+<demo src="./demo/destroy-on-hidden.vue">Destroy On Hidden</demo>
 
 ## API
 
 ### ThinkProps
 
-| Property           | Description                  | Type                                                  | Default | Version |
-| ------------------ | ---------------------------- | ----------------------------------------------------- | ------- | ------- |
-| classes            | Semantic DOM class           | [Record\<SemanticDOM, string\>](#semantic-dom)        | -       | -       |
-| styles             | Semantic DOM style           | [Record\<SemanticDOM, CSSProperties\>](#semantic-dom) | -       | -       |
-| default            | Content (default slot)       | `VNodeChild`                                          | -       | -       |
-| title              | Text of status               | `VNodeChild`                                          | -       | -       |
-| icon               | Show icon                    | `VNodeChild`                                          | -       | -       |
-| loading            | Loading                      | `boolean \| VNodeChild`                               | `false` | -       |
-| defaultExpanded    | Default Expand state         | `boolean`                                             | `true`  | -       |
-| expanded (v-model) | Expand state                 | `boolean`                                             | -       | -       |
-| onExpand           | Callback when expand changes | `(expand: boolean) => void`                           | -       | -       |
-| blink              | Blink mode                   | `boolean`                                             | -       | -       |
+| Property           | Description                                        | Type                                                  | Default | Version |
+| ------------------ | -------------------------------------------------- | ----------------------------------------------------- | ------- | ------- |
+| classes            | Semantic DOM class                                 | [Record\<SemanticDOM, string\>](#semantic-dom)        | -       | -       |
+| styles             | Semantic DOM style                                 | [Record\<SemanticDOM, CSSProperties\>](#semantic-dom) | -       | -       |
+| default            | Content (default slot)                             | `VNodeChild`                                          | -       | -       |
+| title              | Text of status                                     | `VNodeChild`                                          | -       | -       |
+| icon               | Show icon                                          | `VNodeChild`                                          | -       | -       |
+| loading            | Loading                                            | `boolean \| VNodeChild`                               | `false` | -       |
+| defaultExpanded    | Default Expand state                               | `boolean`                                             | `true`  | -       |
+| expanded (v-model) | Expand state                                       | `boolean`                                             | -       | -       |
+| onExpand           | Callback when expand changes                       | `(expand: boolean) => void`                           | -       | -       |
+| blink              | Blink mode                                         | `boolean`                                             | -       | -       |
+| destroyOnHidden    | Whether to destroy the content node when collapsed | `boolean`                                             | `true`  | -       |
 
 ### Think Slots
 

--- a/packages/docs/src/pages/components/think/index.zh-CN.md
+++ b/packages/docs/src/pages/components/think/index.zh-CN.md
@@ -14,23 +14,25 @@ description: 展示大模型深度思考过程。
 <demo src="./demo/status.vue">设置状态</demo>
 <demo src="./demo/expand.vue">是否展开</demo>
 <demo src="./demo/slot.vue">插槽用法</demo>
+<demo src="./demo/destroy-on-hidden.vue">折叠时销毁内容</demo>
 
 ## API
 
 ### ThinkProps
 
-| 属性               | 说明             | 类型                                                | 默认值  | 版本 |
-| ------------------ | ---------------- | --------------------------------------------------- | ------- | ---- |
-| classes            | 语义化结构类名   | [Record\<SemanticDOM, string\>](#语义化-dom)        | -       | -    |
-| styles             | 语义化结构样式   | [Record\<SemanticDOM, CSSProperties\>](#语义化-dom) | -       | -    |
-| default            | 内容（默认插槽） | `VNodeChild`                                        | -       | -    |
-| title              | 状态文本         | `VNodeChild`                                        | -       | -    |
-| icon               | 状态图标         | `VNodeChild`                                        | -       | -    |
-| loading            | 加载中           | `boolean \| VNodeChild`                             | `false` | -    |
-| defaultExpanded    | 默认是否展开     | `boolean`                                           | `true`  | -    |
-| expanded (v-model) | 是否展开         | `boolean`                                           | -       | -    |
-| onExpand           | 展开事件         | `(expand: boolean) => void`                         | -       | -    |
-| blink              | 闪动模式         | `boolean`                                           | -       | -    |
+| 属性               | 说明                   | 类型                                                | 默认值  | 版本 |
+| ------------------ | ---------------------- | --------------------------------------------------- | ------- | ---- |
+| classes            | 语义化结构类名         | [Record\<SemanticDOM, string\>](#语义化-dom)        | -       | -    |
+| styles             | 语义化结构样式         | [Record\<SemanticDOM, CSSProperties\>](#语义化-dom) | -       | -    |
+| default            | 内容（默认插槽）       | `VNodeChild`                                        | -       | -    |
+| title              | 状态文本               | `VNodeChild`                                        | -       | -    |
+| icon               | 状态图标               | `VNodeChild`                                        | -       | -    |
+| loading            | 加载中                 | `boolean \| VNodeChild`                             | `false` | -    |
+| defaultExpanded    | 默认是否展开           | `boolean`                                           | `true`  | -    |
+| expanded (v-model) | 是否展开               | `boolean`                                           | -       | -    |
+| onExpand           | 展开事件               | `(expand: boolean) => void`                         | -       | -    |
+| blink              | 闪动模式               | `boolean`                                           | -       | -    |
+| destroyOnHidden    | 折叠时是否销毁内容节点 | `boolean`                                           | `true`  | -    |
 
 ### Think 插槽
 

--- a/packages/docs/src/pages/components/thought-chain/demo/destroy-on-hidden.vue
+++ b/packages/docs/src/pages/components/thought-chain/demo/destroy-on-hidden.vue
@@ -1,0 +1,55 @@
+<script setup lang="ts">
+import type { ThoughtChainProps } from "@antdv-next/x";
+
+import { computed, onBeforeUnmount, ref } from "vue";
+
+const destroyOnHidden = ref(false);
+const seconds = ref(0);
+
+const timer = setInterval(() => {
+  seconds.value += 1;
+}, 1000);
+
+onBeforeUnmount(() => clearInterval(timer));
+
+const items = computed<ThoughtChainProps["items"]>(() => [
+  {
+    key: "keep_alive",
+    title: "Streaming Node",
+    description: "Collapse and expand to compare the two behaviors",
+    collapsible: true,
+    status: "loading",
+    destroyOnHidden: destroyOnHidden.value,
+  },
+]);
+</script>
+
+<template>
+  <a-card :style="{ width: '500px' }">
+    <a-switch
+      v-model:checked="destroyOnHidden"
+      checked-children="destroyOnHidden: true"
+      un-checked-children="destroyOnHidden: false"
+    />
+    <br />
+    <br />
+    <ax-thought-chain :default-expanded-keys="['keep_alive']" :items="items">
+      <template #content>
+        <a-flex gap="small" vertical>
+          <a-typography-text type="secondary">
+            Streaming for {{ seconds }}s.
+          </a-typography-text>
+          <a-input placeholder="Type something, then collapse" />
+        </a-flex>
+      </template>
+    </ax-thought-chain>
+  </a-card>
+</template>
+
+<docs lang="zh-CN">
+节点的 `destroyOnHidden` 默认为 `true`，折叠时销毁内容节点。设为 `false` 时内容节点保留在 DOM 中，仅隐藏，可以保留流式输出与内部组件状态（例如上面输入框中已输入的内容）。
+</docs>
+
+<docs lang="en-US">
+The node level `destroyOnHidden` defaults to `true`, which destroys the content node on collapse. Set it to `false` to keep the node mounted and merely hidden, preserving streaming output and inner component state (such as the text typed into the input above).
+</docs>

--- a/packages/docs/src/pages/components/thought-chain/index.en-US.md
+++ b/packages/docs/src/pages/components/thought-chain/index.en-US.md
@@ -19,6 +19,7 @@ description: The ThoughtChain component is used to visualize and track the call 
 <demo src="./demo/slot.vue">Slots</demo>
 <demo src="./demo/nested.vue">Nested Usage</demo>
 <demo src="./demo/single-row.vue">Single Row</demo>
+<demo src="./demo/destroy-on-hidden.vue">Destroy On Hidden</demo>
 
 ## API
 
@@ -50,17 +51,18 @@ description: The ThoughtChain component is used to visualize and track the call 
 
 ### ThoughtChainItemType
 
-| Property    | Description                                          | Type                                           | Default     | Version |
-| ----------- | ---------------------------------------------------- | ---------------------------------------------- | ----------- | ------- |
-| content     | Content of the thought node                          | `VNodeChild`                                   | -           | -       |
-| description | Description of the thought node                      | `VNodeChild`                                   | -           | -       |
-| footer      | Footer of the thought node                           | `VNodeChild`                                   | -           | -       |
-| icon        | Icon of the thought node, not displayed when `false` | `false \| VNodeChild`                          | DefaultIcon | -       |
-| key         | Unique identifier for the thought node               | `string`                                       | -           | -       |
-| status      | Status of the thought node                           | `'loading' \| 'success' \| 'error' \| 'abort'` | -           | -       |
-| title       | Title of the thought node                            | `VNodeChild`                                   | -           | -       |
-| collapsible | Whether the thought node is collapsible              | `boolean`                                      | `false`     | -       |
-| blink       | Blink mode                                           | `boolean`                                      | -           | -       |
+| Property        | Description                                          | Type                                           | Default     | Version |
+| --------------- | ---------------------------------------------------- | ---------------------------------------------- | ----------- | ------- |
+| content         | Content of the thought node                          | `VNodeChild`                                   | -           | -       |
+| description     | Description of the thought node                      | `VNodeChild`                                   | -           | -       |
+| footer          | Footer of the thought node                           | `VNodeChild`                                   | -           | -       |
+| icon            | Icon of the thought node, not displayed when `false` | `false \| VNodeChild`                          | DefaultIcon | -       |
+| key             | Unique identifier for the thought node               | `string`                                       | -           | -       |
+| status          | Status of the thought node                           | `'loading' \| 'success' \| 'error' \| 'abort'` | -           | -       |
+| title           | Title of the thought node                            | `VNodeChild`                                   | -           | -       |
+| collapsible     | Whether the thought node is collapsible              | `boolean`                                      | `false`     | -       |
+| blink           | Blink mode                                           | `boolean`                                      | -           | -       |
+| destroyOnHidden | Whether to destroy the content node when collapsed   | `boolean`                                      | `true`      | -       |
 
 ### ThoughtChain.Item
 

--- a/packages/docs/src/pages/components/thought-chain/index.zh-CN.md
+++ b/packages/docs/src/pages/components/thought-chain/index.zh-CN.md
@@ -20,6 +20,7 @@ description: 思维链组件用于可视化和追踪 Agent 对 Actions 和 Tools
 <demo src="./demo/slot.vue">插槽自定义</demo>
 <demo src="./demo/nested.vue">嵌套使用</demo>
 <demo src="./demo/single-row.vue">单行折叠</demo>
+<demo src="./demo/destroy-on-hidden.vue">折叠时销毁内容</demo>
 
 ## API
 
@@ -51,17 +52,18 @@ description: 思维链组件用于可视化和追踪 Agent 对 Actions 和 Tools
 
 ### ThoughtChainItemType
 
-| 属性        | 说明                              | 类型                                           | 默认值      | 版本 |
-| ----------- | --------------------------------- | ---------------------------------------------- | ----------- | ---- |
-| content     | 思维节点内容                      | `VNodeChild`                                   | -           | -    |
-| description | 思维节点描述                      | `VNodeChild`                                   | -           | -    |
-| footer      | 思维节点脚注                      | `VNodeChild`                                   | -           | -    |
-| icon        | 思维节点图标，为 `false` 时不展示 | `false \| VNodeChild`                          | DefaultIcon | -    |
-| key         | 思维节点唯一标识符                | `string`                                       | -           | -    |
-| status      | 思维节点状态                      | `'loading' \| 'success' \| 'error' \| 'abort'` | -           | -    |
-| title       | 思维节点标题                      | `VNodeChild`                                   | -           | -    |
-| collapsible | 思维节点是否可折叠                | `boolean`                                      | `false`     | -    |
-| blink       | 闪动效果                          | `boolean`                                      | -           | -    |
+| 属性            | 说明                              | 类型                                           | 默认值      | 版本 |
+| --------------- | --------------------------------- | ---------------------------------------------- | ----------- | ---- |
+| content         | 思维节点内容                      | `VNodeChild`                                   | -           | -    |
+| description     | 思维节点描述                      | `VNodeChild`                                   | -           | -    |
+| footer          | 思维节点脚注                      | `VNodeChild`                                   | -           | -    |
+| icon            | 思维节点图标，为 `false` 时不展示 | `false \| VNodeChild`                          | DefaultIcon | -    |
+| key             | 思维节点唯一标识符                | `string`                                       | -           | -    |
+| status          | 思维节点状态                      | `'loading' \| 'success' \| 'error' \| 'abort'` | -           | -    |
+| title           | 思维节点标题                      | `VNodeChild`                                   | -           | -    |
+| collapsible     | 思维节点是否可折叠                | `boolean`                                      | `false`     | -    |
+| blink           | 闪动效果                          | `boolean`                                      | -           | -    |
+| destroyOnHidden | 折叠时是否销毁内容节点            | `boolean`                                      | `true`      | -    |
 
 ### ThoughtChain.Item
 

--- a/packages/x/components/think/Think.tsx
+++ b/packages/x/components/think/Think.tsx
@@ -8,7 +8,9 @@ import {
   defineComponent,
   ref,
   useAttrs,
+  vShow,
   watch,
+  withDirectives,
 } from "vue";
 
 import type { SemanticType, ThinkProps, ThinkRef } from "./interface";
@@ -68,6 +70,10 @@ export const XThink = defineComponent({
     blink: {
       type: Boolean,
       default: false,
+    },
+    destroyOnHidden: {
+      type: Boolean,
+      default: true,
     },
   },
   emits: ["update:expanded", "expand"],
@@ -163,6 +169,33 @@ export const XThink = defineComponent({
 
     const prefixCls = computed(() => props.prefixCls);
 
+    // Content is kept mounted and only toggled with `v-show` when
+    // `destroyOnHidden` is false, so streaming output and inner component
+    // state survive a collapse.
+    function renderContent() {
+      const node = (
+        <div ref={contentRef}>
+          <div
+            class={[
+              `${prefixCls.value}-content`,
+              contextConfig.value.classes?.content,
+              props.classes?.content,
+            ]}
+            style={[
+              contextConfig.value.styles?.content,
+              props.styles?.content,
+            ]}
+          >
+            {slots.default?.()}
+          </div>
+        </div>
+      );
+
+      return props.destroyOnHidden
+        ? node
+        : withDirectives(node, [[vShow, mergedExpanded.value]]);
+    }
+
     expose<ThinkRef>({
       get nativeElement() {
         return rootRef.value as HTMLDivElement;
@@ -237,23 +270,9 @@ export const XThink = defineComponent({
           onLeave={onLeave}
           onAfterLeave={onAfterLeave}
         >
-          {mergedExpanded.value ? (
-            <div ref={contentRef}>
-              <div
-                class={[
-                  `${prefixCls.value}-content`,
-                  contextConfig.value.classes?.content,
-                  props.classes?.content,
-                ]}
-                style={[
-                  contextConfig.value.styles?.content,
-                  props.styles?.content,
-                ]}
-              >
-                {slots.default?.()}
-              </div>
-            </div>
-          ) : null}
+          {props.destroyOnHidden && !mergedExpanded.value
+            ? null
+            : renderContent()}
         </Transition>
       </div>
     );

--- a/packages/x/components/think/Think.tsx
+++ b/packages/x/components/think/Think.tsx
@@ -171,7 +171,8 @@ export const XThink = defineComponent({
 
     // Content is kept mounted and only toggled with `v-show` when
     // `destroyOnHidden` is false, so streaming output and inner component
-    // state survive a collapse.
+    // state survive a collapse. Keep `vShow` attached in both modes so changing
+    // `destroyOnHidden` at runtime does not reset the directive lifecycle.
     function renderContent() {
       const node = (
         <div ref={contentRef}>
@@ -191,9 +192,7 @@ export const XThink = defineComponent({
         </div>
       );
 
-      return props.destroyOnHidden
-        ? node
-        : withDirectives(node, [[vShow, mergedExpanded.value]]);
+      return withDirectives(node, [[vShow, mergedExpanded.value]]);
     }
 
     expose<ThinkRef>({
@@ -263,6 +262,7 @@ export const XThink = defineComponent({
         {/* Collapsible content */}
         <Transition
           name={`${prefixCls.value}-collapse`}
+          persisted={!props.destroyOnHidden}
           onBeforeEnter={onBeforeEnter}
           onEnter={onEnter}
           onAfterEnter={onAfterEnter}

--- a/packages/x/components/think/__tests__/index.test.tsx
+++ b/packages/x/components/think/__tests__/index.test.tsx
@@ -219,7 +219,7 @@ describe("Think", () => {
     expect(wrapper.find(".antd-think-content").exists()).toBe(false);
   });
 
-  it("keeps the content node mounted when destroyOnHidden is false", () => {
+  it("keeps the content node mounted and toggles its visibility when destroyOnHidden is false", async () => {
     const wrapper = mount(Think, {
       props: { destroyOnHidden: false, defaultExpanded: false },
       slots: { default: () => "Hidden but mounted" },
@@ -228,6 +228,20 @@ describe("Think", () => {
     const content = wrapper.find(".antd-think-content");
     expect(content.exists()).toBe(true);
     expect(wrapper.text()).toContain("Hidden but mounted");
+    expect(content.element.parentElement?.getAttribute("style")).toContain(
+      "display: none",
+    );
+
+    await wrapper.find(".antd-think-status-wrapper").trigger("click");
+    await nextTick();
+
+    expect(
+      content.element.parentElement?.getAttribute("style") ?? "",
+    ).not.toContain("display: none");
+
+    await wrapper.find(".antd-think-status-wrapper").trigger("click");
+    await nextTick();
+
     expect(content.element.parentElement?.getAttribute("style")).toContain(
       "display: none",
     );
@@ -252,6 +266,38 @@ describe("Think", () => {
     // Same DOM node, so the value typed before collapsing survives.
     expect(afterCollapse.element).toBe(inputEl);
     expect(afterCollapse.element.value).toBe("streaming");
+  });
+
+  it("keeps toggling after destroyOnHidden changes at runtime", async () => {
+    const wrapper = mount(Think, {
+      props: { destroyOnHidden: false },
+      slots: { default: () => "Dynamic content" },
+    });
+
+    await wrapper.setProps({ destroyOnHidden: true });
+    await wrapper.find(".antd-think-status-wrapper").trigger("click");
+    await nextTick();
+    expect(wrapper.find(".antd-think-content").exists()).toBe(false);
+
+    await wrapper.find(".antd-think-status-wrapper").trigger("click");
+    await nextTick();
+    expect(wrapper.find(".antd-think-content").exists()).toBe(true);
+
+    await wrapper.setProps({ destroyOnHidden: false });
+    const content = wrapper.find(".antd-think-content");
+
+    await wrapper.find(".antd-think-status-wrapper").trigger("click");
+    await nextTick();
+    expect(content.exists()).toBe(true);
+    expect(content.element.parentElement?.getAttribute("style")).toContain(
+      "display: none",
+    );
+
+    await wrapper.find(".antd-think-status-wrapper").trigger("click");
+    await nextTick();
+    expect(
+      content.element.parentElement?.getAttribute("style") ?? "",
+    ).not.toContain("display: none");
   });
 
   it("keeps the content node mounted for controlled expanded when destroyOnHidden is false", async () => {

--- a/packages/x/components/think/__tests__/index.test.tsx
+++ b/packages/x/components/think/__tests__/index.test.tsx
@@ -206,6 +206,69 @@ describe("Think", () => {
     expect(chevron.attributes("style")).toContain("rotate(0deg)");
   });
 
+  it("destroys the content node on collapse by default", async () => {
+    const wrapper = mount(Think, {
+      slots: { default: () => "Toggle me" },
+    });
+
+    expect(wrapper.find(".antd-think-content").exists()).toBe(true);
+
+    await wrapper.find(".antd-think-status-wrapper").trigger("click");
+    await nextTick();
+
+    expect(wrapper.find(".antd-think-content").exists()).toBe(false);
+  });
+
+  it("keeps the content node mounted when destroyOnHidden is false", () => {
+    const wrapper = mount(Think, {
+      props: { destroyOnHidden: false, defaultExpanded: false },
+      slots: { default: () => "Hidden but mounted" },
+    });
+
+    const content = wrapper.find(".antd-think-content");
+    expect(content.exists()).toBe(true);
+    expect(wrapper.text()).toContain("Hidden but mounted");
+    expect(content.element.parentElement?.getAttribute("style")).toContain(
+      "display: none",
+    );
+  });
+
+  it("preserves inner state across collapse when destroyOnHidden is false", async () => {
+    const wrapper = mount(Think, {
+      props: { destroyOnHidden: false },
+      slots: { default: () => h("input", { class: "inner-input" }) },
+    });
+
+    const input = wrapper.find<HTMLInputElement>(".inner-input");
+    expect(input.exists()).toBe(true);
+    const inputEl = input.element;
+    inputEl.value = "streaming";
+
+    await wrapper.find(".antd-think-status-wrapper").trigger("click");
+    await nextTick();
+
+    const afterCollapse = wrapper.find<HTMLInputElement>(".inner-input");
+    expect(afterCollapse.exists()).toBe(true);
+    // Same DOM node, so the value typed before collapsing survives.
+    expect(afterCollapse.element).toBe(inputEl);
+    expect(afterCollapse.element.value).toBe("streaming");
+  });
+
+  it("keeps the content node mounted for controlled expanded when destroyOnHidden is false", async () => {
+    const wrapper = mount(Think, {
+      props: { destroyOnHidden: false, expanded: true },
+      slots: { default: () => "Controlled content" },
+    });
+
+    expect(wrapper.find(".antd-think-content").exists()).toBe(true);
+
+    await wrapper.setProps({ expanded: false });
+    await nextTick();
+
+    expect(wrapper.find(".antd-think-content").exists()).toBe(true);
+    expect(wrapper.text()).toContain("Controlled content");
+  });
+
   it("exposes nativeElement ref", () => {
     const wrapper = mount(Think, {
       slots: { default: () => "Content" },

--- a/packages/x/components/think/interface.ts
+++ b/packages/x/components/think/interface.ts
@@ -79,6 +79,13 @@ export interface ThinkProps extends Omit<HTMLAttributes, "title"> {
    * @descZH 标题文字闪烁动画
    */
   blink?: boolean;
+
+  /**
+   * @desc Whether to destroy the content node when collapsed
+   * @descZH 折叠时是否销毁内容节点
+   * @default true
+   */
+  destroyOnHidden?: boolean;
 }
 
 export interface ThinkRef {

--- a/packages/x/components/thought-chain/Node.tsx
+++ b/packages/x/components/thought-chain/Node.tsx
@@ -271,7 +271,8 @@ export default defineComponent({
 
       // Keep the content mounted and only toggle it with `v-show` when
       // `destroyOnHidden` is false, so streaming output and inner component
-      // state survive a collapse.
+      // state survive a collapse. Keep `vShow` attached in both modes so
+      // changing `destroyOnHidden` at runtime does not reset its lifecycle.
       const renderContent = () => {
         const node = (
           <div>
@@ -284,9 +285,7 @@ export default defineComponent({
           </div>
         );
 
-        return destroyOnHidden
-          ? node
-          : withDirectives(node, [[vShow, showContent]]);
+        return withDirectives(node, [[vShow, showContent]]);
       };
 
       return (
@@ -298,6 +297,7 @@ export default defineComponent({
             {hasContent && (
               <Transition
                 name={`${props.prefixCls}-collapse`}
+                persisted={!destroyOnHidden}
                 onBeforeEnter={onBeforeEnter}
                 onEnter={onEnter}
                 onAfterEnter={onAfterEnter}

--- a/packages/x/components/thought-chain/Node.tsx
+++ b/packages/x/components/thought-chain/Node.tsx
@@ -2,7 +2,13 @@ import type { CSSProperties, PropType, VNodeChild } from "vue";
 
 import { LeftOutlined, RightOutlined } from "@antdv-next/icons";
 import { useConfig } from "antdv-next/config-provider/context";
-import { Transition, computed, defineComponent } from "vue";
+import {
+  Transition,
+  computed,
+  defineComponent,
+  vShow,
+  withDirectives,
+} from "vue";
 
 import type {
   SemanticType,
@@ -261,6 +267,27 @@ export default defineComponent({
           } as ThoughtChainFooterSlotInfo)
         : item.footer;
       const showContent = hasContent && (!collapsible || props.expanded);
+      const destroyOnHidden = item.destroyOnHidden ?? true;
+
+      // Keep the content mounted and only toggle it with `v-show` when
+      // `destroyOnHidden` is false, so streaming output and inner component
+      // state survive a collapse.
+      const renderContent = () => {
+        const node = (
+          <div>
+            <div
+              class={[`${cls}-content`, props.classes?.itemContent]}
+              style={props.styles?.itemContent}
+            >
+              <div class={`${cls}-content-box`}>{contentNode}</div>
+            </div>
+          </div>
+        );
+
+        return destroyOnHidden
+          ? node
+          : withDirectives(node, [[vShow, showContent]]);
+      };
 
       return (
         <div class={[`${cls}`, props.classes?.item]} style={props.styles?.item}>
@@ -278,16 +305,7 @@ export default defineComponent({
                 onLeave={onLeave}
                 onAfterLeave={onAfterLeave}
               >
-                {showContent ? (
-                  <div>
-                    <div
-                      class={[`${cls}-content`, props.classes?.itemContent]}
-                      style={props.styles?.itemContent}
-                    >
-                      <div class={`${cls}-content-box`}>{contentNode}</div>
-                    </div>
-                  </div>
-                ) : null}
+                {destroyOnHidden && !showContent ? null : renderContent()}
               </Transition>
             )}
 

--- a/packages/x/components/thought-chain/__tests__/index.test.tsx
+++ b/packages/x/components/thought-chain/__tests__/index.test.tsx
@@ -346,7 +346,7 @@ describe("ThoughtChain", () => {
     expect(wrapper.findAll(".antd-thought-chain-node").length).toBe(2);
   });
 
-  it("keeps the item content mounted when destroyOnHidden is false", () => {
+  it("keeps the item content mounted and toggles its visibility when destroyOnHidden is false", async () => {
     const wrapper = mount(ThoughtChain, {
       props: {
         items: [
@@ -365,6 +365,20 @@ describe("ThoughtChain", () => {
     const content = wrapper.find(".antd-thought-chain-node-content");
     expect(content.exists()).toBe(true);
     expect(wrapper.text()).toContain("Hidden but mounted");
+    expect(content.element.parentElement?.getAttribute("style")).toContain(
+      "display: none",
+    );
+
+    await wrapper.find(".antd-thought-chain-node-collapsible").trigger("click");
+    await nextTick();
+
+    expect(
+      content.element.parentElement?.getAttribute("style") ?? "",
+    ).not.toContain("display: none");
+
+    await wrapper.find(".antd-thought-chain-node-collapsible").trigger("click");
+    await nextTick();
+
     expect(content.element.parentElement?.getAttribute("style")).toContain(
       "display: none",
     );
@@ -397,6 +411,53 @@ describe("ThoughtChain", () => {
     // Same DOM node, so the value typed before collapsing survives.
     expect(afterCollapse.element).toBe(inputEl);
     expect(afterCollapse.element.value).toBe("streaming");
+  });
+
+  it("keeps toggling after destroyOnHidden changes at runtime", async () => {
+    const createItems = (destroyOnHidden: boolean) => [
+      {
+        key: "1",
+        title: "Step 1",
+        content: h("span", "Dynamic content"),
+        collapsible: true,
+        destroyOnHidden,
+      },
+    ];
+    const wrapper = mount(ThoughtChain, {
+      props: {
+        items: createItems(false),
+        defaultExpandedKeys: ["1"],
+      },
+    });
+
+    await wrapper.setProps({ items: createItems(true) });
+    await wrapper.find(".antd-thought-chain-node-collapsible").trigger("click");
+    await nextTick();
+    expect(wrapper.find(".antd-thought-chain-node-content").exists()).toBe(
+      false,
+    );
+
+    await wrapper.find(".antd-thought-chain-node-collapsible").trigger("click");
+    await nextTick();
+    expect(wrapper.find(".antd-thought-chain-node-content").exists()).toBe(
+      true,
+    );
+
+    await wrapper.setProps({ items: createItems(false) });
+    const content = wrapper.find(".antd-thought-chain-node-content");
+
+    await wrapper.find(".antd-thought-chain-node-collapsible").trigger("click");
+    await nextTick();
+    expect(content.exists()).toBe(true);
+    expect(content.element.parentElement?.getAttribute("style")).toContain(
+      "display: none",
+    );
+
+    await wrapper.find(".antd-thought-chain-node-collapsible").trigger("click");
+    await nextTick();
+    expect(
+      content.element.parentElement?.getAttribute("style") ?? "",
+    ).not.toContain("display: none");
   });
 
   it("keeps the item content mounted for controlled expandedKeys when destroyOnHidden is false", async () => {

--- a/packages/x/components/thought-chain/__tests__/index.test.tsx
+++ b/packages/x/components/thought-chain/__tests__/index.test.tsx
@@ -346,6 +346,88 @@ describe("ThoughtChain", () => {
     expect(wrapper.findAll(".antd-thought-chain-node").length).toBe(2);
   });
 
+  it("keeps the item content mounted when destroyOnHidden is false", () => {
+    const wrapper = mount(ThoughtChain, {
+      props: {
+        items: [
+          {
+            key: "1",
+            title: "Step 1",
+            content: h("span", "Hidden but mounted"),
+            collapsible: true,
+            destroyOnHidden: false,
+          },
+        ],
+        defaultExpandedKeys: [],
+      },
+    });
+
+    const content = wrapper.find(".antd-thought-chain-node-content");
+    expect(content.exists()).toBe(true);
+    expect(wrapper.text()).toContain("Hidden but mounted");
+    expect(content.element.parentElement?.getAttribute("style")).toContain(
+      "display: none",
+    );
+  });
+
+  it("preserves item content across collapse when destroyOnHidden is false", async () => {
+    const wrapper = mount(ThoughtChain, {
+      props: {
+        items: [
+          {
+            key: "1",
+            title: "Step 1",
+            content: h("input", { class: "inner-input" }),
+            collapsible: true,
+            destroyOnHidden: false,
+          },
+        ],
+        defaultExpandedKeys: ["1"],
+      },
+    });
+
+    const inputEl = wrapper.find<HTMLInputElement>(".inner-input").element;
+    inputEl.value = "streaming";
+
+    await wrapper.find(".antd-thought-chain-node-collapsible").trigger("click");
+    await nextTick();
+
+    const afterCollapse = wrapper.find<HTMLInputElement>(".inner-input");
+    expect(afterCollapse.exists()).toBe(true);
+    // Same DOM node, so the value typed before collapsing survives.
+    expect(afterCollapse.element).toBe(inputEl);
+    expect(afterCollapse.element.value).toBe("streaming");
+  });
+
+  it("keeps the item content mounted for controlled expandedKeys when destroyOnHidden is false", async () => {
+    const wrapper = mount(ThoughtChain, {
+      props: {
+        items: [
+          {
+            key: "1",
+            title: "Step 1",
+            content: h("span", "Controlled content"),
+            collapsible: true,
+            destroyOnHidden: false,
+          },
+        ],
+        expandedKeys: ["1"],
+      },
+    });
+
+    expect(wrapper.find(".antd-thought-chain-node-content").exists()).toBe(
+      true,
+    );
+
+    await wrapper.setProps({ expandedKeys: [] });
+    await nextTick();
+
+    expect(wrapper.find(".antd-thought-chain-node-content").exists()).toBe(
+      true,
+    );
+    expect(wrapper.text()).toContain("Controlled content");
+  });
+
   it("exposes nativeElement ref", () => {
     const wrapper = mount(ThoughtChain, {
       props: { items: basicItems },

--- a/packages/x/components/thought-chain/interface.ts
+++ b/packages/x/components/thought-chain/interface.ts
@@ -100,6 +100,13 @@ export interface ThoughtChainItemType {
    * @descZH 标题闪烁动画
    */
   blink?: boolean;
+
+  /**
+   * @desc Whether to destroy the content node when collapsed
+   * @descZH 折叠时是否销毁内容节点
+   * @default true
+   */
+  destroyOnHidden?: boolean;
 }
 
 export interface ThoughtChainProps extends Omit<HTMLAttributes, "title"> {


### PR DESCRIPTION
## 背景

同步上游 [ant-design/x#1985](https://github.com/ant-design/x/pull/1985)（merge commit `818b6e05999886ce11b9b79ebf111a38aca09d95`）。

为 Think 与 ThoughtChain 暴露 `destroyOnHidden`，让使用方决定折叠时内容是被销毁还是保留在 DOM 中。

## 与上游实现的差异（重点）

上游 React 侧是把标志透传给 rc-motion 的 `removeOnLeave`。Vue 侧没有对应能力，因此改为：

- `destroyOnHidden: true`（默认）— 保持原有 `Transition` + 条件渲染，折叠后节点被销毁
- `destroyOnHidden: false` — 用 `withDirectives(node, [[vShow, expanded]])` 让节点常驻、仅 `display: none`

`Transition` 与 `v-show` 组合是 Vue 官方支持的用法，`vShow` 指令会复用 vnode 上的 transition 钩子，因此原有的 height/opacity 折叠动画不受影响，`onAfterLeave` 仍会清空 height/opacity。

另外，默认路径下**不会**构造内容 vnode（`slots.default` 不被调用），与改动前行为完全一致，避免折叠状态下的无谓渲染。

## 实现范围

- `Think.tsx`：新增 `destroyOnHidden` prop，默认 `true`
- `thought-chain/Node.tsx`：读取 `item.destroyOnHidden ?? true`
- 两处 `interface.ts` 补类型与 `@default true`
- 中英文档 API 表格各补一行（表格因新增列宽做了重新对齐）
- 新增 `demo/destroy-on-hidden.vue` 各一个
- 单测 7 个

## 验收标准

- [x] 默认行为下折叠后内容 DOM 仍被销毁，向后兼容
- [x] `destroyOnHidden=false` 时 DOM 与内部状态跨折叠保留
- [x] Think 与 ThoughtChain 均覆盖受控 / 非受控展开场景
- [x] 动画结束后不残留 height/opacity（沿用原 `onAfterLeave`）
- [ ] `vp check` / `vp test` — **本地环境无 Node 运行时，未执行，需在 CI 或有 Node 的环境确认**

### 关于测试

单测刻意避开了 transition 时序（jsdom 下 leave 依赖 rAF/transitionend），改为断言「折叠后仍是同一个 DOM 节点、且折叠前写入 input 的值仍在」，这正是 `destroyOnHidden=false` 要保证的语义，且不受动画完成时机影响。

Ref #149
close #145