### PR TITLE
perf(x-markdown): bypass reactivity in streaming cache hot loop

### DIFF
--- a/packages/x-markdown/src/XMarkdown/composables/useStreaming.ts
+++ b/packages/x-markdown/src/XMarkdown/composables/useStreaming.ts
@@ -251,7 +251,13 @@ export function useStreaming(
   streaming: Ref<StreamingOption | undefined>,
   components?: Ref<Record<string, Component> | undefined>,
 ) {
-  const streamCache = ref<StreamCache>(getInitialCache());
+  // Deliberately a plain (non-reactive) object: processStreaming touches
+  // every field on every character, and going through a deep reactive proxy
+  // costs a get/set/trigger chain per field per char, which makes long
+  // single-line content such as base64 image data URIs (~300 KB) take tens
+  // of seconds on slower machines. The cache is internal only - callers see
+  // `processedContent` and `reset`.
+  let streamCache: StreamCache = getInitialCache();
   const processedContent = ref("");
 
   function handleIncompleteMarkdown(
@@ -283,18 +289,17 @@ export function useStreaming(
   function processStreaming(text: string, opts?: StreamingOption): void {
     if (!text) {
       processedContent.value = "";
-      streamCache.value = getInitialCache();
+      streamCache = getInitialCache();
       return;
     }
 
-    const expectedPrefix =
-      streamCache.value.completeMarkdown + streamCache.value.pending;
+    const expectedPrefix = streamCache.completeMarkdown + streamCache.pending;
 
     if (!text.startsWith(expectedPrefix)) {
-      streamCache.value = getInitialCache();
+      streamCache = getInitialCache();
     }
 
-    const cache = streamCache.value;
+    const cache = streamCache;
     const chunk = text.slice(cache.processedLength);
 
     if (!chunk) {
@@ -347,7 +352,7 @@ export function useStreaming(
   }
 
   function reset(): void {
-    streamCache.value = getInitialCache();
+    streamCache = getInitialCache();
     processedContent.value = "";
   }
 
@@ -359,7 +364,7 @@ export function useStreaming(
 
       if (!enableCache) {
         processedContent.value = newContent;
-        streamCache.value = {
+        streamCache = {
           pending: "",
           token: TokenType.Text,
           processedLength: newContent.length,


### PR DESCRIPTION
## 问题

CI test job 失败（[#176 引入的 perf 测试](https://github.com/antdv-next/x/actions/runs/31456624266)）：

```
AssertionError: expected 11801.803946 to be less than 10000
packages/x-markdown/src/XMarkdown/composables/__tests__/useStreaming.test.ts:125
```

`useStreaming` 的 perf 测试（300KB base64 图片 data URI，按 1000 字符/块流式）在 CI runner 上耗时 11.8s，超过 10s 断言阈值；本地 ~1s 能过，但测试对机器速度过于敏感。

## 根因

`streamCache` 是一个 deep-reactive 的 `ref`，而 `processStreaming` 的**每字符热循环**里所有字段都走 Vue reactive proxy：

- `cache.pending += char` / `cache.completeMarkdown += ...`
- `feedFenceState` 里 `cache.fence.lineFenceLen` 等每次自增
- `cache.token` / `cache.processedLength` 等

每个字符都是一条 get→set→trigger 全链路。CPU profiler 显示约 35% 的时间花在 reactivity 的 `set`/`get` 上（`reactivity.cjs.js`），30 万字符累积后在慢机器上就是 11.8s。

## 修复

`streamCache` 只被 `useStreaming` 内部使用（对外只暴露 `processedContent` 和 `reset`，见 `index.vue`），所以把它从 `ref<StreamCache>` 改成普通闭包对象 `let streamCache: StreamCache`，热循环变成纯 JS 对象操作，零 reactivity 开销。

## 验证

- 本地 300KB base64 流式：~1000ms → **~195ms**（约 5 倍提速），CI 预计降到 ~2.4s，远低于 10s 阈值
- 全部 14 个 `useStreaming` 单测通过
- `vue-tsc --project tsconfig.build.json --noEmit` 通过
- `vp check --fix`（pre-commit hook）通过
