### PR TITLE
fix(suggestion): narrow the trigger keyboard guard to the keys BaseSelect breaks

### DIFF
--- a/packages/x/components/suggestion/Suggestion.tsx
+++ b/packages/x/components/suggestion/Suggestion.tsx
@@ -96,17 +96,22 @@ const XSuggestion = defineComponent({
     const innerOpen = ref(false);
     const mergedOpen = computed(() => props.open ?? innerOpen.value);
     const itemList = ref<SuggestionItem[]>([]);
+    /**
+     * What the last `onTrigger` asked for. A function `items` is usually an inline arrow,
+     * so it gets a new identity on every parent render — without this the watcher below
+     * would re-evaluate it with no info and drop the triggered list.
+     */
+    const triggerInfo = ref<any>();
+
+    const resolveItems = (source: SuggestionProps["items"], info?: any) => {
+      if (typeof source === "function") return source(info);
+      return Array.isArray(source) ? source : [];
+    };
 
     watch(
       () => props.items,
       nextItems => {
-        if (Array.isArray(nextItems)) {
-          itemList.value = nextItems;
-        } else if (typeof nextItems === "function") {
-          itemList.value = nextItems();
-        } else {
-          itemList.value = [];
-        }
+        itemList.value = resolveItems(nextItems, triggerInfo.value);
       },
       { immediate: true },
     );
@@ -130,8 +135,10 @@ const XSuggestion = defineComponent({
         return;
       }
 
+      triggerInfo.value = nextInfo;
+
       if (typeof props.items === "function") {
-        itemList.value = props.items(nextInfo);
+        itemList.value = resolveItems(props.items, nextInfo);
       }
 
       triggerOpen(true);
@@ -150,7 +157,7 @@ const XSuggestion = defineComponent({
       triggerOpen(false);
     };
 
-    const [activePath, onKeyDown] = useActive(
+    const [activePath, onKeyDown, shouldSelectOnEnter] = useActive(
       itemList as any,
       mergedOpen as any,
       isRtl as any,
@@ -166,17 +173,30 @@ const XSuggestion = defineComponent({
     /**
      * Cascader renders our children as its raw input element, so every keydown from the
      * children bubbles into BaseSelect's keyboard model. That model is built for a
-     * non-editable trigger: it calls `preventDefault()` on Space/Enter and opens the popup,
-     * which breaks typing inside an editable trigger such as Sender.
+     * non-editable trigger and breaks typing inside an editable one such as Sender:
      *
-     * Keep the events inside the content wrapper. Enter still needs to reach Cascader while
-     * the popup is open so the active option can be selected by keyboard.
+     * - Space is always `preventDefault()`ed, so no space can be typed;
+     * - Enter is always `preventDefault()`ed, even when there is nothing to select;
+     * - Backspace makes the option list step back a level or close the popup.
+     *
+     * Keep exactly those inside the content wrapper. Every other key — Escape, arrows,
+     * application shortcuts — must keep bubbling, otherwise the app around us stops
+     * receiving keyboard events while the trigger has focus.
      */
     const onContentKeyDown = (event: KeyboardEvent) => {
-      if (mergedOpen.value && event.key === "Enter") {
+      const { key } = event;
+
+      if (key === "Enter") {
+        // Forward it only when the popup owns this Enter, so the option list can select.
+        if (!shouldSelectOnEnter(event)) {
+          event.stopPropagation();
+        }
         return;
       }
-      event.stopPropagation();
+
+      if (key === " " || (key === "Backspace" && mergedOpen.value)) {
+        event.stopPropagation();
+      }
     };
 
     const domAttrs = computed(() => {

--- a/packages/x/components/suggestion/__tests__/index.test.tsx
+++ b/packages/x/components/suggestion/__tests__/index.test.tsx
@@ -1,10 +1,11 @@
 import { mount, VueWrapper } from "@vue/test-utils";
 import { ConfigProvider } from "antdv-next";
 import { afterEach, describe, expect, it, vi } from "vite-plus/test";
-import { nextTick } from "vue";
+import { nextTick, ref } from "vue";
 
 import type { SuggestionItem } from "../interface";
 
+import Sender from "../../sender";
 import Suggestion from "../index";
 
 const wrappers: VueWrapper[] = [];
@@ -52,6 +53,27 @@ function createSlot() {
       />
     ),
   };
+}
+
+function dispatchKey(
+  element: Element,
+  key: string,
+  init: KeyboardEventInit = {},
+) {
+  const { isComposing, ...rest } = init;
+  const event = new KeyboardEvent("keydown", {
+    key,
+    bubbles: true,
+    cancelable: true,
+    ...rest,
+  });
+  // Cascader's option list still reads the legacy `which`, which jsdom leaves at 0.
+  Object.defineProperty(event, "which", { value: key === "Enter" ? 13 : 0 });
+  if (isComposing) {
+    Object.defineProperty(event, "isComposing", { value: true });
+  }
+  element.dispatchEvent(event);
+  return event;
 }
 
 describe("Suggestion", () => {
@@ -372,13 +394,8 @@ describe("Suggestion", () => {
     const input = wrapper.find(".trigger-input");
 
     // Closed: neither key may be prevented nor may it open the popup.
-    for (const key of ["Space", "Enter"] as const) {
-      const event = new KeyboardEvent("keydown", {
-        key: key === "Space" ? " " : "Enter",
-        bubbles: true,
-        cancelable: true,
-      });
-      input.element.dispatchEvent(event);
+    for (const key of [" ", "Enter"]) {
+      const event = dispatchKey(input.element, key);
       await flush();
 
       expect(event.defaultPrevented).toBe(false);
@@ -389,12 +406,7 @@ describe("Suggestion", () => {
     await input.trigger("keydown", { key: "@" });
     await flush();
 
-    const spaceEvent = new KeyboardEvent("keydown", {
-      key: " ",
-      bubbles: true,
-      cancelable: true,
-    });
-    input.element.dispatchEvent(spaceEvent);
+    const spaceEvent = dispatchKey(input.element, " ");
     await flush();
 
     expect(spaceEvent.defaultPrevented).toBe(false);
@@ -413,20 +425,266 @@ describe("Suggestion", () => {
     await wrapper.find(".trigger-input").trigger("keydown", { key: "@" });
     await flush();
 
-    const enterEvent = new KeyboardEvent("keydown", {
-      key: "Enter",
-      bubbles: true,
-      cancelable: true,
-    });
-    // Cascader's option list still reads the legacy `which`, which jsdom leaves at 0.
-    Object.defineProperty(enterEvent, "which", { value: 13 });
-    wrapper.find(".trigger-input").element.dispatchEvent(enterEvent);
+    dispatchKey(wrapper.find(".trigger-input").element, "Enter");
     await flush();
 
     expect(onSelect).toHaveBeenCalledWith(
       "report",
       expect.arrayContaining([expect.objectContaining({ value: "report" })]),
     );
+  });
+
+  it("keeps unrelated keys bubbling to the app around it", async () => {
+    const onWindowKeyDown = vi.fn();
+    window.addEventListener("keydown", onWindowKeyDown);
+
+    try {
+      const wrapper = track(
+        mount(Suggestion, {
+          attachTo: document.body,
+          props: { items },
+          slots: createSlot(),
+        }),
+      );
+
+      const input = wrapper.find(".trigger-input");
+
+      // Closed: Escape belongs to the app, e.g. a Modal wrapping the Sender.
+      dispatchKey(input.element, "Escape");
+      await flush();
+
+      expect(onWindowKeyDown).toHaveBeenCalled();
+
+      await input.trigger("keydown", { key: "@" });
+      await flush();
+      onWindowKeyDown.mockClear();
+
+      // Open: application shortcuts still get through...
+      dispatchKey(input.element, "k", { metaKey: true });
+      await flush();
+
+      expect(onWindowKeyDown).toHaveBeenCalledTimes(1);
+
+      // ...but Escape stops at the popup it just closed.
+      onWindowKeyDown.mockClear();
+      dispatchKey(input.element, "Escape");
+      await flush();
+
+      expect(onWindowKeyDown).not.toHaveBeenCalled();
+      expect(wrapper.emitted("update:open")).toEqual([[true], [false]]);
+    } finally {
+      window.removeEventListener("keydown", onWindowKeyDown);
+    }
+  });
+
+  it("expands a parent item with Enter instead of swallowing the key", async () => {
+    const onSelect = vi.fn();
+    const wrapper = track(
+      mount(Suggestion, {
+        attachTo: document.body,
+        props: { items, onSelect },
+        slots: createSlot(),
+      }),
+    );
+
+    const input = wrapper.find(".trigger-input");
+    await input.trigger("keydown", { key: "@" });
+    await input.trigger("keydown", { key: "ArrowDown" });
+    await flush();
+
+    // "Check some knowledge" has children, so it cannot be selected yet.
+    dispatchKey(input.element, "Enter");
+    await flush();
+
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(
+      document.querySelector<HTMLElement>(
+        ".ant-cascader-menu-item-active:not(.ant-cascader-menu-item-expand)",
+      )?.textContent,
+    ).toContain("About Vue");
+
+    dispatchKey(input.element, "Enter");
+    await flush();
+
+    expect(onSelect).toHaveBeenCalledWith(
+      "vue",
+      expect.arrayContaining([expect.objectContaining({ value: "vue" })]),
+    );
+  });
+
+  it("leaves Enter to the trigger when there is nothing to select", async () => {
+    const onSelect = vi.fn();
+    const wrapper = track(
+      mount(Suggestion, {
+        attachTo: document.body,
+        props: { items: [], onSelect },
+        slots: createSlot(),
+      }),
+    );
+
+    const input = wrapper.find(".trigger-input");
+    await input.trigger("keydown", { key: "@" });
+    await flush();
+
+    const event = dispatchKey(input.element, "Enter");
+    await flush();
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("does not hijack Enter from an IME composition or a modifier combo", async () => {
+    const onSelect = vi.fn();
+    const wrapper = track(
+      mount(Suggestion, {
+        attachTo: document.body,
+        props: { items, onSelect },
+        slots: createSlot(),
+      }),
+    );
+
+    const input = wrapper.find(".trigger-input");
+    await input.trigger("keydown", { key: "@" });
+    await flush();
+
+    const composingEnter = dispatchKey(input.element, "Enter", {
+      isComposing: true,
+    });
+    const shiftEnter = dispatchKey(input.element, "Enter", { shiftKey: true });
+    await flush();
+
+    expect(composingEnter.defaultPrevented).toBe(false);
+    expect(shiftEnter.defaultPrevented).toBe(false);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("keeps the popup open while backspacing in the trigger", async () => {
+    const wrapper = track(
+      mount(Suggestion, {
+        attachTo: document.body,
+        props: { items },
+        slots: createSlot(),
+      }),
+    );
+
+    const input = wrapper.find(".trigger-input");
+    await input.trigger("keydown", { key: "@" });
+    await flush();
+
+    dispatchKey(input.element, "Backspace");
+    await flush();
+
+    expect(wrapper.emitted("update:open")).toEqual([[true]]);
+    expect(document.body.textContent).toContain("Write a report");
+  });
+
+  it("keeps a Sender trigger usable while the popup is open", async () => {
+    const submits: string[] = [];
+    const value = ref("");
+    const wrapper = track(
+      mount(
+        {
+          render() {
+            return (
+              <Suggestion
+                items={items}
+                onSelect={(nextValue: string) => {
+                  value.value = `[${nextValue}]:`;
+                }}
+              >
+                {({ onTrigger, onKeyDown }: any) => (
+                  <Sender
+                    value={value.value}
+                    onChange={(next: string) => {
+                      if (next.endsWith("/")) {
+                        onTrigger("/");
+                      } else if (!next) {
+                        onTrigger(false);
+                      }
+                      value.value = next;
+                    }}
+                    onKeyDown={onKeyDown}
+                    onSubmit={(content: string) => {
+                      submits.push(content);
+                      value.value = "";
+                    }}
+                  />
+                )}
+              </Suggestion>
+            );
+          },
+        },
+        { attachTo: document.body },
+      ),
+    );
+
+    const textarea = wrapper.find("textarea");
+    await textarea.setValue("/");
+    await flush();
+
+    expect(document.body.textContent).toContain("Write a report");
+
+    // The popup must not steal the space bar from the textarea (#171).
+    expect(dispatchKey(textarea.element, " ").defaultPrevented).toBe(false);
+
+    // Enter picks the active suggestion instead of sending the message.
+    dispatchKey(textarea.element, "Enter");
+    await flush();
+
+    expect(submits).toEqual([]);
+    expect(value.value).toBe("[report]:");
+
+    // With the popup closed, Enter sends again.
+    await textarea.setValue("hello");
+    await flush();
+    dispatchKey(textarea.element, "Enter");
+    await flush();
+
+    expect(submits).toEqual(["hello"]);
+  });
+
+  it("keeps the trigger info when items is an inline function", async () => {
+    const version = ref(0);
+    const wrapper = track(
+      mount(
+        {
+          render() {
+            return (
+              <Suggestion
+                items={(info?: string) => [
+                  { label: `Trigger by '${info}'`, value: String(info) },
+                ]}
+              >
+                {({ onTrigger, onKeyDown }: any) => (
+                  <input
+                    class="trigger-input"
+                    data-version={version.value}
+                    onKeydown={(event: KeyboardEvent) => {
+                      if (event.key === "@") {
+                        onTrigger("@");
+                      }
+                      return onKeyDown(event);
+                    }}
+                  />
+                )}
+              </Suggestion>
+            );
+          },
+        },
+        { attachTo: document.body },
+      ),
+    );
+
+    await wrapper.find(".trigger-input").trigger("keydown", { key: "@" });
+    await flush();
+
+    expect(document.body.textContent).toContain("Trigger by '@'");
+
+    // The inline `items` gets a new identity on every render of the parent.
+    version.value += 1;
+    await flush();
+
+    expect(document.body.textContent).toContain("Trigger by '@'");
   });
 
   it("keeps every option reachable inside the scrollable popup for long lists", async () => {

--- a/packages/x/components/suggestion/useActive.ts
+++ b/packages/x/components/suggestion/useActive.ts
@@ -8,6 +8,20 @@ interface ActiveItem {
 }
 
 /**
+ * An Enter pressed with a modifier or while an IME is composing belongs to the trigger
+ * (submit, newline, candidate confirmation), never to the suggestion list.
+ */
+function isPlainEnter(event: KeyboardEvent) {
+  return (
+    !event.isComposing &&
+    !event.shiftKey &&
+    !event.ctrlKey &&
+    !event.altKey &&
+    !event.metaKey
+  );
+}
+
+/**
  * Cascader does not expose active item control, so we use `value` to mirror focus path.
  */
 export default function useActive(
@@ -70,6 +84,31 @@ export default function useActive(
     }
   };
 
+  const getActiveItem = () => {
+    let currentItems = items.value;
+    let activeItem: ActiveItem | undefined;
+
+    for (const activePath of activePaths.value) {
+      activeItem = currentItems.find(item => item.value === activePath);
+      if (!activeItem) return undefined;
+      currentItems = activeItem.children || [];
+    }
+
+    return activeItem;
+  };
+
+  /**
+   * Whether this Enter belongs to the popup: it needs an open popup, a plain Enter and a
+   * leaf item to select. Anything else stays with the trigger, so the input can still
+   * submit, insert a newline or confirm an IME candidate.
+   */
+  const shouldSelectOnEnter = (event: KeyboardEvent) => {
+    if (!open.value || !isPlainEnter(event)) return false;
+
+    const activeItem = getActiveItem();
+    return !!activeItem && !activeItem.children?.length;
+  };
+
   const onKeyDown = (event: KeyboardEvent) => {
     if (!open.value) return;
 
@@ -102,12 +141,27 @@ export default function useActive(
         event.preventDefault();
         event.stopPropagation();
         break;
-      case "Enter":
+      case "Enter": {
+        if (!isPlainEnter(event)) break;
+
+        const activeItem = getActiveItem();
+        // Nothing to act on (empty list): let the trigger keep the key.
+        if (!activeItem) break;
+
         event.preventDefault();
+
+        // A parent item cannot be selected, so Enter expands it like ArrowRight does.
+        if (activeItem.children?.length) {
+          offsetNext();
+          event.stopPropagation();
+        }
+
         return false;
+      }
       case "Escape":
         onCancel();
         event.preventDefault();
+        event.stopPropagation();
         break;
       default:
         break;
@@ -124,5 +178,5 @@ export default function useActive(
     { immediate: true },
   );
 
-  return [activePaths, onKeyDown] as const;
+  return [activePaths, onKeyDown, shouldSelectOnEnter] as const;
 }


### PR DESCRIPTION
[中文版模板 / Chinese template](./PULL_REQUEST_TEMPLATE_CN.md)

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [x] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

- Follow-up to #171 / #177 — the minimal fix landed there, this PR covers the edge cases it left open. (Not a `close`: #171 is already closed.)
- Same root cause as upstream ant-design/x#1873

### 💡 Background and Solution

#177 fixed #171 by stopping every keydown on the `-content` wrapper except Enter while the popup is open. That does keep Space and Enter away from `BaseSelect`, but it is wider than the problem and leaves four holes. Each one below was reproduced with a real `mount` before writing the fix.

**1. The trigger became a keyboard black hole**

`stopPropagation()` sits below every ancestor listener, so nothing typed in the trigger reaches the host app. Measured: with a listener on `window`, an `Escape` and a `Cmd+K` typed in the trigger produced **0** calls.

That breaks, among others, Modal/Drawer Esc — `@v-c/portal`'s esc stack listens in the bubble phase on `window`:

```js
function onWindowKeyDown(e) {
  if (e.key === "Escape" && !e.isComposing) { /* ... close the top-most portal */ }
}
window.addEventListener("keydown", onWindowKeyDown);
```

A `Sender` inside a `Modal` is a common layout in chat UIs, and Esc stopped closing it.

**2. Enter was a dead key whenever the popup could not use it**

`useActive` returns `false` for Enter as long as the popup is open, which makes `Sender` skip submitting, and the wrapper then forwarded the event to `BaseSelect`, which `preventDefault()`s Enter unconditionally. When the option list has nothing to select, the key does nothing at all — no selection, no newline, no submit. Two reachable cases:

- the active item has `children` (the `basic` demo's *Explore a topic*) — measured `defaultPrevented: true`, `select` never fired;
- a function `items` filtered down to `[]` while the popup is still open.

**3. Enter from an IME composition, or with a modifier, selected a suggestion**

Measured with the popup open: an Enter carrying `isComposing: true` was forwarded, `preventDefault()`ed, and emitted `select("report")` — so confirming a Chinese candidate picks a suggestion instead. `Shift+Enter` behaved the same way, which also means a `submitType="shiftEnter"` user cannot send at all while the popup is open (`submits: []`, `selected: ["report"]`). `Sender` already guards on `isComposing` and on modifiers in `TextArea.tsx`; `Suggestion` did not.

**4. Unrelated: a function `items` lost its trigger info**

`items` is usually an inline arrow (see the `trigger` demo), so it gets a new identity on every parent render, the watcher re-evaluates it with no argument and the list is rebuilt as if nothing had triggered it — `Trigger by 'undefined'`. Since `Sender` re-renders the parent on every keystroke, this fires constantly in real usage.

**Solution**

Stop only what BaseSelect's non-editable keyboard model actually breaks, and let everything else bubble:

```tsx
const onContentKeyDown = (event: KeyboardEvent) => {
  const { key } = event;

  if (key === "Enter") {
    // Forward it only when the popup owns this Enter, so the option list can select.
    if (!shouldSelectOnEnter(event)) {
      event.stopPropagation();
    }
    return;
  }

  if (key === " " || (key === "Backspace" && mergedOpen.value)) {
    event.stopPropagation();
  }
};
```

Space and Backspace keep #177's behaviour (`onInternalKeyDown` always `preventDefault()`s Space; the option list turns Backspace into `prevColumn()` / close, which is wrong inside a textarea). Escape, arrows and application shortcuts now reach the app again.

Who owns an Enter is decided in one place, in `useActive`, and reused by the wrapper:

```ts
const shouldSelectOnEnter = (event: KeyboardEvent) => {
  if (!open.value || !isPlainEnter(event)) return false;

  const activeItem = getActiveItem();
  return !!activeItem && !activeItem.children?.length;
};
```

`useActive`'s own Enter branch follows the same rule: a modifier or IME Enter is left to the trigger, an Enter with nothing to select falls through (so `Sender` submits or inserts a newline), and an Enter on a parent item expands it like ArrowRight instead of doing nothing. Escape additionally calls `stopPropagation()` — consistent with the arrow branches — so the popup absorbs the first Esc and the Modal behind it survives.

Finally, `Suggestion` remembers the last `onTrigger` info and passes it back when a function `items` is re-evaluated.

**Tests**

15 → 22 cases. New: keys still bubble to `window` (with Esc layering), Enter expands a parent item, Enter falls back to the trigger on an empty list, IME and modifier Enter are not hijacked, Backspace does not close the popup, a function `items` keeps its trigger info, plus one **`Suggestion` + real `Sender`** integration case walking the original #171 flow — space types while the popup is open, Enter selects instead of sending, Enter sends again once it is closed.

Full suite: 472 passed (46 files). `vp check` and `type-check` both pass.

> Manual pass still worth doing on a real browser for IME behaviour (Chrome reports `key: "Process"`, Safari `key: "Enter"` + `isComposing`) and for the macOS double-space-to-period substitution mentioned in ant-design/x#1873.

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix `Suggestion` swallowing keyboard events that belong to the app around it, such as Esc closing a Modal, and fix Enter doing nothing when the highlighted item has children or the list is empty. Enter from an IME composition or with a modifier now stays with the trigger, and a function `items` no longer loses its trigger info. |
| 🇨🇳 Chinese | 修复 `Suggestion` 吞掉宿主应用按键的问题（如 Esc 无法关闭外层 Modal），以及高亮项含子项或列表为空时回车无响应的问题。输入法组合中或带修饰键的回车不再被建议列表接管，函数式 `items` 也不会再丢失触发信息。 |
