### PR TITLE
ci: add PR quality gates and harden deploy and workflow permissions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+
+updates:
+  # Keeps the SHA-pinned third-party actions in deploy.yml current — pinning
+  # without an updater just means running stale, unpatched actions forever.
+  #
+  # npm is deliberately not enabled here: every dependency in this workspace
+  # is declared via pnpm's `catalog:` protocol in pnpm-workspace.yaml, which
+  # Dependabot does not resolve. Use `vp outdated` / `vp update` instead.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: ci
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,33 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+  push:
+    branches:
+      - main
 
 concurrency:
   group: ci-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
-  test:
-    if: github.event.pull_request.draft == false
+  check:
+    name: ${{ matrix.task }}
+    if: github.event_name == 'push' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      matrix:
+        task:
+          - lint
+          - type-check
+          - test
+          - build
+          - docs
 
     steps:
       - name: Checkout code
@@ -26,5 +44,32 @@ jobs:
         with:
           cache: true
 
-      - name: Run tests
+      # Explicit install so a stale or hand-edited lockfile fails loudly here
+      # instead of silently resolving during the first `vp run`.
+      - name: Install dependencies
+        run: vp install --frozen-lockfile
+
+      # `vp check` runs fmt + lint + type-aware lint (see `lint`/`fmt` in
+      # vite.config.ts). Locally this only runs on staged files via the
+      # pre-commit hook, which `--no-verify` and fork PRs bypass.
+      - name: Format & lint
+        if: matrix.task == 'lint'
+        run: vp check
+
+      - name: Type check
+        if: matrix.task == 'type-check'
+        run: vp run type-check
+
+      - name: Unit tests
+        if: matrix.task == 'test'
         run: vp run test:unit
+
+      - name: Build packages
+        if: matrix.task == 'build'
+        run: vp run build:packages
+
+      # Guards the deploy workflow: a docs build break used to surface only
+      # after merge, on the job that publishes the site.
+      - name: Build docs
+        if: matrix.task == 'docs'
+        run: vp run docs:build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,21 @@ jobs:
       - name: Install dependencies
         run: vp install --frozen-lockfile
 
-      # `vp check` runs fmt + lint + type-aware lint (see `lint`/`fmt` in
-      # vite.config.ts). Locally this only runs on staged files via the
-      # pre-commit hook, which `--no-verify` and fork PRs bypass.
+      # `vp check` type-aware lint (lint.options.typeCheck in vite.config.ts)
+      # resolves three gitignored, generated inputs that a clean checkout lacks:
+      #   - packages/x/dist        — referenced by packages/x/global.d.ts and by
+      #                              scripts/token/collect-token-statistic.ts
+      #   - docs types/auto-imports.d.ts — unplugin-auto-import output backing
+      #                              the bare `computed` / `createGlobalState`
+      #                              calls in packages/docs/src/composables
+      # `docs:build` produces both (it runs @antdv-next/x `build:token`, which
+      # chains `build:comp`). Without it `vp check` reports 41 phantom errors.
+      - name: Generate build artifacts for type-aware lint
+        if: matrix.task == 'lint'
+        run: vp run docs:build
+
+      # Locally this only runs on staged files via the pre-commit hook, which
+      # `--no-verify` and fork PRs bypass.
       - name: Format & lint
         if: matrix.task == 'lint'
         run: vp check

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   claude-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -27,6 +27,7 @@ jobs:
         (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,35 +7,37 @@ on:
 
 concurrency:
   group: deploy-x-main
-  cancel-in-progress: true
+  # Never cancel a deploy mid-flight: the switch step below empties the live
+  # `index` dir before moving the new build in, so a cancelled run can leave
+  # the server serving nothing.
+  cancel-in-progress: false
+
+permissions:
+  contents: read
 
 jobs:
   build:
     if: github.repository == 'antdv-next/x'
 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      # Same toolchain as CI, so a green PR exercises the exact path used here.
+      - name: Setup Vite+
+        uses: voidzero-dev/setup-vp@v1
         with:
-          run_install: false
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: pnpm
+          cache: true
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: vp install --frozen-lockfile
 
       - name: Build site
         run: |
-          pnpm docs:build
+          vp run docs:build
           rm -rf dist
           cp -r packages/docs/dist dist
 
@@ -49,6 +51,11 @@ jobs:
     needs: build
 
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    permissions:
+      contents: read
+      actions: read
 
     steps:
       - name: Download site artifact
@@ -60,8 +67,10 @@ jobs:
       - name: Inspect downloaded site artifact
         run: ls -R dist
 
+      # Third-party actions that receive deploy credentials are pinned to a
+      # commit SHA — a mutable tag would let an upstream compromise read them.
       - name: Scp dir to server
-        uses: appleboy/scp-action@v1
+        uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USERNAME }}
@@ -71,7 +80,7 @@ jobs:
           target: ${{ secrets.DEPLOY_TARGET_PATH }}
 
       - name: Switch current site
-        uses: appleboy/ssh-action@v1
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1
         with:
           host: ${{ secrets.DEPLOY_HOST }}
           username: ${{ secrets.DEPLOY_USERNAME }}
@@ -103,6 +112,11 @@ jobs:
     needs: build
 
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    permissions:
+      contents: read
+      actions: read
 
     steps:
       - name: Download site artifact
@@ -115,7 +129,7 @@ jobs:
         run: ls -R dist
 
       - name: Scp dir to CN server
-        uses: appleboy/scp-action@v1
+        uses: appleboy/scp-action@ff85246acaad7bdce478db94a363cd2bf7c90345 # v1
         with:
           host: ${{ secrets.DEPLOY_HOST_CN }}
           username: ${{ secrets.DEPLOY_USERNAME_CN }}
@@ -125,7 +139,7 @@ jobs:
           target: ${{ secrets.DEPLOY_TARGET_PATH_CN }}
 
       - name: Switch current site on CN server
-        uses: appleboy/ssh-action@v1
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1
         with:
           host: ${{ secrets.DEPLOY_HOST_CN }}
           username: ${{ secrets.DEPLOY_USERNAME_CN }}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,49 @@
+name: PR Title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+
+concurrency:
+  group: pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  conventional-title:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      # Squash merges use the PR title as the commit message, and there is no
+      # commit-msg hook in .vite-hooks — so this is the only place the
+      # conventional-commit convention is actually enforced.
+      - name: Validate conventional commit title
+        env:
+          # Passed through the environment, never interpolated into the script,
+          # so a crafted PR title cannot inject shell commands.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -eu
+
+          TYPES='feat|fix|docs|dx|style|refactor|perf|test|workflow|build|ci|chore|types|wip|release'
+
+          if printf '%s' "$PR_TITLE" | grep -Eq "^($TYPES)(\([^)]+\))?!?: .+"; then
+            echo "OK: $PR_TITLE"
+            exit 0
+          fi
+
+          echo "::error::PR title does not follow the conventional commit format."
+          echo ""
+          echo "  Received: $PR_TITLE"
+          echo "  Expected: <type>(<optional scope>): <subject>"
+          echo "  Types:    $TYPES"
+          echo ""
+          echo "  Example:  feat(bubble): add streaming animation"
+          exit 1


### PR DESCRIPTION
[中文版模板 / Chinese template](./PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [x] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None. Follow-up work is split into #178.

### 💡 Background and Solution

**The problem.** CI ran a single job on pull requests: `vp run test:unit`. Everything else was ungated.

- `vite.config.ts` configures `lint` and `fmt`, but they only ever ran against staged files through the `.vite-hooks/pre-commit` hook. `--no-verify` and fork PRs bypass them entirely.
- Five of the six packages define a `type-check` script. CI never invoked any of them.
- The docs build only ran on push to `main`, inside `deploy.yml`. A PR that broke the docs site could merge cleanly and then take the live deployment down.
- `ci.yml` listened only to `pull_request`, so `main` itself was never verified.

**The solution.**

`ci.yml` becomes a parallel matrix of `lint` / `type-check` / `test` / `build` / `docs` with `fail-fast: false`, so one failure does not mask the others and the failing category is obvious from the job name. Added a push-to-`main` trigger, an explicit `permissions: contents: read` block (it previously ran on the repository's default token scope), `timeout-minutes`, and an explicit `vp install --frozen-lockfile` so lockfile drift fails loudly rather than resolving silently inside the first `vp run`.

`deploy.yml` now builds through `setup-vp` instead of `pnpm/action-setup` + `setup-node`. Previously the deploy path was never exercised by CI, so a green PR did not imply a working deploy. Three further fixes:

- `cancel-in-progress: false`. The switch step empties the live `index` directory before moving the new build in, so cancelling two rapid pushes could leave the server serving nothing.
- `appleboy/scp-action` and `appleboy/ssh-action` are pinned to commit SHAs. Both receive the deploy password through secrets, and a mutable tag would expose those credentials to an upstream compromise.
- Added `permissions` and `timeout-minutes`.

`pr-title.yml` is new: it validates that PR titles follow the conventional commit format. Squash merges use the PR title as the commit message, and `.vite-hooks/` contains only `pre-commit` — there is no `commit-msg` hook — so this is the only point at which the convention is actually enforced. Implemented as a plain bash regex with no third-party action; the title is passed through the environment rather than interpolated into the script, so a crafted title cannot inject shell commands. The type list is taken from `CLAUDE.md`.

> Note: the list has no `revert`, so GitHub's auto-generated `Revert "..."` titles will be rejected and need renaming. Easy to add if that proves annoying.

`dependabot.yml` is new and enables the `github-actions` ecosystem only — pinning SHAs without an updater just means running unpatched actions forever. The npm ecosystem is deliberately left off: every dependency is declared through pnpm's `catalog:` protocol in `pnpm-workspace.yaml`, which Dependabot cannot resolve, so enabling it would only generate noise. Use `vp outdated` / `vp update` instead.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Gate pull requests on lint, type checks, package builds and the docs build; enforce conventional commit PR titles; harden the deploy workflow with least-privilege permissions, timeouts and SHA-pinned third-party actions. |
| 🇨🇳 Chinese | PR 增加 lint、类型检查、包构建与文档构建门禁；强制 PR 标题遵循 conventional commit；部署工作流补齐最小权限、超时与第三方 action 的 SHA 固定。 |