### PR TITLE
fix(docs): lazy-load demo source in development

### DIFF
--- a/packages/docs/plugins/markdown/demo/index.ts
+++ b/packages/docs/plugins/markdown/demo/index.ts
@@ -102,6 +102,31 @@ async function parseDemoFile(
   md: ReturnType<ReturnType<typeof createMarkdown>>,
 ): Promise<ParsedDemoFile> {
   const code = await fs.readFile(filePath, "utf-8");
+  const locales = await parseDemoLocales(code, filePath, md);
+
+  const sourceCode = code.replace(/<docs[^>]*>[\s\S]*?<\/docs>/g, "").trim();
+  const jsSourceCode = await tsToJs(sourceCode);
+  const sourceHtml = await md.renderAsync(`\`\`\`vue\n${sourceCode}\n\`\`\``);
+  const jsSourceHtml = await md.renderAsync(
+    `\`\`\`vue\n${jsSourceCode}\n\`\`\``,
+  );
+  const extraFiles = await collectExtraFiles(filePath, sourceCode, md);
+
+  return {
+    locales,
+    sourceCode,
+    jsSourceCode,
+    sourceHtml,
+    jsSourceHtml,
+    extraFiles,
+  };
+}
+
+async function parseDemoLocales(
+  code: string,
+  filePath: string,
+  md: ReturnType<ReturnType<typeof createMarkdown>>,
+) {
   const { descriptor } = parse(code, {
     filename: filePath,
     sourceMap: false,
@@ -126,23 +151,7 @@ async function parseDemoFile(
       };
     }),
   );
-
-  const sourceCode = code.replace(/<docs[^>]*>[\s\S]*?<\/docs>/g, "").trim();
-  const jsSourceCode = await tsToJs(sourceCode);
-  const sourceHtml = await md.renderAsync(`\`\`\`vue\n${sourceCode}\n\`\`\``);
-  const jsSourceHtml = await md.renderAsync(
-    `\`\`\`vue\n${jsSourceCode}\n\`\`\``,
-  );
-  const extraFiles = await collectExtraFiles(filePath, sourceCode, md);
-
-  return {
-    locales,
-    sourceCode,
-    jsSourceCode,
-    sourceHtml,
-    jsSourceHtml,
-    extraFiles,
-  };
+  return locales;
 }
 
 export function demoPlugin(): PluginOption {
@@ -159,21 +168,85 @@ export function demoPlugin(): PluginOption {
   const DEMO_GLOB = ["/src/pages/**/demo/*.vue"];
   const DEMO_REGISTRY_ADD_EVENT = "demo-registry:add";
   const DEMO_REGISTRY_REMOVE_EVENT = "demo-registry:remove";
+  const DEV_SOURCE_PATH = "/__demo_source";
+  let isServe = false;
+  let root = process.cwd();
+  let base = "/";
 
-  // Cache parsed demo files so core + highlighted modules don't parse twice.
-  const demoParseCache = new Map<string, ParsedDemoFile>();
+  // Build parses each demo once. Dev only deduplicates concurrent source requests.
+  const buildDemoParseCache = new Map<string, ParsedDemoFile>();
+  const devDemoParseTasks = new Map<string, Promise<ParsedDemoFile>>();
 
-  async function getParsedDemo(filePath: string) {
-    if (!demoParseCache.has(filePath)) {
-      demoParseCache.set(filePath, await parseDemoFile(filePath, md));
+  async function getBuildParsedDemo(filePath: string) {
+    if (!buildDemoParseCache.has(filePath)) {
+      buildDemoParseCache.set(filePath, await parseDemoFile(filePath, md));
     }
-    return demoParseCache.get(filePath)!;
+    return buildDemoParseCache.get(filePath)!;
+  }
+
+  function getDevParsedDemo(filePath: string) {
+    const currentTask = devDemoParseTasks.get(filePath);
+    if (currentTask) return currentTask;
+
+    const task = parseDemoFile(filePath, md).finally(() => {
+      if (devDemoParseTasks.get(filePath) === task)
+        devDemoParseTasks.delete(filePath);
+    });
+    devDemoParseTasks.set(filePath, task);
+    return task;
   }
 
   return {
     name: "vite:demo",
     enforce: "pre",
+    configResolved(config) {
+      isServe = config.command === "serve";
+      root = config.root;
+      base = config.base;
+    },
     configureServer(server) {
+      const sourcePath = `${base === "/" ? "" : base.replace(/\/$/, "")}${DEV_SOURCE_PATH}`;
+      server.middlewares.use(async (request, response, next) => {
+        const url = new URL(request.url ?? "", "http://vite.local");
+        if (url.pathname !== sourcePath) return next();
+
+        const id = url.searchParams.get("id");
+        const filePath = id ? path.resolve(root, `.${id}`) : "";
+        const relativePath = filePath ? path.relative(root, filePath) : "..";
+        if (
+          !id?.startsWith("/") ||
+          relativePath.startsWith("..") ||
+          path.isAbsolute(relativePath) ||
+          !isDemoFile(filePath, root, DEMO_GLOB)
+        ) {
+          response.statusCode = 400;
+          response.end("Invalid demo source path");
+          return;
+        }
+
+        try {
+          const parsed = await getDevParsedDemo(filePath);
+          response.statusCode = 200;
+          response.setHeader("Content-Type", "application/json; charset=utf-8");
+          response.setHeader("Cache-Control", "no-store");
+          response.end(
+            JSON.stringify({
+              source: parsed.sourceCode,
+              jsSource: parsed.jsSourceCode,
+              html: parsed.sourceHtml,
+              jsHtml: parsed.jsSourceHtml,
+              extraFiles: parsed.extraFiles,
+            }),
+          );
+        } catch (error) {
+          server.config.logger.error(
+            `Failed to load demo source ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+          response.statusCode = 500;
+          response.end("Failed to load demo source");
+        }
+      });
+
       const handleDemoAdd = (filePath: string) => {
         if (!isDemoFile(filePath, server.config.root, DEMO_GLOB)) return;
 
@@ -275,72 +348,73 @@ export default demos
         const normalizedFile = normalizePath(filePath);
         this.addWatchFile(filePath);
 
-        const {
-          locales,
-          sourceCode,
-          jsSourceCode,
-          sourceHtml,
-          jsSourceHtml,
-          extraFiles,
-        } = await getParsedDemo(filePath);
+        const parsed = isServe ? undefined : await getBuildParsedDemo(filePath);
+        const locales = parsed
+          ? parsed.locales
+          : await parseDemoLocales(
+              await fs.readFile(filePath, "utf-8"),
+              filePath,
+              md,
+            );
 
         // Watch extra files so HMR re-runs this loader when they change.
-        for (const file of extraFiles) {
+        for (const file of parsed?.extraFiles ?? []) {
           this.addWatchFile(path.resolve(path.dirname(filePath), file.name));
         }
 
-        const isDev = this.meta?.watchMode === true;
         // Production: emit source data as a JSON asset for on-demand fetch.
         // getFileName() returns a path relative to outDir root (e.g. "assets/foo.json"),
         // so prefix with BASE_URL to form a root-relative URL that resolves correctly
         // regardless of deploy base (root "/" or a PR-preview subpath). Without the
         // prefix, new URL("assets/foo.json", import.meta.url) doubles the "assets/"
         // segment (chunk already lives under assets/) and 404s.
-        const sourceUrl = this.getFileName(
-          this.emitFile({
-            type: "asset",
-            name: `demo-source-${path.basename(filePath, ".vue")}.json`,
-            source: JSON.stringify({
-              source: sourceCode,
-              jsSource: jsSourceCode,
-              html: sourceHtml,
-              jsHtml: jsSourceHtml,
-              extraFiles,
-            }),
-          }),
-        );
+        const sourceUrl = isServe
+          ? undefined
+          : this.getFileName(
+              this.emitFile({
+                type: "asset",
+                name: `demo-source-${path.basename(filePath, ".vue")}.json`,
+                source: JSON.stringify({
+                  source: parsed!.sourceCode,
+                  jsSource: parsed!.jsSourceCode,
+                  html: parsed!.sourceHtml,
+                  jsHtml: parsed!.jsSourceHtml,
+                  extraFiles: parsed!.extraFiles,
+                }),
+              }),
+            );
 
         return {
-          code: isDev
+          code: isServe
             ? `
 import { ref } from 'vue'
 
 const localesRef = ref(${JSON.stringify(locales)})
-const sourceRef = ref(${JSON.stringify(sourceCode)})
-const jsSourceRef = ref(${JSON.stringify(jsSourceCode)})
-const htmlRef = ref(${JSON.stringify(sourceHtml)})
-const jsHtmlRef = ref(${JSON.stringify(jsSourceHtml)})
-const extraFilesRef = ref(${JSON.stringify(extraFiles)})
+const sourceVersionRef = ref(0)
 
 const demoData = {
   component: () => import(${JSON.stringify(filePath)}),
   get locales() { return localesRef.value },
-  get source() { return sourceRef.value },
-  get jsSource() { return jsSourceRef.value },
-  get html() { return htmlRef.value },
-  get jsHtml() { return jsHtmlRef.value },
-  get extraFiles() { return extraFilesRef.value }
+  get sourceVersion() { return sourceVersionRef.value },
+  async loadSource(signal) {
+    const url = new URL(import.meta.env.BASE_URL + ${JSON.stringify(DEV_SOURCE_PATH.slice(1))}, window.location.origin)
+    url.searchParams.set('id', ${JSON.stringify(toDemoKey(filePath, root))})
+    url.searchParams.set('t', String(sourceVersionRef.value))
+    const res = await fetch(url.href, { cache: 'no-store', signal })
+    if (!res.ok)
+      throw new Error(\`Failed to load demo source: \${res.status} \${res.statusText}\`)
+    return res.json()
+  }
 }
 
 if (import.meta.hot) {
   import.meta.hot.accept()
+  import.meta.hot.on('vite:beforeUpdate', () => {
+    sourceVersionRef.value = Date.now()
+  })
   import.meta.hot.on(${JSON.stringify(`demo-update:${normalizedFile}`)}, (data) => {
     if ('locales' in data) localesRef.value = data.locales
-    if ('source' in data) sourceRef.value = data.source
-    if ('jsSource' in data) jsSourceRef.value = data.jsSource
-    if ('html' in data) htmlRef.value = data.html
-    if ('jsHtml' in data) jsHtmlRef.value = data.jsHtml
-    if ('extraFiles' in data) extraFilesRef.value = data.extraFiles
+    if ('timestamp' in data) sourceVersionRef.value = data.timestamp
   })
 }
 
@@ -354,9 +428,10 @@ const localesRef = ref(${JSON.stringify(locales)})
 const demoData = {
   component: () => import(${JSON.stringify(filePath)}),
   get locales() { return localesRef.value },
-  async loadSource() {
+  sourceVersion: 0,
+  async loadSource(signal) {
     const url = new URL(import.meta.env.BASE_URL + ${JSON.stringify(sourceUrl)}, import.meta.url)
-    const res = await fetch(url.href)
+    const res = await fetch(url.href, { signal })
     if (!res.ok)
       throw new Error(\`Failed to load demo source: \${res.status} \${res.statusText}\`)
     return res.json()
@@ -382,26 +457,19 @@ export default demoData
       const normalizedFile = normalizePath(ctx.file);
 
       // Bust cache and re-parse.
-      demoParseCache.delete(ctx.file);
-      const {
-        locales,
-        sourceCode,
-        jsSourceCode,
-        sourceHtml,
-        jsSourceHtml,
-        extraFiles,
-      } = await getParsedDemo(ctx.file);
+      buildDemoParseCache.delete(ctx.file);
+      const locales = await parseDemoLocales(
+        await fs.readFile(ctx.file, "utf-8"),
+        ctx.file,
+        md,
+      );
 
       ctx.server.ws.send({
         type: "custom",
         event: `demo-update:${normalizedFile}`,
         data: {
           locales,
-          source: sourceCode,
-          jsSource: jsSourceCode,
-          html: sourceHtml,
-          jsHtml: jsSourceHtml,
-          extraFiles,
+          timestamp: Date.now(),
         },
       });
       return ctx.modules;

--- a/packages/docs/src/components/doc-demo/demo.vue
+++ b/packages/docs/src/components/doc-demo/demo.vue
@@ -1,11 +1,18 @@
 <script setup lang="ts">
+import type { DemoExtraFile, DemoModule, DemoSourceData } from "virtual:demos";
 import type { Component, CSSProperties } from "vue";
 
 import { CheckOutlined, CodeOutlined, CopyOutlined } from "@antdv-next/icons";
 import { useClipboard } from "@vueuse/core";
 import { createStyles } from "antdv-style";
 import { loadDemo } from "virtual:demos";
-import { computed, defineAsyncComponent, shallowRef, watch } from "vue";
+import {
+  computed,
+  defineAsyncComponent,
+  onBeforeUnmount,
+  shallowRef,
+  watch,
+} from "vue";
 import { useRoute, useRouter } from "vue-router";
 
 import { getDemoId } from "@/utils/get-demo-id";
@@ -167,29 +174,42 @@ const route = useRoute();
 const router = useRouter();
 const showCode = shallowRef(false);
 const codeType = shallowRef<string>("ts");
-const demo = shallowRef<any>(null);
-const sourceData = shallowRef<any>(null);
+const demo = shallowRef<DemoModule | null>(null);
+const sourceData = shallowRef<DemoSourceData | null>(null);
 const sourceLoading = shallowRef(false);
 const sourceLoadError = shallowRef<Error | null>(null);
 const demoLoading = shallowRef(true);
 let demoLoadVersion = 0;
 let sourceLoadPromise: Promise<void> | null = null;
+let sourceAbortController: AbortController | null = null;
+
+function releaseSource() {
+  sourceAbortController?.abort();
+  sourceAbortController = null;
+  sourceData.value = null;
+  sourceLoadError.value = null;
+  sourceLoadPromise = null;
+  sourceLoading.value = false;
+}
 
 async function ensureSourceLoaded() {
   if (sourceData.value || !demo.value) return;
   if (sourceLoadPromise) return sourceLoadPromise;
 
   const currentDemo = demo.value;
+  const abortController = new AbortController();
+  sourceAbortController = abortController;
   sourceLoading.value = true;
   sourceLoadError.value = null;
 
-  const request = Promise.resolve(
-    currentDemo.loadSource ? currentDemo.loadSource() : currentDemo,
-  )
+  const request = currentDemo
+    .loadSource(abortController.signal)
     .then(data => {
-      if (demo.value === currentDemo) sourceData.value = data;
+      if (demo.value === currentDemo && !abortController.signal.aborted)
+        sourceData.value = data;
     })
     .catch(error => {
+      if (abortController.signal.aborted) return;
       const loadError =
         error instanceof Error ? error : new Error(String(error));
       if (demo.value === currentDemo) sourceLoadError.value = loadError;
@@ -197,6 +217,7 @@ async function ensureSourceLoaded() {
     })
     .finally(() => {
       if (sourceLoadPromise === request) {
+        sourceAbortController = null;
         sourceLoadPromise = null;
         sourceLoading.value = false;
       }
@@ -206,20 +227,26 @@ async function ensureSourceLoaded() {
   return request;
 }
 
-watch(
-  demo,
-  () => {
-    sourceData.value = null;
-    sourceLoadError.value = null;
-    sourceLoadPromise = null;
-    sourceLoading.value = false;
-  },
-  { flush: "sync" },
-);
+watch(demo, releaseSource, { flush: "sync" });
 
 watch([showCode, demo], ([visible, currentDemo]) => {
-  if (visible && currentDemo) void ensureSourceLoaded().catch(() => {});
+  if (!visible) {
+    releaseSource();
+    return;
+  }
+  if (currentDemo) void ensureSourceLoaded().catch(() => {});
 });
+
+watch(
+  () => demo.value?.sourceVersion,
+  (version, previousVersion) => {
+    if (!showCode.value || version === previousVersion) return;
+    releaseSource();
+    void ensureSourceLoaded().catch(() => {});
+  },
+);
+
+onBeforeUnmount(releaseSource);
 
 watch(
   () => props.src,
@@ -266,9 +293,9 @@ const component = computed<Component | undefined>(() => {
 
 const id = computed(() => getDemoId(props.src));
 const hasJsSource = computed(() => Boolean(sourceData.value?.jsSource?.trim()));
-const extraFiles = computed<
-  { name: string; lang: string; code: string; html: string }[]
->(() => sourceData.value?.extraFiles ?? []);
+const extraFiles = computed<DemoExtraFile[]>(
+  () => sourceData.value?.extraFiles ?? [],
+);
 const hasExtraFiles = computed(() => extraFiles.value.length > 0);
 const hasCodeTabs = computed(() => hasJsSource.value || hasExtraFiles.value);
 const codeTabKeys = computed(() => {

--- a/packages/docs/types/markdown.d.ts
+++ b/packages/docs/types/markdown.d.ts
@@ -15,13 +15,26 @@ declare module "virtual:demos" {
     title?: string;
   }
 
-  interface DemoModule {
+  export interface DemoExtraFile {
+    name: string;
+    lang: string;
+    code: string;
+    html: string;
+  }
+
+  export interface DemoSourceData {
+    source: string;
+    jsSource: string;
+    html: string;
+    jsHtml: string;
+    extraFiles: DemoExtraFile[];
+  }
+
+  export interface DemoModule {
     component?: () => Promise<unknown>;
     locales?: Record<string, DemoLocale>;
-    source?: string;
-    jsSource?: string;
-    html?: string;
-    jsHtml?: string;
+    sourceVersion: number;
+    loadSource: (signal?: AbortSignal) => Promise<DemoSourceData>;
   }
 
   export function loadDemo(id: string): Promise<DemoModule | null>;


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
如果你要提交新功能或修复 Bug，请基于 `main` 分支创建 feature/bugfix 分支后再提交。
在提交 Pull Request 前，请确认下方清单已完成。
Pull Request 会在至少一位协作者审核通过后合并。
谢谢！
-->

[English template / 英文模板](./PULL_REQUEST_TEMPLATE.md)

### 🤔 本次变更属于 ...

- [ ] 🆕 新功能
- [x] 🐞 Bug 修复
- [x] 📝 站点 / 文档改进
- [ ] 📽️ Demo 改进
- [ ] 💄 组件样式改进
- [x] 🤖 TypeScript 类型定义改进
- [x] 📦 包体积优化
- [x] ⚡️ 性能优化
- [ ] ⭐️ 功能增强
- [ ] 🌐 国际化
- [ ] 🛠 重构
- [ ] 🎨 代码风格优化
- [ ] ✅ 测试用例
- [ ] 🔀 分支合并
- [ ] ⏩ 工作流
- [ ] ⌨️ 无障碍改进
- [ ] ❓ 其他（请说明）

### 🔗 相关 Issue

暂无关联 Issue。

### 💡 背景与方案

文档开发服务加载 demo 时，`vite:demo` 插件会在 serve 模式调用仅构建阶段支持的 `emitFile()` 和 `getFileName()`，导致 Vite 持续输出插件兼容警告。同时，开发模块会内联完整源码与高亮 HTML，长时间浏览大量 demo 时会增加客户端和开发服务器内存占用。

本次调整统一开发与生产的 `loadSource(signal?)` 异步接口：

- 开发环境通过 `__demo_source` 端点在展开代码时实时解析并返回源码，插件仅合并进行中的重复请求，完成后不保留解析结果。
- 生产环境继续在构建时生成带 hash 的 `demo-source-*.json`，保持源码按需加载和现有包体积优化。
- 折叠代码、切换 demo 或组件卸载时取消未完成请求并释放源码数据。
- HMR 仅传递版本和 locale 信息，代码面板展开时按版本重新获取源码。
- `emitFile()` 和 `getFileName()` 仅在 build 模式调用。
- 补充 `DemoModule`、`DemoSourceData` 与 `DemoExtraFile` 类型约束。

验证结果：

- `vp test`：46 个测试文件、463 项测试全部通过。
- 本次变更文件通过 `vp check`。
- `vp build packages/docs` 构建成功，`demo-source-*.json` 正常生成。
- 开发环境直接加载 demo 模块和源码端点成功，未再出现 serve-mode 插件兼容警告。

### 📝 变更日志

| 语言    | 变更日志 |
| ------- | -------- |
| 🇺🇸 英文 | Fix Vite serve-mode warnings and load documentation demo source on demand in development. |
| 🇨🇳 中文 | 修复 Vite 开发模式插件兼容警告，并在开发环境按需加载文档 demo 源码。 |
