### PR TITLE
style(docs): center demo source loading

### DIFF
--- a/packages/docs/src/components/doc-demo/demo.vue
+++ b/packages/docs/src/components/doc-demo/demo.vue
@@ -131,6 +131,11 @@ const useStyles = createStyles(({ token }) => ({
       lineHeight: 2,
       padding: `${token.paddingSM}px ${token.padding}px`,
     },
+    "& .ant-doc-demo-box-code-loading": {
+      display: "flex",
+      justifyContent: "center",
+      paddingBlock: token.paddingLG,
+    },
     "& .ant-doc-demo-box-code-tabs": {
       borderTop: `1px dashed ${token.colorSplit}`,
     },
@@ -470,7 +475,10 @@ async function openPlayground() {
             />
           </a-tabs>
         </div>
-        <div v-if="sourceLoading" class="ant-doc-demo-box-code">
+        <div
+          v-if="sourceLoading"
+          class="ant-doc-demo-box-code ant-doc-demo-box-code-loading"
+        >
           <a-spin />
         </div>
         <div v-else-if="sourceLoadError" class="ant-doc-demo-box-code">


### PR DESCRIPTION
### This is a ...

- [x] Site / documentation improvement
- [x] Demo improvement

### Related Issues

N/A

### Background and Solution

The loading spinner shown while fetching demo source code was aligned to the start of the code panel and had limited vertical spacing. This centers the spinner horizontally and applies token-based vertical padding to make the loading state visually balanced.

Validation: `vp check packages/docs/src/components/doc-demo/demo.vue`

### Change Log

| Language | Changelog |
| --- | --- |
| English | Center the demo source loading indicator and improve its vertical spacing. |
| Chinese | 居中显示 Demo 源码加载指示器，并优化上下间距。 |