### PR TITLE
fix(code-highlighter): make light-theme colors fully self-contained

### DIFF
--- a/packages/docs/src/pages/components/code-highlighter/index.en-US.md
+++ b/packages/docs/src/pages/components/code-highlighter/index.en-US.md
@@ -129,6 +129,7 @@ When the `header` slot is provided, it fully replaces the default header (langua
 | codeHeaderBgDark        | Header background in dark theme                         | `string` | `#252526`                |
 | codeBorderColorDark     | Header and gutter divider color in dark theme           | `string` | `#3e3e42`                |
 | codeLangColorDark       | Language label color in dark theme                      | `string` | `#cccccc`                |
+| codeLineNumberColor     | Line number color in light theme                        | `string` | `rgba(0, 0, 0, 0.25)`    |
 | codeLineNumberColorDark | Line number color in dark theme                         | `string` | `#858585`                |
 | codeBtnColorDark        | Header action button color in dark theme                | `string` | `#ffffff`                |
 | codeBtnHoverBgDark      | Header action button hover background in dark theme     | `string` | `#3e3e42`                |

--- a/packages/docs/src/pages/components/code-highlighter/index.en-US.md
+++ b/packages/docs/src/pages/components/code-highlighter/index.en-US.md
@@ -126,12 +126,17 @@ When the `header` slot is provided, it fully replaces the default header (langua
 | codeColorDark           | Code text color in dark theme (unhighlighted fallback)  | `string` | `#dbd7caee`              |
 | codeBg                  | Background of the code area and gutter in light theme   | `string` | `#fafafa`                |
 | codeBgDark              | Background of the code area and gutter in dark theme    | `string` | `#1e1e1e`                |
+| codeHeaderBg            | Header background in light theme                        | `string` | `#f0f0f0`                |
 | codeHeaderBgDark        | Header background in dark theme                         | `string` | `#252526`                |
+| codeBorderColor         | Header and gutter divider color in light theme          | `string` | `#f0f0f0`                |
 | codeBorderColorDark     | Header and gutter divider color in dark theme           | `string` | `#3e3e42`                |
+| codeLangColor           | Language label color in light theme                     | `string` | `rgba(0, 0, 0, 0.65)`    |
 | codeLangColorDark       | Language label color in dark theme                      | `string` | `#cccccc`                |
 | codeLineNumberColor     | Line number color in light theme                        | `string` | `rgba(0, 0, 0, 0.25)`    |
 | codeLineNumberColorDark | Line number color in dark theme                         | `string` | `#858585`                |
+| codeBtnColor            | Header action button color in light theme               | `string` | `rgba(0, 0, 0, 0.65)`    |
 | codeBtnColorDark        | Header action button color in dark theme                | `string` | `#ffffff`                |
+| codeBtnHoverBg          | Header action button hover background in light theme    | `string` | `rgba(0, 0, 0, 0.06)`    |
 | codeBtnHoverBgDark      | Header action button hover background in dark theme     | `string` | `#3e3e42`                |
 
 ## Design Token

--- a/packages/docs/src/pages/components/code-highlighter/index.zh-CN.md
+++ b/packages/docs/src/pages/components/code-highlighter/index.zh-CN.md
@@ -126,12 +126,17 @@ setupCodeHighlighter({
 | codeColorDark           | 暗色主题下的代码文字颜色（未高亮时的降级色） | `string` | `#dbd7caee`              |
 | codeBg                  | 亮色主题下代码区与行号栏的背景色             | `string` | `#fafafa`                |
 | codeBgDark              | 暗色主题下代码区与行号栏的背景色             | `string` | `#1e1e1e`                |
+| codeHeaderBg            | 亮色主题下头部区域的背景色                   | `string` | `#f0f0f0`                |
 | codeHeaderBgDark        | 暗色主题下头部区域的背景色                   | `string` | `#252526`                |
+| codeBorderColor         | 亮色主题下头部与行号栏的分隔线颜色           | `string` | `#f0f0f0`                |
 | codeBorderColorDark     | 暗色主题下头部与行号栏的分隔线颜色           | `string` | `#3e3e42`                |
+| codeLangColor           | 亮色主题下语言标签的文字颜色                 | `string` | `rgba(0, 0, 0, 0.65)`    |
 | codeLangColorDark       | 暗色主题下语言标签的文字颜色                 | `string` | `#cccccc`                |
 | codeLineNumberColor     | 亮色主题下行号的文字颜色                     | `string` | `rgba(0, 0, 0, 0.25)`    |
 | codeLineNumberColorDark | 暗色主题下行号的文字颜色                     | `string` | `#858585`                |
+| codeBtnColor            | 亮色主题下头部操作按钮的文字颜色             | `string` | `rgba(0, 0, 0, 0.65)`    |
 | codeBtnColorDark        | 暗色主题下头部操作按钮的文字颜色             | `string` | `#ffffff`                |
+| codeBtnHoverBg          | 亮色主题下头部操作按钮悬浮态的背景色         | `string` | `rgba(0, 0, 0, 0.06)`    |
 | codeBtnHoverBgDark      | 暗色主题下头部操作按钮悬浮态的背景色         | `string` | `#3e3e42`                |
 
 ## 主题变量（Design Token）

--- a/packages/docs/src/pages/components/code-highlighter/index.zh-CN.md
+++ b/packages/docs/src/pages/components/code-highlighter/index.zh-CN.md
@@ -129,6 +129,7 @@ setupCodeHighlighter({
 | codeHeaderBgDark        | 暗色主题下头部区域的背景色                   | `string` | `#252526`                |
 | codeBorderColorDark     | 暗色主题下头部与行号栏的分隔线颜色           | `string` | `#3e3e42`                |
 | codeLangColorDark       | 暗色主题下语言标签的文字颜色                 | `string` | `#cccccc`                |
+| codeLineNumberColor     | 亮色主题下行号的文字颜色                     | `string` | `rgba(0, 0, 0, 0.25)`    |
 | codeLineNumberColorDark | 暗色主题下行号的文字颜色                     | `string` | `#858585`                |
 | codeBtnColorDark        | 暗色主题下头部操作按钮的文字颜色             | `string` | `#ffffff`                |
 | codeBtnHoverBgDark      | 暗色主题下头部操作按钮悬浮态的背景色         | `string` | `#3e3e42`                |

--- a/packages/x/components/code-highlighter/style/index.ts
+++ b/packages/x/components/code-highlighter/style/index.ts
@@ -47,6 +47,10 @@ export interface ComponentToken {
    */
   codeLangColorDark?: string;
   /**
+   * 亮色主题下行号的文字颜色
+   */
+  codeLineNumberColor?: string;
+  /**
    * 暗色主题下行号的文字颜色
    */
   codeLineNumberColorDark?: string;
@@ -128,7 +132,7 @@ const genCodeHighlighterStyle: GenerateStyle<CodeHighlighterToken> = token => {
         fontSize: unit(token.codeFontSize ?? 13),
         lineHeight: "1.5em",
         height: "1.5em",
-        color: token.colorTextQuaternary,
+        color: token.codeLineNumberColor,
         display: "flex",
         alignItems: "center",
         justifyContent: "flex-end",
@@ -218,6 +222,7 @@ export const prepareComponentToken: GetDefaultToken<
   codeHeaderBgDark: "#252526",
   codeBorderColorDark: "#3e3e42",
   codeLangColorDark: "#cccccc",
+  codeLineNumberColor: "rgba(0, 0, 0, 0.25)",
   codeLineNumberColorDark: "#858585",
   codeBtnColorDark: "#ffffff",
   codeBtnHoverBgDark: "#3e3e42",

--- a/packages/x/components/code-highlighter/style/index.ts
+++ b/packages/x/components/code-highlighter/style/index.ts
@@ -35,13 +35,25 @@ export interface ComponentToken {
    */
   codeBgDark?: string;
   /**
+   * 亮色主题下头部区域的背景色
+   */
+  codeHeaderBg?: string;
+  /**
    * 暗色主题下头部区域的背景色
    */
   codeHeaderBgDark?: string;
   /**
+   * 亮色主题下头部与行号栏的分隔线颜色
+   */
+  codeBorderColor?: string;
+  /**
    * 暗色主题下头部与行号栏的分隔线颜色
    */
   codeBorderColorDark?: string;
+  /**
+   * 亮色主题下语言标签的文字颜色
+   */
+  codeLangColor?: string;
   /**
    * 暗色主题下语言标签的文字颜色
    */
@@ -55,9 +67,17 @@ export interface ComponentToken {
    */
   codeLineNumberColorDark?: string;
   /**
+   * 亮色主题下头部操作按钮的文字颜色
+   */
+  codeBtnColor?: string;
+  /**
    * 暗色主题下头部操作按钮的文字颜色
    */
   codeBtnColorDark?: string;
+  /**
+   * 亮色主题下头部操作按钮悬浮态的背景色
+   */
+  codeBtnHoverBg?: string;
   /**
    * 暗色主题下头部操作按钮悬浮态的背景色
    */
@@ -76,7 +96,7 @@ const genCodeHighlighterStyle: GenerateStyle<CodeHighlighterToken> = token => {
       overflow: "hidden",
       fontFamily: token.fontFamily,
       fontSize: token.fontSize,
-      border: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorderSecondary}`,
+      border: `${unit(token.lineWidth)} ${token.lineType} ${token.codeBorderColor}`,
 
       // Header
       [`${componentCls}-header`]: {
@@ -85,13 +105,13 @@ const genCodeHighlighterStyle: GenerateStyle<CodeHighlighterToken> = token => {
         justifyContent: "space-between",
         paddingInline: unit(token.paddingSM),
         paddingBlock: 4,
-        borderBottom: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorderSecondary}`,
-        backgroundColor: token.colorFillSecondary,
+        borderBottom: `${unit(token.lineWidth)} ${token.lineType} ${token.codeBorderColor}`,
+        backgroundColor: token.codeHeaderBg,
       },
 
       [`${componentCls}-lang`]: {
         fontSize: token.fontSizeSM,
-        color: token.colorTextSecondary,
+        color: token.codeLangColor,
         fontWeight: 500,
         textTransform: "capitalize",
       },
@@ -103,7 +123,11 @@ const genCodeHighlighterStyle: GenerateStyle<CodeHighlighterToken> = token => {
       },
 
       [`${componentCls}-theme-btn, ${componentCls}-copy-btn`]: {
-        color: token.colorTextSecondary,
+        color: `${token.codeBtnColor} !important`,
+        "&:hover, &:focus": {
+          color: `${token.codeBtnColor} !important`,
+          backgroundColor: `${token.codeBtnHoverBg} !important`,
+        },
       },
 
       // Content
@@ -120,7 +144,7 @@ const genCodeHighlighterStyle: GenerateStyle<CodeHighlighterToken> = token => {
         paddingInline: unit(token.paddingXS),
         textAlign: "right",
         backgroundColor: token.codeBg,
-        borderRight: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorderSecondary}`,
+        borderRight: `${unit(token.lineWidth)} ${token.lineType} ${token.codeBorderColor}`,
         userSelect: "none",
         flexShrink: 0,
         minWidth: "3em",
@@ -168,7 +192,7 @@ const genCodeHighlighterStyle: GenerateStyle<CodeHighlighterToken> = token => {
 
       // Theme: Dark
       [`&${componentCls}-dark`]: {
-        borderColor: token.colorBorder,
+        borderColor: token.codeBorderColorDark,
 
         [`${componentCls}-header`]: {
           backgroundColor: token.codeHeaderBgDark,
@@ -219,12 +243,17 @@ export const prepareComponentToken: GetDefaultToken<
   codeColorDark: "#dbd7caee",
   codeBg: "#fafafa",
   codeBgDark: "#1e1e1e",
+  codeHeaderBg: "#f0f0f0",
   codeHeaderBgDark: "#252526",
+  codeBorderColor: "#f0f0f0",
   codeBorderColorDark: "#3e3e42",
+  codeLangColor: "rgba(0, 0, 0, 0.65)",
   codeLangColorDark: "#cccccc",
   codeLineNumberColor: "rgba(0, 0, 0, 0.25)",
   codeLineNumberColorDark: "#858585",
+  codeBtnColor: "rgba(0, 0, 0, 0.65)",
   codeBtnColorDark: "#ffffff",
+  codeBtnHoverBg: "rgba(0, 0, 0, 0.06)",
   codeBtnHoverBgDark: "#3e3e42",
 });
 


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix

### 🔗 Related Issues

> - Follow-up to #172 (`fix(code-highlighter): 修复暗色主题下未高亮代码为黑色文字，并将硬编码色 token 化`), which tokenized the dark-theme colors but left most of the light-theme side on algorithm-driven global tokens.

### 💡 Background and Solution

The `-light` / `-dark` variants are self-contained color schemes driven by the user-controlled `theme` prop, so their colors must not follow the app color algorithm - this is the principle #172 established ("using `colorText` would break the mirrored case"). #172 only tokenized the **dark** side (plus the line-number light token in the first commit here); the rest of the **light** chrome still used global tokens.

**Impact of the gap** - in the mirrored case (app on the dark algorithm + `theme="light"`), the global tokens resolve to dark-algorithm values:

| Global token (light rule) | Light algo | Dark algo (mirrored) | Result on `#fafafa` |
| --- | --- | --- | --- |
| `colorTextSecondary` (lang label, buttons) | `rgba(0,0,0,0.65)` | `rgba(255,255,255,0.65)` | **invisible** text/icons |
| `colorTextQuaternary` (line numbers) | `rgba(0,0,0,0.25)` | `rgba(255,255,255,0.25)` | **invisible** line numbers |
| `colorFillSecondary` (header bg) | `rgba(0,0,0,0.06)` | `rgba(255,255,255,0.12)` | header loses separation |
| `colorBorderSecondary` (borders) | `#f0f0f0` | dark-algo value | wrong borders |

And the dark-theme root border used the global `colorBorder` instead of `codeBorderColorDark`, so in the opposite mirrored case (light algorithm + `theme="dark"`) it drew a light `#d9d9d9` outline around the dark card.

**Solution**

Add the missing light counterparts to the existing dark tokens and wire them in, so `-light` / `-dark` are now fully self-contained and symmetric:

| New light token | Replaces | Dark counterpart (existing) |
| --- | --- | --- |
| `codeLineNumberColor` | `colorTextQuaternary` | `codeLineNumberColorDark` |
| `codeHeaderBg` | `colorFillSecondary` | `codeHeaderBgDark` |
| `codeBorderColor` | `colorBorderSecondary` (root / header-bottom / gutter-right) | `codeBorderColorDark` |
| `codeLangColor` | `colorTextSecondary` | `codeLangColorDark` |
| `codeBtnColor` | `colorTextSecondary` | `codeBtnColorDark` |
| `codeBtnHoverBg` | (light had no hover override) | `codeBtnHoverBgDark` |

Also: dark root border `colorBorder` -> `codeBorderColorDark`; light action buttons now mirror the dark side with `!important` + explicit hover background (the dark side already needed `!important` to beat antd Button `.ant-btn-variant-text` color).

**Defaults preserve the previous common-case appearance** - opaque hexes are the equivalent of the prior translucent global tokens composited over white (e.g. `#f0f0f0` == `colorBorderSecondary` / `colorFillSecondary` over white), and the rgba text colors match the prior `colorTextSecondary` / `colorTextQuaternary` under the light algorithm. No visual change in the common case; only the mirrored cases are fixed.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix `CodeHighlighter` rendering in the mirrored case (app color algorithm opposite to the component `theme` prop): line numbers, language label, and action buttons were invisible, the header lost separation, and borders were wrong. All light-theme colors are now self-contained component tokens (`codeHeaderBg`, `codeBorderColor`, `codeLangColor`, `codeBtnColor`, `codeBtnHoverBg`, `codeLineNumberColor`) matching the existing dark counterparts; the dark root border now reuses `codeBorderColorDark`. |
| 🇨🇳 Chinese | 修复 `CodeHighlighter` 在镜像场景（应用算法与组件 `theme` 相反）下的显示：行号、语言标签、操作按钮不可见，头部背景与内容区糊在一起，边框颜色错误。亮色主题所有颜色改为自包含的组件 token（`codeHeaderBg`、`codeBorderColor`、`codeLangColor`、`codeBtnColor`、`codeBtnHoverBg`、`codeLineNumberColor`），与已有暗色 token 一一对应；暗色根边框改用 `codeBorderColorDark`。 |
