### PR TITLE
fix(code-highlighter): 修复暗色主题下未高亮代码为黑色文字，并将硬编码色 token 化

### DIFF
--- a/packages/docs/src/pages/components/code-highlighter/index.en-US.md
+++ b/packages/docs/src/pages/components/code-highlighter/index.en-US.md
@@ -118,10 +118,12 @@ When the `header` slot is provided, it fully replaces the default header (langua
 
 ### Component Token
 
-| Name           | Description      | Type     | Default                  |
-| -------------- | ---------------- | -------- | ------------------------ |
-| codeFontFamily | Code font family | `string` | `'Fira Code', monospace` |
-| codeFontSize   | Code font size   | `number` | `14`                     |
+| Name           | Description                                             | Type     | Default                  |
+| -------------- | ------------------------------------------------------- | -------- | ------------------------ |
+| codeFontFamily | Code font family                                        | `string` | `'Fira Code', monospace` |
+| codeFontSize   | Code font size                                          | `number` | `14`                     |
+| codeColor      | Code text color in light theme (unhighlighted fallback) | `string` | `#393a34`                |
+| codeColorDark  | Code text color in dark theme (unhighlighted fallback)  | `string` | `#dbd7caee`              |
 
 ## Design Token
 

--- a/packages/docs/src/pages/components/code-highlighter/index.en-US.md
+++ b/packages/docs/src/pages/components/code-highlighter/index.en-US.md
@@ -118,12 +118,20 @@ When the `header` slot is provided, it fully replaces the default header (langua
 
 ### Component Token
 
-| Name           | Description                                             | Type     | Default                  |
-| -------------- | ------------------------------------------------------- | -------- | ------------------------ |
-| codeFontFamily | Code font family                                        | `string` | `'Fira Code', monospace` |
-| codeFontSize   | Code font size                                          | `number` | `14`                     |
-| codeColor      | Code text color in light theme (unhighlighted fallback) | `string` | `#393a34`                |
-| codeColorDark  | Code text color in dark theme (unhighlighted fallback)  | `string` | `#dbd7caee`              |
+| Name                    | Description                                             | Type     | Default                  |
+| ----------------------- | ------------------------------------------------------- | -------- | ------------------------ |
+| codeFontFamily          | Code font family                                        | `string` | `'Fira Code', monospace` |
+| codeFontSize            | Code font size                                          | `number` | `14`                     |
+| codeColor               | Code text color in light theme (unhighlighted fallback) | `string` | `#393a34`                |
+| codeColorDark           | Code text color in dark theme (unhighlighted fallback)  | `string` | `#dbd7caee`              |
+| codeBg                  | Background of the code area and gutter in light theme   | `string` | `#fafafa`                |
+| codeBgDark              | Background of the code area and gutter in dark theme    | `string` | `#1e1e1e`                |
+| codeHeaderBgDark        | Header background in dark theme                         | `string` | `#252526`                |
+| codeBorderColorDark     | Header and gutter divider color in dark theme           | `string` | `#3e3e42`                |
+| codeLangColorDark       | Language label color in dark theme                      | `string` | `#cccccc`                |
+| codeLineNumberColorDark | Line number color in dark theme                         | `string` | `#858585`                |
+| codeBtnColorDark        | Header action button color in dark theme                | `string` | `#ffffff`                |
+| codeBtnHoverBgDark      | Header action button hover background in dark theme     | `string` | `#3e3e42`                |
 
 ## Design Token
 

--- a/packages/docs/src/pages/components/code-highlighter/index.zh-CN.md
+++ b/packages/docs/src/pages/components/code-highlighter/index.zh-CN.md
@@ -118,12 +118,20 @@ setupCodeHighlighter({
 
 ### Component Token
 
-| 名称           | 说明                                         | 类型     | 默认值                   |
-| -------------- | -------------------------------------------- | -------- | ------------------------ |
-| codeFontFamily | 代码字体                                     | `string` | `'Fira Code', monospace` |
-| codeFontSize   | 代码字体大小                                 | `number` | `14`                     |
-| codeColor      | 亮色主题下的代码文字颜色（未高亮时的降级色） | `string` | `#393a34`                |
-| codeColorDark  | 暗色主题下的代码文字颜色（未高亮时的降级色） | `string` | `#dbd7caee`              |
+| 名称                    | 说明                                         | 类型     | 默认值                   |
+| ----------------------- | -------------------------------------------- | -------- | ------------------------ |
+| codeFontFamily          | 代码字体                                     | `string` | `'Fira Code', monospace` |
+| codeFontSize            | 代码字体大小                                 | `number` | `14`                     |
+| codeColor               | 亮色主题下的代码文字颜色（未高亮时的降级色） | `string` | `#393a34`                |
+| codeColorDark           | 暗色主题下的代码文字颜色（未高亮时的降级色） | `string` | `#dbd7caee`              |
+| codeBg                  | 亮色主题下代码区与行号栏的背景色             | `string` | `#fafafa`                |
+| codeBgDark              | 暗色主题下代码区与行号栏的背景色             | `string` | `#1e1e1e`                |
+| codeHeaderBgDark        | 暗色主题下头部区域的背景色                   | `string` | `#252526`                |
+| codeBorderColorDark     | 暗色主题下头部与行号栏的分隔线颜色           | `string` | `#3e3e42`                |
+| codeLangColorDark       | 暗色主题下语言标签的文字颜色                 | `string` | `#cccccc`                |
+| codeLineNumberColorDark | 暗色主题下行号的文字颜色                     | `string` | `#858585`                |
+| codeBtnColorDark        | 暗色主题下头部操作按钮的文字颜色             | `string` | `#ffffff`                |
+| codeBtnHoverBgDark      | 暗色主题下头部操作按钮悬浮态的背景色         | `string` | `#3e3e42`                |
 
 ## 主题变量（Design Token）
 

--- a/packages/docs/src/pages/components/code-highlighter/index.zh-CN.md
+++ b/packages/docs/src/pages/components/code-highlighter/index.zh-CN.md
@@ -118,10 +118,12 @@ setupCodeHighlighter({
 
 ### Component Token
 
-| 名称           | 说明         | 类型     | 默认值                   |
-| -------------- | ------------ | -------- | ------------------------ |
-| codeFontFamily | 代码字体     | `string` | `'Fira Code', monospace` |
-| codeFontSize   | 代码字体大小 | `number` | `14`                     |
+| 名称           | 说明                                         | 类型     | 默认值                   |
+| -------------- | -------------------------------------------- | -------- | ------------------------ |
+| codeFontFamily | 代码字体                                     | `string` | `'Fira Code', monospace` |
+| codeFontSize   | 代码字体大小                                 | `number` | `14`                     |
+| codeColor      | 亮色主题下的代码文字颜色（未高亮时的降级色） | `string` | `#393a34`                |
+| codeColorDark  | 暗色主题下的代码文字颜色（未高亮时的降级色） | `string` | `#dbd7caee`              |
 
 ## 主题变量（Design Token）
 

--- a/packages/x/components/code-highlighter/style/index.ts
+++ b/packages/x/components/code-highlighter/style/index.ts
@@ -26,6 +26,38 @@ export interface ComponentToken {
    * 暗色主题下的代码文字颜色，用于语言未命中高亮时的降级文本
    */
   codeColorDark?: string;
+  /**
+   * 亮色主题下代码区与行号栏的背景色
+   */
+  codeBg?: string;
+  /**
+   * 暗色主题下代码区与行号栏的背景色
+   */
+  codeBgDark?: string;
+  /**
+   * 暗色主题下头部区域的背景色
+   */
+  codeHeaderBgDark?: string;
+  /**
+   * 暗色主题下头部与行号栏的分隔线颜色
+   */
+  codeBorderColorDark?: string;
+  /**
+   * 暗色主题下语言标签的文字颜色
+   */
+  codeLangColorDark?: string;
+  /**
+   * 暗色主题下行号的文字颜色
+   */
+  codeLineNumberColorDark?: string;
+  /**
+   * 暗色主题下头部操作按钮的文字颜色
+   */
+  codeBtnColorDark?: string;
+  /**
+   * 暗色主题下头部操作按钮悬浮态的背景色
+   */
+  codeBtnHoverBgDark?: string;
 }
 
 export interface CodeHighlighterToken extends FullToken<"CodeHighlighter"> {}
@@ -74,7 +106,7 @@ const genCodeHighlighterStyle: GenerateStyle<CodeHighlighterToken> = token => {
       [`${componentCls}-content`]: {
         display: "flex",
         overflow: "auto",
-        backgroundColor: "#fafafa",
+        backgroundColor: token.codeBg,
         alignItems: "stretch",
       },
 
@@ -83,7 +115,7 @@ const genCodeHighlighterStyle: GenerateStyle<CodeHighlighterToken> = token => {
         paddingBlock: unit(token.paddingSM),
         paddingInline: unit(token.paddingXS),
         textAlign: "right",
-        backgroundColor: "#fafafa",
+        backgroundColor: token.codeBg,
         borderRight: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorderSecondary}`,
         userSelect: "none",
         flexShrink: 0,
@@ -135,33 +167,33 @@ const genCodeHighlighterStyle: GenerateStyle<CodeHighlighterToken> = token => {
         borderColor: token.colorBorder,
 
         [`${componentCls}-header`]: {
-          backgroundColor: "#252526",
-          borderBottomColor: "#3e3e42",
+          backgroundColor: token.codeHeaderBgDark,
+          borderBottomColor: token.codeBorderColorDark,
         },
 
         [`${componentCls}-lang`]: {
-          color: "#cccccc",
+          color: token.codeLangColorDark,
         },
 
         [`${componentCls}-theme-btn, ${componentCls}-copy-btn`]: {
-          color: "#ffffff !important",
+          color: `${token.codeBtnColorDark} !important`,
           "&:hover, &:focus": {
-            color: "#ffffff !important",
-            backgroundColor: "#3e3e42 !important",
+            color: `${token.codeBtnColorDark} !important`,
+            backgroundColor: `${token.codeBtnHoverBgDark} !important`,
           },
         },
 
         [`${componentCls}-content`]: {
-          backgroundColor: "#1e1e1e",
+          backgroundColor: token.codeBgDark,
         },
 
         [`${componentCls}-line-numbers`]: {
-          backgroundColor: "#1e1e1e",
-          borderRightColor: "#3e3e42",
+          backgroundColor: token.codeBgDark,
+          borderRightColor: token.codeBorderColorDark,
         },
 
         [`${componentCls}-line-number`]: {
-          color: "#858585",
+          color: token.codeLineNumberColorDark,
         },
 
         [`${componentCls}-code`]: {
@@ -181,6 +213,14 @@ export const prepareComponentToken: GetDefaultToken<
   // 与 shiki vitesse-light / vitesse-dark 的前景色保持一致
   codeColor: "#393a34",
   codeColorDark: "#dbd7caee",
+  codeBg: "#fafafa",
+  codeBgDark: "#1e1e1e",
+  codeHeaderBgDark: "#252526",
+  codeBorderColorDark: "#3e3e42",
+  codeLangColorDark: "#cccccc",
+  codeLineNumberColorDark: "#858585",
+  codeBtnColorDark: "#ffffff",
+  codeBtnHoverBgDark: "#3e3e42",
 });
 
 export default genStyleHooks<"CodeHighlighter">(

--- a/packages/x/components/code-highlighter/style/index.ts
+++ b/packages/x/components/code-highlighter/style/index.ts
@@ -18,6 +18,14 @@ export interface ComponentToken {
    * 代码字体大小
    */
   codeFontSize?: number;
+  /**
+   * 亮色主题下的代码文字颜色，用于语言未命中高亮时的降级文本
+   */
+  codeColor?: string;
+  /**
+   * 暗色主题下的代码文字颜色，用于语言未命中高亮时的降级文本
+   */
+  codeColorDark?: string;
 }
 
 export interface CodeHighlighterToken extends FullToken<"CodeHighlighter"> {}
@@ -99,6 +107,8 @@ const genCodeHighlighterStyle: GenerateStyle<CodeHighlighterToken> = token => {
       [`${componentCls}-code`]: {
         flex: 1,
         overflow: "auto",
+        // 语言未命中高亮时会回退成无内联样式的 pre/code，需要兜底文字色
+        color: token.codeColor,
 
         // Shiki generated pre/code
         "& > pre": {
@@ -153,6 +163,10 @@ const genCodeHighlighterStyle: GenerateStyle<CodeHighlighterToken> = token => {
         [`${componentCls}-line-number`]: {
           color: "#858585",
         },
+
+        [`${componentCls}-code`]: {
+          color: token.codeColorDark,
+        },
       },
     },
   };
@@ -164,6 +178,9 @@ export const prepareComponentToken: GetDefaultToken<
   codeFontFamily:
     "'Fira Code', 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Mono', 'Droid Sans Mono', 'Source Code Pro', monospace",
   codeFontSize: 14,
+  // 与 shiki vitesse-light / vitesse-dark 的前景色保持一致
+  codeColor: "#393a34",
+  codeColorDark: "#dbd7caee",
 });
 
 export default genStyleHooks<"CodeHighlighter">(


### PR DESCRIPTION
## 问题

最小复现：

```vue
<ax-code-highlighter theme="dark" language="text" content="123" />
```

暗色主题下文字仍是黑色，压在 `#1e1e1e` 的背景上，基本看不见。

## 原因

`shiki.ts:147` 里，语言没命中高亮时会直接返回裸的 `<pre><code>…</code></pre>`，**不带任何 inline 颜色**：

```ts
if (!hasLang) return `<pre><code>${escapeHtml(code)}</code></pre>`;
```

而 `style/index.ts` 的 `&-dark` 样式块只设置了 header 背景、`-lang`、按钮、`-content` 背景、行号颜色，**唯独没有给 `-code` 设 `color`**。于是文字继承外层的 `token.colorText`（浅色上下文里是近黑色），黑字压深底。

影响面比纯文本更大：内置语言白名单只有 `typescript` / `javascript` / `python` / `json` / `html` / `css`（`shiki.ts:22-29`），因此 `bash`、`go`、`java`、`sql` 等在未调用 `setupCodeHighlighter` 注入 loader 时都会走同一条降级路径，暗色下同样是黑字。

## 修复（commit 1）

新增 `codeColor` / `codeColorDark` 两个 Component Token，分别作用于亮色态和 `&-dark` 态的 `-code`，默认值取 shiki `vitesse-light` / `vitesse-dark` 的前景色，保证降级文本与正常高亮的色调一致。

Shiki 高亮成功时颜色写在 inline style 上，优先级更高，因此这两条规则只在「未高亮」时生效，不影响已高亮的代码。

## 顺带清理（commit 2）

把样式函数里剩余的 8 处硬编码色也全部移到 Component Token，**默认值保持原样，无视觉变化**：

| Token | 默认值 | 作用 |
| --- | --- | --- |
| `codeBg` / `codeBgDark` | `#fafafa` / `#1e1e1e` | 代码区与行号栏背景 |
| `codeHeaderBgDark` | `#252526` | 暗色头部背景 |
| `codeBorderColorDark` | `#3e3e42` | 暗色头部与行号栏分隔线 |
| `codeLangColorDark` | `#cccccc` | 暗色语言标签文字 |
| `codeLineNumberColorDark` | `#858585` | 暗色行号文字 |
| `codeBtnColorDark` | `#ffffff` | 暗色操作按钮文字 |
| `codeBtnHoverBgDark` | `#3e3e42` | 暗色操作按钮悬浮背景 |

改完后样式函数里已无颜色字面量，字面量只存在于 `prepareComponentToken`，使用方可通过 `theme.components.CodeHighlighter` 覆盖。

### 为什么用 Component Token 而不是全局 Token

`theme` prop 完全由使用方控制，`-light` / `-dark` 是两套各自自包含的配色，与全局 algorithm 无关。如果这些颜色改用 `colorText` / `colorFillQuaternary` 之类的全局 token，那么「`theme` 与全局 algorithm 相反」时（例如整站 darkAlgorithm 但组件用默认 `theme="light"`），背景与文字会同时朝一个方向漂移，重新造出这次修的那类「深底深字 / 白底白字」问题。固定默认值 + 可覆盖的 Component Token 在两个方向上都稳。

## 说明

组件的 `theme` 保持完全由使用方控制，本 PR 不引入任何自动跟随全局 algorithm 的行为。

## 验证

- `vp run --filter @antdv-next/x type-check` 通过
- `vp check --fix`（commit hook）通过
