### PR TITLE
feat(code-highlighter): Component Token 默认值随 Design Token 派生

### DIFF
--- a/packages/docs/src/pages/components/code-highlighter/index.en-US.md
+++ b/packages/docs/src/pages/components/code-highlighter/index.en-US.md
@@ -114,31 +114,6 @@ When the `header` slot is provided, it fully replaces the default header (langua
 
 <demo src="./demo/semantic.vue" simplify>CodeHighlighter Semantic DOM</demo>
 
-## Design Tokens
-
-### Component Token
-
-| Name                    | Description                                             | Type     | Default                  |
-| ----------------------- | ------------------------------------------------------- | -------- | ------------------------ |
-| codeFontFamily          | Code font family                                        | `string` | `'Fira Code', monospace` |
-| codeFontSize            | Code font size                                          | `number` | `14`                     |
-| codeColor               | Code text color in light theme (unhighlighted fallback) | `string` | `#393a34`                |
-| codeColorDark           | Code text color in dark theme (unhighlighted fallback)  | `string` | `#dbd7caee`              |
-| codeBg                  | Background of the code area and gutter in light theme   | `string` | `#fafafa`                |
-| codeBgDark              | Background of the code area and gutter in dark theme    | `string` | `#1e1e1e`                |
-| codeHeaderBg            | Header background in light theme                        | `string` | `#f0f0f0`                |
-| codeHeaderBgDark        | Header background in dark theme                         | `string` | `#252526`                |
-| codeBorderColor         | Header and gutter divider color in light theme          | `string` | `#f0f0f0`                |
-| codeBorderColorDark     | Header and gutter divider color in dark theme           | `string` | `#3e3e42`                |
-| codeLangColor           | Language label color in light theme                     | `string` | `rgba(0, 0, 0, 0.65)`    |
-| codeLangColorDark       | Language label color in dark theme                      | `string` | `#cccccc`                |
-| codeLineNumberColor     | Line number color in light theme                        | `string` | `rgba(0, 0, 0, 0.25)`    |
-| codeLineNumberColorDark | Line number color in dark theme                         | `string` | `#858585`                |
-| codeBtnColor            | Header action button color in light theme               | `string` | `rgba(0, 0, 0, 0.65)`    |
-| codeBtnColorDark        | Header action button color in dark theme                | `string` | `#ffffff`                |
-| codeBtnHoverBg          | Header action button hover background in light theme    | `string` | `rgba(0, 0, 0, 0.06)`    |
-| codeBtnHoverBgDark      | Header action button hover background in dark theme     | `string` | `#3e3e42`                |
-
 ## Design Token
 
 <ComponentTokenTable component="CodeHighlighter"></ComponentTokenTable>

--- a/packages/docs/src/pages/components/code-highlighter/index.zh-CN.md
+++ b/packages/docs/src/pages/components/code-highlighter/index.zh-CN.md
@@ -114,31 +114,6 @@ setupCodeHighlighter({
 
 <demo src="./demo/semantic.vue" simplify>CodeHighlighter 语义结构</demo>
 
-## 设计令牌
-
-### Component Token
-
-| 名称                    | 说明                                         | 类型     | 默认值                   |
-| ----------------------- | -------------------------------------------- | -------- | ------------------------ |
-| codeFontFamily          | 代码字体                                     | `string` | `'Fira Code', monospace` |
-| codeFontSize            | 代码字体大小                                 | `number` | `14`                     |
-| codeColor               | 亮色主题下的代码文字颜色（未高亮时的降级色） | `string` | `#393a34`                |
-| codeColorDark           | 暗色主题下的代码文字颜色（未高亮时的降级色） | `string` | `#dbd7caee`              |
-| codeBg                  | 亮色主题下代码区与行号栏的背景色             | `string` | `#fafafa`                |
-| codeBgDark              | 暗色主题下代码区与行号栏的背景色             | `string` | `#1e1e1e`                |
-| codeHeaderBg            | 亮色主题下头部区域的背景色                   | `string` | `#f0f0f0`                |
-| codeHeaderBgDark        | 暗色主题下头部区域的背景色                   | `string` | `#252526`                |
-| codeBorderColor         | 亮色主题下头部与行号栏的分隔线颜色           | `string` | `#f0f0f0`                |
-| codeBorderColorDark     | 暗色主题下头部与行号栏的分隔线颜色           | `string` | `#3e3e42`                |
-| codeLangColor           | 亮色主题下语言标签的文字颜色                 | `string` | `rgba(0, 0, 0, 0.65)`    |
-| codeLangColorDark       | 暗色主题下语言标签的文字颜色                 | `string` | `#cccccc`                |
-| codeLineNumberColor     | 亮色主题下行号的文字颜色                     | `string` | `rgba(0, 0, 0, 0.25)`    |
-| codeLineNumberColorDark | 暗色主题下行号的文字颜色                     | `string` | `#858585`                |
-| codeBtnColor            | 亮色主题下头部操作按钮的文字颜色             | `string` | `rgba(0, 0, 0, 0.65)`    |
-| codeBtnColorDark        | 暗色主题下头部操作按钮的文字颜色             | `string` | `#ffffff`                |
-| codeBtnHoverBg          | 亮色主题下头部操作按钮悬浮态的背景色         | `string` | `rgba(0, 0, 0, 0.06)`    |
-| codeBtnHoverBgDark      | 暗色主题下头部操作按钮悬浮态的背景色         | `string` | `#3e3e42`                |
-
 ## 主题变量（Design Token）
 
 <ComponentTokenTable component="CodeHighlighter"></ComponentTokenTable>

--- a/packages/x/components/code-highlighter/style/index.ts
+++ b/packages/x/components/code-highlighter/style/index.ts
@@ -103,7 +103,6 @@ const genCodeHighlighterStyle: GenerateStyle<CodeHighlighterToken> = token => {
       position: "relative",
       borderRadius: token.borderRadiusLG,
       overflow: "hidden",
-      fontFamily: token.fontFamily,
       fontSize: token.fontSize,
       border: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorderCode}`,
 

--- a/packages/x/components/code-highlighter/style/index.ts
+++ b/packages/x/components/code-highlighter/style/index.ts
@@ -42,53 +42,53 @@ export interface ComponentToken {
    */
   colorBorderCodeDark?: string;
   /**
-   * @desc 亮色主题下代码区与行号栏的背景色
-   * @descEN Background of the code area and gutter in light theme
+   * @desc 代码区与行号栏背景色
+   * @descEN Background of the code area and gutter
    */
   codeBg?: string;
   /**
-   * @desc 暗色主题下代码区与行号栏的背景色
+   * @desc 暗色主题下代码区与行号栏背景色
    * @descEN Background of the code area and gutter in dark theme
    */
   codeBgDark?: string;
   /**
-   * @desc 亮色主题下的代码文字颜色，用于语言未命中高亮时的降级文本
-   * @descEN Code text color in light theme (unhighlighted fallback)
+   * @desc 代码文字颜色（语言未命中高亮时降级）
+   * @descEN Code text color (fallback when language is not highlighted)
    */
   codeColor?: string;
   /**
-   * @desc 暗色主题下的代码文字颜色，用于语言未命中高亮时的降级文本
-   * @descEN Code text color in dark theme (unhighlighted fallback)
+   * @desc 暗色主题下代码文字颜色（语言未命中高亮时降级）
+   * @descEN Code text color in dark theme (fallback when language is not highlighted)
    */
   codeColorDark?: string;
   /**
-   * @desc 亮色主题下行号的文字颜色
-   * @descEN Line number color in light theme
+   * @desc 行号文字颜色
+   * @descEN Line number color
    */
   codeLineNumberColor?: string;
   /**
-   * @desc 暗色主题下行号的文字颜色
+   * @desc 暗色主题下行号文字颜色
    * @descEN Line number color in dark theme
    */
   codeLineNumberColorDark?: string;
   /**
-   * @desc 亮色主题下头部操作按钮的文字颜色
-   * @descEN Header action button color in light theme
+   * @desc 操作按钮文字颜色
+   * @descEN Action button color
    */
   codeBtnColor?: string;
   /**
-   * @desc 暗色主题下头部操作按钮的文字颜色
-   * @descEN Header action button color in dark theme
+   * @desc 暗色主题下操作按钮文字颜色
+   * @descEN Action button color in dark theme
    */
   codeBtnColorDark?: string;
   /**
-   * @desc 亮色主题下头部操作按钮悬浮态的背景色
-   * @descEN Header action button hover background in light theme
+   * @desc 操作按钮悬浮背景色
+   * @descEN Action button hover background
    */
   codeBtnHoverBg?: string;
   /**
-   * @desc 暗色主题下头部操作按钮悬浮态的背景色
-   * @descEN Header action button hover background in dark theme
+   * @desc 暗色主题下操作按钮悬浮背景色
+   * @descEN Action button hover background in dark theme
    */
   codeBtnHoverBgDark?: string;
 }

--- a/packages/x/components/code-highlighter/style/index.ts
+++ b/packages/x/components/code-highlighter/style/index.ts
@@ -12,25 +12,35 @@ import { genStyleHooks } from "../../theme/genStyleUtils";
 
 export interface ComponentToken {
   /**
-   * @desc 代码字体
-   * @descEN Code font family
+   * @desc 标题背景颜色
+   * @descEN Title background color
    */
-  codeFontFamily?: string;
+  colorBgTitle?: string;
   /**
-   * @desc 代码字体大小
-   * @descEN Code font size
+   * @desc 暗色主题下标题背景颜色
+   * @descEN Title background color in dark theme
    */
-  codeFontSize?: number;
+  colorBgTitleDark?: string;
   /**
-   * @desc 亮色主题下的代码文字颜色，用于语言未命中高亮时的降级文本
-   * @descEN Code text color in light theme (unhighlighted fallback)
+   * @desc 标题文本颜色
+   * @descEN Title text color
    */
-  codeColor?: string;
+  colorTextTitle?: string;
   /**
-   * @desc 暗色主题下的代码文字颜色，用于语言未命中高亮时的降级文本
-   * @descEN Code text color in dark theme (unhighlighted fallback)
+   * @desc 暗色主题下标题文本颜色
+   * @descEN Title text color in dark theme
    */
-  codeColorDark?: string;
+  colorTextTitleDark?: string;
+  /**
+   * @desc 代码块边框颜色
+   * @descEN Code block border color
+   */
+  colorBorderCode?: string;
+  /**
+   * @desc 暗色主题下代码块边框颜色
+   * @descEN Code block border color in dark theme
+   */
+  colorBorderCodeDark?: string;
   /**
    * @desc 亮色主题下代码区与行号栏的背景色
    * @descEN Background of the code area and gutter in light theme
@@ -42,35 +52,15 @@ export interface ComponentToken {
    */
   codeBgDark?: string;
   /**
-   * @desc 亮色主题下头部区域的背景色
-   * @descEN Header background in light theme
+   * @desc 亮色主题下的代码文字颜色，用于语言未命中高亮时的降级文本
+   * @descEN Code text color in light theme (unhighlighted fallback)
    */
-  codeHeaderBg?: string;
+  codeColor?: string;
   /**
-   * @desc 暗色主题下头部区域的背景色
-   * @descEN Header background in dark theme
+   * @desc 暗色主题下的代码文字颜色，用于语言未命中高亮时的降级文本
+   * @descEN Code text color in dark theme (unhighlighted fallback)
    */
-  codeHeaderBgDark?: string;
-  /**
-   * @desc 亮色主题下头部与行号栏的分隔线颜色
-   * @descEN Header and gutter divider color in light theme
-   */
-  codeBorderColor?: string;
-  /**
-   * @desc 暗色主题下头部与行号栏的分隔线颜色
-   * @descEN Header and gutter divider color in dark theme
-   */
-  codeBorderColorDark?: string;
-  /**
-   * @desc 亮色主题下语言标签的文字颜色
-   * @descEN Language label color in light theme
-   */
-  codeLangColor?: string;
-  /**
-   * @desc 暗色主题下语言标签的文字颜色
-   * @descEN Language label color in dark theme
-   */
-  codeLangColorDark?: string;
+  codeColorDark?: string;
   /**
    * @desc 亮色主题下行号的文字颜色
    * @descEN Line number color in light theme
@@ -115,7 +105,7 @@ const genCodeHighlighterStyle: GenerateStyle<CodeHighlighterToken> = token => {
       overflow: "hidden",
       fontFamily: token.fontFamily,
       fontSize: token.fontSize,
-      border: `${unit(token.lineWidth)} ${token.lineType} ${token.codeBorderColor}`,
+      border: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorderCode}`,
 
       // Header
       [`${componentCls}-header`]: {
@@ -124,13 +114,13 @@ const genCodeHighlighterStyle: GenerateStyle<CodeHighlighterToken> = token => {
         justifyContent: "space-between",
         paddingInline: unit(token.paddingSM),
         paddingBlock: 4,
-        borderBottom: `${unit(token.lineWidth)} ${token.lineType} ${token.codeBorderColor}`,
-        backgroundColor: token.codeHeaderBg,
+        borderBottom: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorderCode}`,
+        backgroundColor: token.colorBgTitle,
       },
 
       [`${componentCls}-lang`]: {
         fontSize: token.fontSizeSM,
-        color: token.codeLangColor,
+        color: token.colorTextTitle,
         fontWeight: 500,
         textTransform: "capitalize",
       },
@@ -163,7 +153,7 @@ const genCodeHighlighterStyle: GenerateStyle<CodeHighlighterToken> = token => {
         paddingInline: unit(token.paddingXS),
         textAlign: "right",
         backgroundColor: token.codeBg,
-        borderRight: `${unit(token.lineWidth)} ${token.lineType} ${token.codeBorderColor}`,
+        borderRight: `${unit(token.lineWidth)} ${token.lineType} ${token.colorBorderCode}`,
         userSelect: "none",
         flexShrink: 0,
         minWidth: "3em",
@@ -171,8 +161,8 @@ const genCodeHighlighterStyle: GenerateStyle<CodeHighlighterToken> = token => {
       },
 
       [`${componentCls}-line-number`]: {
-        fontFamily: token.codeFontFamily,
-        fontSize: unit(token.codeFontSize ?? 13),
+        fontFamily: token.fontFamilyCode,
+        fontSize: unit(token.fontSize),
         lineHeight: "1.5em",
         height: "1.5em",
         color: token.codeLineNumberColor,
@@ -194,8 +184,8 @@ const genCodeHighlighterStyle: GenerateStyle<CodeHighlighterToken> = token => {
           margin: 0,
           padding: unit(token.paddingSM),
           backgroundColor: "transparent !important",
-          fontFamily: token.codeFontFamily,
-          fontSize: unit(token.codeFontSize ?? 13),
+          fontFamily: token.fontFamilyCode,
+          fontSize: unit(token.fontSize),
           lineHeight: "1.5em",
           overflow: "visible",
         },
@@ -211,15 +201,15 @@ const genCodeHighlighterStyle: GenerateStyle<CodeHighlighterToken> = token => {
 
       // Theme: Dark
       [`&${componentCls}-dark`]: {
-        borderColor: token.codeBorderColorDark,
+        borderColor: token.colorBorderCodeDark,
 
         [`${componentCls}-header`]: {
-          backgroundColor: token.codeHeaderBgDark,
-          borderBottomColor: token.codeBorderColorDark,
+          backgroundColor: token.colorBgTitleDark,
+          borderBottomColor: token.colorBorderCodeDark,
         },
 
         [`${componentCls}-lang`]: {
-          color: token.codeLangColorDark,
+          color: token.colorTextTitleDark,
         },
 
         [`${componentCls}-theme-btn, ${componentCls}-copy-btn`]: {
@@ -236,7 +226,7 @@ const genCodeHighlighterStyle: GenerateStyle<CodeHighlighterToken> = token => {
 
         [`${componentCls}-line-numbers`]: {
           backgroundColor: token.codeBgDark,
-          borderRightColor: token.codeBorderColorDark,
+          borderRightColor: token.colorBorderCodeDark,
         },
 
         [`${componentCls}-line-number`]: {
@@ -261,14 +251,13 @@ export const prepareComponentToken: GetDefaultToken<
   const isDarkApp = new FastColor(token.colorBgContainer).isDark();
 
   return {
-    codeFontFamily: token.fontFamilyCode,
-    codeFontSize: token.fontSize,
+    // 标题（头部）背景/文字/边框：与上游 @ant-design/x 对齐
+    colorBgTitle: isDarkApp ? "#f0f0f0" : token.colorFillContent,
+    colorTextTitle: isDarkApp ? "rgba(0, 0, 0, 0.65)" : token.colorText,
+    colorBorderCode: isDarkApp ? "#f0f0f0" : token.colorBorderSecondary,
     // 亮色预览（默认模式）：亮色应用下跟随 Design Token，暗色应用下保持固定值
     codeColor: isDarkApp ? "#393a34" : token.colorText,
     codeBg: isDarkApp ? "#fafafa" : token.colorBgLayout,
-    codeHeaderBg: isDarkApp ? "#f0f0f0" : token.colorFillSecondary,
-    codeBorderColor: isDarkApp ? "#f0f0f0" : token.colorBorderSecondary,
-    codeLangColor: isDarkApp ? "rgba(0, 0, 0, 0.65)" : token.colorTextSecondary,
     codeLineNumberColor: isDarkApp
       ? "rgba(0, 0, 0, 0.25)"
       : token.colorTextQuaternary,
@@ -277,11 +266,11 @@ export const prepareComponentToken: GetDefaultToken<
       ? "rgba(0, 0, 0, 0.06)"
       : token.colorFillSecondary,
     // 暗色预览（`theme="dark"`）：暗色应用下跟随 Design Token，亮色应用下保持固定值
+    colorBgTitleDark: isDarkApp ? token.colorFillContent : "#252526",
+    colorTextTitleDark: isDarkApp ? token.colorText : "#cccccc",
+    colorBorderCodeDark: isDarkApp ? token.colorBorder : "#3e3e42",
     codeColorDark: isDarkApp ? token.colorText : "#dbd7caee",
     codeBgDark: isDarkApp ? token.colorBgElevated : "#1e1e1e",
-    codeHeaderBgDark: isDarkApp ? token.colorFillSecondary : "#252526",
-    codeBorderColorDark: isDarkApp ? token.colorBorder : "#3e3e42",
-    codeLangColorDark: isDarkApp ? token.colorTextSecondary : "#cccccc",
     codeLineNumberColorDark: isDarkApp ? token.colorTextQuaternary : "#858585",
     codeBtnColorDark: isDarkApp ? token.colorText : "#ffffff",
     codeBtnHoverBgDark: isDarkApp ? token.colorFillSecondary : "#3e3e42",

--- a/packages/x/components/code-highlighter/style/index.ts
+++ b/packages/x/components/code-highlighter/style/index.ts
@@ -1,3 +1,4 @@
+import { FastColor } from "@ant-design/fast-color";
 import { unit } from "@antdv-next/cssinjs";
 import { mergeToken } from "@antdv-next/cssinjs/cssinjs-utils";
 
@@ -11,75 +12,93 @@ import { genStyleHooks } from "../../theme/genStyleUtils";
 
 export interface ComponentToken {
   /**
-   * 代码字体
+   * @desc 代码字体
+   * @descEN Code font family
    */
   codeFontFamily?: string;
   /**
-   * 代码字体大小
+   * @desc 代码字体大小
+   * @descEN Code font size
    */
   codeFontSize?: number;
   /**
-   * 亮色主题下的代码文字颜色，用于语言未命中高亮时的降级文本
+   * @desc 亮色主题下的代码文字颜色，用于语言未命中高亮时的降级文本
+   * @descEN Code text color in light theme (unhighlighted fallback)
    */
   codeColor?: string;
   /**
-   * 暗色主题下的代码文字颜色，用于语言未命中高亮时的降级文本
+   * @desc 暗色主题下的代码文字颜色，用于语言未命中高亮时的降级文本
+   * @descEN Code text color in dark theme (unhighlighted fallback)
    */
   codeColorDark?: string;
   /**
-   * 亮色主题下代码区与行号栏的背景色
+   * @desc 亮色主题下代码区与行号栏的背景色
+   * @descEN Background of the code area and gutter in light theme
    */
   codeBg?: string;
   /**
-   * 暗色主题下代码区与行号栏的背景色
+   * @desc 暗色主题下代码区与行号栏的背景色
+   * @descEN Background of the code area and gutter in dark theme
    */
   codeBgDark?: string;
   /**
-   * 亮色主题下头部区域的背景色
+   * @desc 亮色主题下头部区域的背景色
+   * @descEN Header background in light theme
    */
   codeHeaderBg?: string;
   /**
-   * 暗色主题下头部区域的背景色
+   * @desc 暗色主题下头部区域的背景色
+   * @descEN Header background in dark theme
    */
   codeHeaderBgDark?: string;
   /**
-   * 亮色主题下头部与行号栏的分隔线颜色
+   * @desc 亮色主题下头部与行号栏的分隔线颜色
+   * @descEN Header and gutter divider color in light theme
    */
   codeBorderColor?: string;
   /**
-   * 暗色主题下头部与行号栏的分隔线颜色
+   * @desc 暗色主题下头部与行号栏的分隔线颜色
+   * @descEN Header and gutter divider color in dark theme
    */
   codeBorderColorDark?: string;
   /**
-   * 亮色主题下语言标签的文字颜色
+   * @desc 亮色主题下语言标签的文字颜色
+   * @descEN Language label color in light theme
    */
   codeLangColor?: string;
   /**
-   * 暗色主题下语言标签的文字颜色
+   * @desc 暗色主题下语言标签的文字颜色
+   * @descEN Language label color in dark theme
    */
   codeLangColorDark?: string;
   /**
-   * 亮色主题下行号的文字颜色
+   * @desc 亮色主题下行号的文字颜色
+   * @descEN Line number color in light theme
    */
   codeLineNumberColor?: string;
   /**
-   * 暗色主题下行号的文字颜色
+   * @desc 暗色主题下行号的文字颜色
+   * @descEN Line number color in dark theme
    */
   codeLineNumberColorDark?: string;
   /**
-   * 亮色主题下头部操作按钮的文字颜色
+   * @desc 亮色主题下头部操作按钮的文字颜色
+   * @descEN Header action button color in light theme
    */
   codeBtnColor?: string;
   /**
-   * 暗色主题下头部操作按钮的文字颜色
+   * @desc 暗色主题下头部操作按钮的文字颜色
+   * @descEN Header action button color in dark theme
    */
   codeBtnColorDark?: string;
   /**
-   * 亮色主题下头部操作按钮悬浮态的背景色
+   * @desc 亮色主题下头部操作按钮悬浮态的背景色
+   * @descEN Header action button hover background in light theme
    */
   codeBtnHoverBg?: string;
   /**
-   * 暗色主题下头部操作按钮悬浮态的背景色
+   * @desc 暗色主题下头部操作按钮悬浮态的背景色
+   * @descEN Header action button hover background in dark theme
    */
   codeBtnHoverBgDark?: string;
 }
@@ -234,28 +253,40 @@ const genCodeHighlighterStyle: GenerateStyle<CodeHighlighterToken> = token => {
 
 export const prepareComponentToken: GetDefaultToken<
   "CodeHighlighter"
-> = () => ({
-  codeFontFamily:
-    "'Fira Code', 'SF Mono', 'Monaco', 'Inconsolata', 'Fira Mono', 'Droid Sans Mono', 'Source Code Pro', monospace",
-  codeFontSize: 14,
-  // 与 shiki vitesse-light / vitesse-dark 的前景色保持一致
-  codeColor: "#393a34",
-  codeColorDark: "#dbd7caee",
-  codeBg: "#fafafa",
-  codeBgDark: "#1e1e1e",
-  codeHeaderBg: "#f0f0f0",
-  codeHeaderBgDark: "#252526",
-  codeBorderColor: "#f0f0f0",
-  codeBorderColorDark: "#3e3e42",
-  codeLangColor: "rgba(0, 0, 0, 0.65)",
-  codeLangColorDark: "#cccccc",
-  codeLineNumberColor: "rgba(0, 0, 0, 0.25)",
-  codeLineNumberColorDark: "#858585",
-  codeBtnColor: "rgba(0, 0, 0, 0.65)",
-  codeBtnColorDark: "#ffffff",
-  codeBtnHoverBg: "rgba(0, 0, 0, 0.06)",
-  codeBtnHoverBgDark: "#3e3e42",
-});
+> = token => {
+  // 组件的 `theme` prop（light/dark 代码预览）与应用主题算法是正交的：
+  // 仅当应用主题与组件模式一致时，才能安全地从全局 token 派生；
+  // 反之（如暗色算法应用 + `theme="light"`）继续使用与 shiki vitesse 主题
+  // 配套的固定值，避免出现 #172/#174 中描述的颜色不可见问题。
+  const isDarkApp = new FastColor(token.colorBgContainer).isDark();
+
+  return {
+    codeFontFamily: token.fontFamilyCode,
+    codeFontSize: token.fontSize,
+    // 亮色预览（默认模式）：亮色应用下跟随 Design Token，暗色应用下保持固定值
+    codeColor: isDarkApp ? "#393a34" : token.colorText,
+    codeBg: isDarkApp ? "#fafafa" : token.colorBgLayout,
+    codeHeaderBg: isDarkApp ? "#f0f0f0" : token.colorFillSecondary,
+    codeBorderColor: isDarkApp ? "#f0f0f0" : token.colorBorderSecondary,
+    codeLangColor: isDarkApp ? "rgba(0, 0, 0, 0.65)" : token.colorTextSecondary,
+    codeLineNumberColor: isDarkApp
+      ? "rgba(0, 0, 0, 0.25)"
+      : token.colorTextQuaternary,
+    codeBtnColor: isDarkApp ? "rgba(0, 0, 0, 0.65)" : token.colorTextSecondary,
+    codeBtnHoverBg: isDarkApp
+      ? "rgba(0, 0, 0, 0.06)"
+      : token.colorFillSecondary,
+    // 暗色预览（`theme="dark"`）：暗色应用下跟随 Design Token，亮色应用下保持固定值
+    codeColorDark: isDarkApp ? token.colorText : "#dbd7caee",
+    codeBgDark: isDarkApp ? token.colorBgElevated : "#1e1e1e",
+    codeHeaderBgDark: isDarkApp ? token.colorFillSecondary : "#252526",
+    codeBorderColorDark: isDarkApp ? token.colorBorder : "#3e3e42",
+    codeLangColorDark: isDarkApp ? token.colorTextSecondary : "#cccccc",
+    codeLineNumberColorDark: isDarkApp ? token.colorTextQuaternary : "#858585",
+    codeBtnColorDark: isDarkApp ? token.colorText : "#ffffff",
+    codeBtnHoverBgDark: isDarkApp ? token.colorFillSecondary : "#3e3e42",
+  };
+};
 
 export default genStyleHooks<"CodeHighlighter">(
   "CodeHighlighter",

--- a/packages/x/scripts/token/collect-token-statistic.ts
+++ b/packages/x/scripts/token/collect-token-statistic.ts
@@ -36,7 +36,6 @@ let ConfigProvider: any;
 // methods / sub-components whose styles are already covered by their parent).
 const blackList = [
   "Mermaid",
-  "CodeHighlighter",
   "XProvider",
   "Notification",
   "XNotification",
@@ -68,6 +67,8 @@ const ComponentCustomizeRender: Record<string, RenderFn> = {
   Folder: Folder => h(Folder, { treeData: [] }),
   Sources: Sources => h(Sources, { items: [] }),
   Actions: Actions => h(Actions, { items: [] }),
+  CodeHighlighter: CodeHighlighter =>
+    h(CodeHighlighter, { content: "const a = 1;" }),
 };
 
 function shouldRenderComponent(name: string) {

--- a/packages/x/tsconfig.node.json
+++ b/packages/x/tsconfig.node.json
@@ -19,6 +19,7 @@
   "include": [
     "vite.build.config.ts",
     "vite.esm.config.ts",
-    "vite.umd.config.ts"
+    "vite.umd.config.ts",
+    "scripts/token/**/*.ts"
   ]
 }


### PR DESCRIPTION
## 背景

CodeHighlighter 的 Component Token 之前存在两个问题：
1. 全部硬编码默认值（`prepareComponentToken` 不接收 token 参数），修改主题变量（Design Token）对组件无效；
2. token 命名与上游 @ant-design/x 不一致（上游只有 3 个 token：`colorBgTitle`/`colorTextTitle`/`colorBorderCode`，字体直接用全局 `fontFamilyCode`/`fontSize`）。

## 变更

### 1. Component Token 默认值随 Design Token 派生（`packages/x/components/code-highlighter/style/index.ts`）

`prepareComponentToken` 改为基于全局 token 派生，并通过 `FastColor(token.colorBgContainer).isDark()` 判断应用是否为暗色：仅当应用主题与组件模式一致时才从全局 token 派生；跨模式（如暗色应用 + `theme="light"`）继续使用与 shiki vitesse 主题配套的固定值，保持 #172/#174 确立的 self-contained 预览行为不回归。

### 2. Token 命名/描述对齐上游 @ant-design/x

| 之前 | 现在 | 派生来源 |
| --- | --- | --- |
| `codeFontFamily` / `codeFontSize` | ❌ 删除 | 样式直接使用全局 `fontFamilyCode` / `fontSize`（与上游一致） |
| `codeHeaderBg` (+Dark) | `colorBgTitle` (+Dark) | `colorFillContent` |
| `codeLangColor` (+Dark) | `colorTextTitle` (+Dark) | `colorText` |
| `codeBorderColor` (+Dark) | `colorBorderCode` (+Dark) | `colorBorderSecondary` |

保留行号/复制按钮/暗色预览等上游没有的扩展 token：`codeBg`、`codeColor`、`codeLineNumberColor`、`codeBtnColor`、`codeBtnHoverBg`（含 -Dark 系列）。

**BREAKING CHANGE**：组件 token 重命名（包为 v1.2.1-beta，token 为 #172/#174 刚引入，重命名成本最低；对齐上游便于 React/Vue 两个版本的迁移与文档对照）。

### 3. 文档去重（`index.zh-CN.md` / `index.en-US.md`）

删除手动维护的 Component Token 表格（与自动生成的 `ComponentTokenTable` 重复），保留自动表格。现在 token 表格、描述全部由代码 JSDoc + 构建期统计自动生成。

### 4. 配套

- `collect-token-statistic.ts`：CodeHighlighter 纳入 token 统计收集（文档表格能自动生成）；
- 为全部 Component Token 补充 `@desc`/`@descEN` JSDoc，自动表格带中英文描述；
- `tsconfig.node.json`：`scripts/token` 纳入 Node 类型检查（预提交钩子需要）。

## 效果

- 改 `fontFamilyCode`/`fontSize`/`colorBgLayout`/`colorText` 等主题变量，或切换暗色算法，组件默认外观自动联动；
- 文档「主题变量（Design Token）」表格与上游结构对齐：Global Token 部分会显示 `fontFamilyCode`/`fontSize` 等实际用到的全局 token。
