### PR TITLE
chore: 优化 .gitignore 忽略本地 pnpm store (.pnpm-store)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Dependencies
+node_modules
+.pnpm-store/
+.worktrees
+
 # Logs
 logs
 *.log
@@ -7,13 +12,16 @@ yarn-error.log*
 pnpm-debug.log*
 lerna-debug.log*
 
-node_modules
-.DS_Store
-.worktrees
+# Environment & local files
+.env
+.env.*
+!.env.example
+*.local
+
+# Build outputs
 dist
 dist-ssr
 coverage
-*.local
 packages/x/es
 packages/x-markdown/plugins
 packages/x-markdown/themes
@@ -28,20 +36,19 @@ packages/x-markdown/themes
 *.sln
 *.sw?
 
+# Tooling caches
 *.tsbuildinfo
-
 .eslintcache
+__screenshots__/
 
 # Cypress
 /cypress/videos/
 /cypress/screenshots/
 
-# Vitest
-__screenshots__/
-
 # Vite
 *.timestamp-*-*.mjs
 
+# Auto-generated types & docs assets
 **/types/auto-imports.d.ts
 **/types/components.d.ts
 packages/docs/public/**/*.md
@@ -52,5 +59,10 @@ packages/docs/public/search.cn.json
 packages/docs/public/search.en.json
 packages/docs/src/assets/token-meta.json
 packages/docs/src/assets/token.json
+
+# Sync tooling
 .sync-upstream.local.json
 .sync-checklist-*.md
+
+# OS
+.DS_Store


### PR DESCRIPTION
[中文版模板 / Chinese template](./PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [x] ❓ Other (about what?) — 工程配置 / 仓库卫生 (repo hygiene)

### 🔗 Related Issues

> - 无关联 issue。

### 💡 Background and Solution

> - 项目根目录存在本地 pnpm store 目录 `.pnpm-store`（pnpm v10 本地 store），但 `.gitignore` 未将其忽略，存在误提交风险。
> - 对 `.gitignore` 按用途分组（依赖、日志、环境变量、构建产物、编辑器、工具缓存、自动生成文件等）重新组织，使规则更清晰、易于维护，并补齐常用的 `.env*` 规则。

### 📝 Change Log

> - 忽略本地 pnpm store 目录 `.pnpm-store/`，避免依赖缓存被误提交。
> - 重新组织 `.gitignore` 分组结构，并新增 `.env*` 环境变量文件忽略规则。

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Ignore local pnpm store directory `.pnpm-store/`; reorganize `.gitignore` sections and add `.env*` rules. |
| 🇨🇳 Chinese | 忽略本地 pnpm store 目录 `.pnpm-store/`；重新整理 `.gitignore` 分组并新增 `.env*` 规则。 |
