### PR TITLE
fix(suggestion): stop Cascader from swallowing Space and Enter in the trigger

### DIFF
--- a/packages/x/components/suggestion/Suggestion.tsx
+++ b/packages/x/components/suggestion/Suggestion.tsx
@@ -163,6 +163,22 @@ const XSuggestion = defineComponent({
       }
     };
 
+    /**
+     * Cascader renders our children as its raw input element, so every keydown from the
+     * children bubbles into BaseSelect's keyboard model. That model is built for a
+     * non-editable trigger: it calls `preventDefault()` on Space/Enter and opens the popup,
+     * which breaks typing inside an editable trigger such as Sender.
+     *
+     * Keep the events inside the content wrapper. Enter still needs to reach Cascader while
+     * the popup is open so the active option can be selected by keyboard.
+     */
+    const onContentKeyDown = (event: KeyboardEvent) => {
+      if (mergedOpen.value && event.key === "Enter") {
+        return;
+      }
+      event.stopPropagation();
+    };
+
     const domAttrs = computed(() => {
       const { class: _class, style: _style, ...rest } = attrs;
       return rest;
@@ -268,6 +284,7 @@ const XSuggestion = defineComponent({
                 contextConfig.value.styles?.content,
                 mergedStyles.value.content,
               ]}
+              onKeydown={onContentKeyDown}
             >
               {childNode}
             </div>

--- a/packages/x/components/suggestion/__tests__/index.test.tsx
+++ b/packages/x/components/suggestion/__tests__/index.test.tsx
@@ -360,6 +360,75 @@ describe("Suggestion", () => {
     expect(document.body.textContent).not.toContain("default-extra");
   });
 
+  it("does not let Cascader swallow Space / Enter typed in the trigger", async () => {
+    const wrapper = track(
+      mount(Suggestion, {
+        attachTo: document.body,
+        props: { items },
+        slots: createSlot(),
+      }),
+    );
+
+    const input = wrapper.find(".trigger-input");
+
+    // Closed: neither key may be prevented nor may it open the popup.
+    for (const key of ["Space", "Enter"] as const) {
+      const event = new KeyboardEvent("keydown", {
+        key: key === "Space" ? " " : "Enter",
+        bubbles: true,
+        cancelable: true,
+      });
+      input.element.dispatchEvent(event);
+      await flush();
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(wrapper.emitted("update:open")).toBeUndefined();
+    }
+
+    // Open: Space still types, Enter is reserved for selecting the active option.
+    await input.trigger("keydown", { key: "@" });
+    await flush();
+
+    const spaceEvent = new KeyboardEvent("keydown", {
+      key: " ",
+      bubbles: true,
+      cancelable: true,
+    });
+    input.element.dispatchEvent(spaceEvent);
+    await flush();
+
+    expect(spaceEvent.defaultPrevented).toBe(false);
+  });
+
+  it("selects the active option with Enter while the popup is open", async () => {
+    const onSelect = vi.fn();
+    const wrapper = track(
+      mount(Suggestion, {
+        attachTo: document.body,
+        props: { items, onSelect },
+        slots: createSlot(),
+      }),
+    );
+
+    await wrapper.find(".trigger-input").trigger("keydown", { key: "@" });
+    await flush();
+
+    const enterEvent = new KeyboardEvent("keydown", {
+      key: "Enter",
+      bubbles: true,
+      cancelable: true,
+    });
+    // Cascader's option list still reads the legacy `which`, which jsdom leaves at 0.
+    Object.defineProperty(enterEvent, "which", { value: 13 });
+    wrapper.find(".trigger-input").element.dispatchEvent(enterEvent);
+    await flush();
+
+    expect(onSelect).toHaveBeenCalledWith(
+      "report",
+      expect.arrayContaining([expect.objectContaining({ value: "report" })]),
+    );
+  });
+
   it("keeps every option reachable inside the scrollable popup for long lists", async () => {
     const longItems: SuggestionItem[] = Array.from(
       { length: 30 },


### PR DESCRIPTION
[中文版模板 / Chinese template](./PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- close #171
- Same root cause as upstream ant-design/x#1873

### 💡 Background and Solution

**Problem**

Once a `Sender` is wrapped by `Suggestion`, you can no longer type a space, and Enter no longer inserts a newline. Every `Suggestion` demo reproduces it.

**Root cause**

The chain is `Suggestion` → `Cascader` → `BaseSelect` (`@v-c/select`).

1. `Suggestion` puts its children into `Cascader`'s default slot, and `@v-c/cascader` picks them up as `getRawInputElement`:

   ```js
   const rawInputElement = slots.default ? () => slots.default?.()[0] : void 0;
   ```

2. `@v-c/select`'s `SelectInput` treats that node as its own root and `cloneVNode`s BaseSelect's keyboard handler onto it:

   ```js
   const mergedProps = mergeVNodeProps(RootComponent.props || {}, domProps); // domProps contains onKeydown
   if (isVNode(RootComponent)) return cloneVNode(RootComponent, { ...mergedProps, ref: rootRef });
   ```

   So `<div class="antd-suggestion">` ends up carrying `BaseSelect.onInternalKeyDown`.

3. Every keydown from the Sender textarea bubbles into it:

   ```js
   const isEnterKey = key === KeyCodeStr.Enter;
   const isSpaceKey = key === KeyCodeStr.Space;   // " "
   if (isEnterKey || isSpaceKey) {
     const isCombobox = mode.value === "combobox";
     const isEditable = isCombobox || !!props.showSearch;
     if (isSpaceKey && !isEditable || isEnterKey && !isCombobox) event.preventDefault();
     if (!mergedOpen.value) triggerOpen(true);
   }
   ```

The Cascader used by `Suggestion` is neither a combobox nor `showSearch`, so `isEditable === false`:

- **Space** → `preventDefault()`, the character is never inserted, and the popup pops open. On macOS the double-space-to-period substitution kicks in because the browser default was cancelled.
- **Enter** → `preventDefault()` as well, so `submitType="shiftEnter"` can't insert a newline and the popup opens unexpectedly.

In short, wrapping `Sender` in `Suggestion` turns it from a standalone input into a Cascader trigger, subject to a keyboard model designed for a *non-editable* trigger.

**Solution**

BaseSelect's listener sits on the **Suggestion root**, so intercepting on the inner `-content` wrapper keeps events from ever reaching it (adding a handler on the same element would depend on listener ordering, which isn't reliable):

```tsx
const onContentKeyDown = (event: KeyboardEvent) => {
  if (mergedOpen.value && event.key === "Enter") {
    return;
  }
  event.stopPropagation();
};
```

Forwarding Enter while the popup is open is load-bearing: arrow keys are handled by `useActive` and mirrored into Cascader's `value`, but **Enter-to-select** needs the event to reach `BaseSelect` → `OptionList.onKeyDown` → `useKeyboard`'s `KeyCode.ENTER` branch in order to fire `onKeyboardSelect`. Swallowing Escape / arrows / Backspace is intended — Backspace previously triggered `prevColumn()` and closed the popup, which is wrong inside a textarea.

**Tests**

Two cases added:

- With the popup closed, Space/Enter are not `preventDefault`ed and do not open the popup; with the popup open, Space still types.
- With the popup open, Enter selects the active option.

Reverting `Suggestion.tsx` makes the first case fail as expected. Full suite: 465 passed (46 files). `vp check` and `pnpm type-check` both pass.

> Note for reviewers: jsdom does not derive `which` from `keyCode` (it stays 0) while `@v-c/cascader`'s `useKeyboard` reads `event.which`, so the Enter case needs `Object.defineProperty(enterEvent, "which", { value: 13 })`. Real browsers are unaffected.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix `Sender` not accepting Space or Enter when wrapped by `Suggestion`. |
| 🇨🇳 Chinese | 修复 `Sender` 被 `Suggestion` 包裹后无法输入空格与换行的问题。 |
