### PR TITLE
fix(x-sdk): support Node timeout handles

### DIFF
--- a/packages/x-sdk/src/x-request/index.ts
+++ b/packages/x-sdk/src/x-request/index.ts
@@ -188,8 +188,8 @@ export class XRequestClass<
 > extends AbstractXRequestClass<Input, Output, ChatMessage> {
   private _asyncHandler!: Promise<any>;
 
-  private timeoutHandler!: number;
-  private streamTimeoutHandler!: number;
+  private timeoutHandler!: ReturnType<typeof setTimeout>;
+  private streamTimeoutHandler!: ReturnType<typeof setTimeout>;
   private abortController!: AbortController;
   private _state = reactive<XRequestReactiveState>({
     isTimeout: false,


### PR DESCRIPTION
### 🤔 本次变更属于 ...

- [x] 🐞 Bug 修复
- [x] 🤖 TypeScript 类型定义改进

### 🔗 相关 Issue

无。

### 💡 背景与方案

`x-sdk` 在 Node 类型环境中，`setTimeout` 返回 `Timeout`，但请求与流式请求的定时器句柄声明为 `number`，导致类型检查失败。

将两个句柄类型改为 `ReturnType<typeof setTimeout>`，与已有的重试定时器保持一致，并兼容浏览器与 Node 运行时。

### 📝 变更日志

| 语言 | 变更日志 |
| --- | --- |
| 🇺🇸 英文 | Fix XRequest timeout handler types for Node environments. |
| 🇨🇳 中文 | 修复 Node 环境下 XRequest 定时器句柄的类型检查错误。 |

### ✅ 验证

- `vp run --filter @antdv-next/x-sdk type-check`
- `vp lint packages/x-sdk`
- `vp test packages/x-sdk/src/x-request/__tests__/index.test.ts --environment node`