### PR TITLE
feat(x-markdown): add componentsProps API (#1993)

### DIFF
--- a/packages/x-markdown/README-zh_CN.md
+++ b/packages/x-markdown/README-zh_CN.md
@@ -105,19 +105,50 @@ import "@antdv-next/x-markdown/themes/light.css";
 
 ### Props
 
-| 属性                     | 说明                                 | 类型                        | 默认值          |
-| ------------------------ | ------------------------------------ | --------------------------- | --------------- |
-| content                  | 需要渲染的 Markdown 内容             | `string`                    | -               |
-| components               | 将 HTML 节点映射为自定义 Vue 组件    | `Record<string, Component>` | -               |
-| streaming                | 流式渲染行为配置                     | `StreamingOption`           | -               |
-| config                   | Marked 解析配置                      | `MarkedConfig`              | `{ gfm: true }` |
-| className                | 根容器的额外 CSS 类名                | `string`                    | -               |
-| style                    | 根容器的内联样式                     | `Record<string, string>`    | -               |
-| paragraphTag             | 段落使用的 HTML 标签                 | `string`                    | `'p'`           |
-| openLinksInNewTab        | 是否为所有链接添加 `target="_blank"` | `boolean`                   | `true`          |
-| protectCustomTagNewlines | 是否保留自定义标签内部的换行         | `boolean`                   | `true`          |
-| escapeRawHtml            | 是否将原始 HTML 转义为纯文本         | `boolean`                   | `false`         |
-| debug                    | 是否开启调试模式                     | `boolean`                   | `false`         |
+| 属性                     | 说明                                 | 类型                                      | 默认值          |
+| ------------------------ | ------------------------------------ | ----------------------------------------- | --------------- |
+| content                  | 需要渲染的 Markdown 内容             | `string`                                  | -               |
+| components               | 将 HTML 节点映射为自定义 Vue 组件    | `Record<string, Component>`               | -               |
+| componentsProps          | 按标签名向自定义组件传递额外 props   | `Record<string, Record<string, unknown>>` | -               |
+| streaming                | 流式渲染行为配置                     | `StreamingOption`                         | -               |
+| config                   | Marked 解析配置                      | `MarkedConfig`                            | `{ gfm: true }` |
+| className                | 根容器的额外 CSS 类名                | `string`                                  | -               |
+| style                    | 根容器的内联样式                     | `Record<string, string>`                  | -               |
+| paragraphTag             | 段落使用的 HTML 标签                 | `string`                                  | `'p'`           |
+| openLinksInNewTab        | 是否为所有链接添加 `target="_blank"` | `boolean`                                 | `true`          |
+| protectCustomTagNewlines | 是否保留自定义标签内部的换行         | `boolean`                                 | `true`          |
+| escapeRawHtml            | 是否将原始 HTML 转义为纯文本         | `boolean`                                 | `false`         |
+| debug                    | 是否开启调试模式                     | `boolean`                                 | `false`         |
+
+### 向自定义组件传递额外的 props
+
+自定义组件常常需要接收业务数据（如主题、回调函数等）。如果通过内联函数传递，每次渲染都会产生新的组件引用，导致子树被反复重建，在流式场景下会丢失内部状态并造成明显的性能损耗。使用 `componentsProps` 可以在保持组件引用稳定的同时传入额外的 props：
+
+```vue
+<script setup>
+import { computed, ref } from "vue";
+import { XMarkdown } from "@antdv-next/x-markdown";
+
+const theme = ref("dark");
+const components = { "custom-chart": CustomChart };
+// 保持引用稳定——传内联对象字面量会让渲染缓存每次失效并触发整棵树重新解析。
+const componentsProps = computed(() => ({
+  "custom-chart": { theme: theme.value, onSelect },
+}));
+</script>
+
+<template>
+  <XMarkdown :components="components" :componentsProps="componentsProps" />
+</template>
+```
+
+`componentsProps` 以标签名为 key，对应的 props 会与解析出的 HTML 属性合并后传给组件。合并规则：
+
+- 同名属性以 `componentsProps` 为准，例如 `componentsProps` 里的 `title` 会覆盖 HTML 上的 `title="..."`。
+- `class` / `className` 是例外，两侧会拼接合并，`componentsProps` 的类名在前（合并结果写入 `class`）。
+- 内部计算的 `streamStatus`、`domNode`、`children`（以及 `code` 组件的 `lang`、`block`）不可覆盖，写进 `componentsProps` 会被忽略。
+
+`componentsProps` 变化时组件只会正常更新 props，不会被重新挂载。但它和 `components` 一样参与渲染缓存，传内联对象字面量会让缓存每次失效并触发整棵树重新解析，所以请像上面那样用 `computed` 保持引用稳定。
 
 ### StreamingOption
 

--- a/packages/x-markdown/README.md
+++ b/packages/x-markdown/README.md
@@ -105,19 +105,51 @@ import "@antdv-next/x-markdown/themes/light.css";
 
 ### Props
 
-| Property                 | Description                             | Type                        | Default         |
-| ------------------------ | --------------------------------------- | --------------------------- | --------------- |
-| content                  | Markdown content to render              | `string`                    | -               |
-| components               | Map HTML nodes to custom Vue components | `Record<string, Component>` | -               |
-| streaming                | Streaming behavior config               | `StreamingOption`           | -               |
-| config                   | Marked parse config                     | `MarkedConfig`              | `{ gfm: true }` |
-| className                | Extra CSS class for root container      | `string`                    | -               |
-| style                    | Inline styles for root container        | `Record<string, string>`    | -               |
-| paragraphTag             | HTML tag for paragraphs                 | `string`                    | `'p'`           |
-| openLinksInNewTab        | Add `target="_blank"` to all links      | `boolean`                   | `true`          |
-| protectCustomTagNewlines | Preserve newlines inside custom tags    | `boolean`                   | `true`          |
-| escapeRawHtml            | Escape raw HTML as plain text           | `boolean`                   | `false`         |
-| debug                    | Enable debug mode                       | `boolean`                   | `false`         |
+| Property                 | Description                                         | Type                                      | Default         |
+| ------------------------ | --------------------------------------------------- | ----------------------------------------- | --------------- |
+| content                  | Markdown content to render                          | `string`                                  | -               |
+| components               | Map HTML nodes to custom Vue components             | `Record<string, Component>`               | -               |
+| componentsProps          | Extra props passed to custom components by tag name | `Record<string, Record<string, unknown>>` | -               |
+| streaming                | Streaming behavior config                           | `StreamingOption`                         | -               |
+| config                   | Marked parse config                                 | `MarkedConfig`                            | `{ gfm: true }` |
+| className                | Extra CSS class for root container                  | `string`                                  | -               |
+| style                    | Inline styles for root container                    | `Record<string, string>`                  | -               |
+| paragraphTag             | HTML tag for paragraphs                             | `string`                                  | `'p'`           |
+| openLinksInNewTab        | Add `target="_blank"` to all links                  | `boolean`                                 | `true`          |
+| protectCustomTagNewlines | Preserve newlines inside custom tags                | `boolean`                                 | `true`          |
+| escapeRawHtml            | Escape raw HTML as plain text                       | `boolean`                                 | `false`         |
+| debug                    | Enable debug mode                                   | `boolean`                                 | `false`         |
+
+### Passing extra props to custom components
+
+Custom components often need business data (theme, callbacks, etc.). Passing it via an inline wrapper function creates a new component on every render and forces the subtree to be re-created, losing internal state and hurting performance in streaming scenarios. Use `componentsProps` to pass extra props while keeping component references stable:
+
+```vue
+<script setup>
+import { computed, ref } from "vue";
+import { XMarkdown } from "@antdv-next/x-markdown";
+
+const theme = ref("dark");
+const components = { "custom-chart": CustomChart };
+// Keep the reference stable — an inline object literal invalidates the render
+// cache and re-parses the whole tree on every render.
+const componentsProps = computed(() => ({
+  "custom-chart": { theme: theme.value, onSelect },
+}));
+</script>
+
+<template>
+  <XMarkdown :components="components" :componentsProps="componentsProps" />
+</template>
+```
+
+`componentsProps` is keyed by tag name. Its props are merged with the parsed HTML attributes and passed to the component:
+
+- On conflict `componentsProps` wins — a `title` in `componentsProps` overrides `title="..."` from the HTML.
+- `class` / `className` is the exception: both sides are concatenated, with the `componentsProps` class name first (merged into `class`).
+- Internally computed props — `streamStatus`, `domNode`, `children` (plus `lang` and `block` for `code`) — cannot be overridden and are ignored if present in `componentsProps`.
+
+When `componentsProps` changes, the component receives a normal props update without being remounted. Like `components`, it takes part in the render cache, so passing an inline object literal invalidates that cache on every render and re-parses the whole tree — keep the reference stable (e.g. with `computed`) as shown above.
 
 ### StreamingOption
 

--- a/packages/x-markdown/src/XMarkdown/__tests__/componentsProps.test.ts
+++ b/packages/x-markdown/src/XMarkdown/__tests__/componentsProps.test.ts
@@ -1,0 +1,185 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import { defineComponent, h, onMounted } from "vue";
+
+import XMarkdown from "../index.vue";
+
+/** A component that snapshots the props it receives and renders a span. */
+function createCaptureComponent(captures: Array<Record<string, unknown>>) {
+  return defineComponent({
+    name: "CaptureWidget",
+    setup(_, { attrs, slots }) {
+      captures.push({ ...attrs });
+      return () => h("span", { class: "captured" }, slots.default?.());
+    },
+  });
+}
+
+describe("XMarkdown componentsProps", () => {
+  it("passes extra props to the matching custom component", () => {
+    const captures: Array<Record<string, unknown>> = [];
+    const Chart = createCaptureComponent(captures);
+    const onSelect = () => {};
+
+    const wrapper = mount(XMarkdown, {
+      props: {
+        content: '<custom-chart data-id="1"></custom-chart>',
+        components: { "custom-chart": Chart },
+        componentsProps: {
+          "custom-chart": { theme: "dark", onSelect },
+        },
+      },
+    });
+
+    const received = captures[0];
+    expect(received.theme).toBe("dark");
+    expect(received.onSelect).toBe(onSelect);
+    expect(received["data-id"]).toBe("1");
+    expect(received.streamStatus).toBe("done");
+  });
+
+  it("extra props take precedence over parsed HTML attributes", () => {
+    const captures: Array<Record<string, unknown>> = [];
+    const Widget = createCaptureComponent(captures);
+
+    mount(XMarkdown, {
+      props: {
+        content: '<my-widget title="from-html"></my-widget>',
+        components: { "my-widget": Widget },
+        componentsProps: { "my-widget": { title: "from-props" } },
+      },
+    });
+
+    expect(captures[0].title).toBe("from-props");
+  });
+
+  it("does not leak props into other custom components", () => {
+    const chartCaptures: Array<Record<string, unknown>> = [];
+    const otherCaptures: Array<Record<string, unknown>> = [];
+    const Chart = createCaptureComponent(chartCaptures);
+    const Other = createCaptureComponent(otherCaptures);
+
+    mount(XMarkdown, {
+      props: {
+        content: "<custom-chart></custom-chart><custom-other></custom-other>",
+        components: { "custom-chart": Chart, "custom-other": Other },
+        componentsProps: { "custom-chart": { theme: "dark" } },
+      },
+    });
+
+    expect(chartCaptures[0].theme).toBe("dark");
+    expect(otherCaptures[0].theme).toBeUndefined();
+  });
+
+  it("cannot shadow internally computed props", () => {
+    const widgetCaptures: Array<Record<string, unknown>> = [];
+    const codeCaptures: Array<Record<string, unknown>> = [];
+    const Widget = createCaptureComponent(widgetCaptures);
+    const Code = createCaptureComponent(codeCaptures);
+
+    mount(XMarkdown, {
+      props: {
+        content: "<my-widget>text</my-widget>",
+        components: { "my-widget": Widget },
+        streaming: { hasNextChunk: true },
+        componentsProps: {
+          "my-widget": {
+            streamStatus: "spoofed",
+            domNode: "spoofed",
+            children: "spoofed",
+          },
+        },
+      },
+    });
+
+    expect(widgetCaptures[0].streamStatus).toBe("done");
+    expect(widgetCaptures[0].domNode).not.toBe("spoofed");
+    expect(widgetCaptures[0].children).toBeUndefined();
+
+    mount(XMarkdown, {
+      props: {
+        content: "```js\nconst a = 1;\n```",
+        components: { code: Code },
+        componentsProps: {
+          code: { lang: "spoofed", block: "spoofed", streamStatus: "spoofed" },
+        },
+      },
+    });
+
+    expect(codeCaptures[0].lang).toBe("js");
+    expect(codeCaptures[0].block).toBe(true);
+    expect(codeCaptures[0].streamStatus).toBe("done");
+  });
+
+  it("does not inherit lang for code without language metadata", () => {
+    const langs: unknown[] = [];
+    const Code = defineComponent({
+      name: "CaptureCode",
+      setup(_, { attrs }) {
+        langs.push(attrs.lang);
+        return () => h("span", "code");
+      },
+    });
+
+    mount(XMarkdown, {
+      props: {
+        content: "`inline`\n\n```\nconst a = 1;\n```",
+        components: { code: Code },
+        componentsProps: { code: { lang: "spoofed" } },
+      },
+    });
+
+    expect(langs.length).toBe(2);
+    expect(langs.every(lang => lang === undefined)).toBe(true);
+  });
+
+  it("merges className from componentsProps with the parsed class attribute", () => {
+    const Widget = createCaptureComponent([]);
+
+    const wrapper = mount(XMarkdown, {
+      props: {
+        content: '<my-widget class="from-html"></my-widget>',
+        components: { "my-widget": Widget },
+        componentsProps: { "my-widget": { className: "from-props" } },
+      },
+    });
+
+    const classes = wrapper.find("span.captured").classes();
+    expect(classes).toContain("from-props");
+    expect(classes).toContain("from-html");
+    // componentsProps' class name comes first in the merged value.
+    expect(classes.indexOf("from-props")).toBeLessThan(
+      classes.indexOf("from-html"),
+    );
+  });
+
+  it("keeps the custom component mounted when componentsProps changes", async () => {
+    let mountCount = 0;
+    const Widget = defineComponent({
+      name: "StepWidget",
+      setup(_, { attrs }) {
+        onMounted(() => {
+          mountCount += 1;
+        });
+        return () => h("span", { "data-step": String(attrs.step) }, "widget");
+      },
+    });
+
+    const wrapper = mount(XMarkdown, {
+      props: {
+        content: "before <my-widget></my-widget> after",
+        components: { "my-widget": Widget },
+        componentsProps: { "my-widget": { step: 1 } },
+      },
+    });
+
+    expect(wrapper.find('[data-step="1"]').exists()).toBe(true);
+
+    await wrapper.setProps({
+      componentsProps: { "my-widget": { step: 2 } },
+    });
+
+    expect(wrapper.find('[data-step="2"]').exists()).toBe(true);
+    expect(mountCount).toBe(1);
+  });
+});

--- a/packages/x-markdown/src/XMarkdown/core/VueRenderer.ts
+++ b/packages/x-markdown/src/XMarkdown/core/VueRenderer.ts
@@ -63,6 +63,7 @@ export class VueRenderer {
   constructor(options: RendererOptions = {}) {
     this.options = {
       components: options.components ?? {},
+      componentsProps: options.componentsProps ?? {},
       enableAnimation: options.enableAnimation ?? true,
       animationConfig: {
         fadeDuration:
@@ -267,13 +268,27 @@ export class VueRenderer {
   ): ComponentProps {
     const props: ComponentProps = {};
 
-    cidRef.tagIndexes[tagName] = (cidRef.tagIndexes[tagName] ?? 0) + 1;
-    const instanceId = getTagInstanceId(tagName, cidRef.tagIndexes[tagName]);
-    props.streamStatus = unclosedTags.has(instanceId) ? "loading" : "done";
-
+    // Parsed HTML attributes first.
     Array.from(element.attributes).forEach(attr => {
       props[attr.name] = attr.value;
     });
+    const htmlClass = typeof props.class === "string" ? props.class : "";
+
+    // componentsProps are merged over the parsed HTML attributes, so extra
+    // business props can be passed without wrapping components inline.
+    const extraProps = this.options.componentsProps[tagName] ?? {};
+    Object.assign(props, extraProps);
+
+    // Internally computed props are applied last so that neither parsed HTML
+    // attributes nor componentsProps can shadow them.
+    cidRef.tagIndexes[tagName] = (cidRef.tagIndexes[tagName] ?? 0) + 1;
+    const instanceId = getTagInstanceId(tagName, cidRef.tagIndexes[tagName]);
+    props.streamStatus = unclosedTags.has(instanceId) ? "loading" : "done";
+    props.domNode = element as HTMLElement;
+
+    // Children are always passed through the default slot; a `children` key
+    // from HTML attributes or componentsProps must not leak into props.
+    delete props.children;
 
     if (tagName === "code") {
       const blockAttr = element.getAttribute("data-block");
@@ -292,8 +307,22 @@ export class VueRenderer {
       const lang = langFromData || langFromClass;
       if (lang) {
         props.lang = lang;
+      } else {
+        // No language metadata: inline code and unlabeled fences must not inherit
+        // a `lang` from the HTML attributes or componentsProps.
+        delete props.lang;
       }
     }
+
+    // class/className merging: componentsProps' class name comes first and both
+    // sides are concatenated. Vue convention: the merged value goes to `class`.
+    const extraClass =
+      extraProps.className ?? extraProps.classname ?? extraProps.class;
+    if (typeof extraClass === "string") {
+      props.class = [extraClass, htmlClass].filter(Boolean).join(" ").trim();
+    }
+    delete props.className;
+    delete props.classname;
 
     return props;
   }
@@ -311,6 +340,12 @@ export class VueRenderer {
       this.options.components = {
         ...this.options.components,
         ...options.components,
+      };
+    }
+    if (options.componentsProps) {
+      this.options.componentsProps = {
+        ...this.options.componentsProps,
+        ...options.componentsProps,
       };
     }
     if (options.enableAnimation !== undefined) {

--- a/packages/x-markdown/src/XMarkdown/index.vue
+++ b/packages/x-markdown/src/XMarkdown/index.vue
@@ -84,6 +84,7 @@ const parser = shallowRef(
 const renderer = shallowRef(
   new VueRenderer({
     components: mergedComponents.value,
+    componentsProps: props.componentsProps,
     enableAnimation: props.streaming?.enableAnimation ?? true,
     animationConfig: props.streaming?.animationConfig,
   }),
@@ -152,6 +153,17 @@ watch(
   newComponents => {
     renderer.value.setOptions({
       components: newComponents,
+    });
+    bumpOptionsVersion();
+  },
+  { deep: true },
+);
+
+watch(
+  () => props.componentsProps,
+  newComponentsProps => {
+    renderer.value.setOptions({
+      componentsProps: newComponentsProps,
     });
     bumpOptionsVersion();
   },

--- a/packages/x-markdown/src/XMarkdown/interface.ts
+++ b/packages/x-markdown/src/XMarkdown/interface.ts
@@ -49,6 +49,11 @@ export interface StreamingOption {
 export interface XMarkdownProps {
   content?: string;
   components?: Record<string, Component>;
+  /**
+   * 按标签名向 `components` 中的自定义组件传递额外的 props，使组件引用保持稳定，避免内联函数导致的重复挂载
+   * Extra props passed to custom components in `components` by tag name, keeping component references stable and avoiding remounts caused by inline functions
+   */
+  componentsProps?: Record<string, Record<string, unknown>>;
   streaming?: StreamingOption;
   config?: MarkedConfig;
   debug?: boolean;
@@ -102,6 +107,7 @@ export interface ParserOptions {
 
 export interface RendererOptions {
   components?: Record<string, Component>;
+  componentsProps?: Record<string, Record<string, unknown>>;
   enableAnimation?: boolean;
   animationConfig?: {
     fadeDuration?: number;


### PR DESCRIPTION
## 背景

同步上游 [ant-design/x#1993](https://github.com/ant-design/x/pull/1993)（commit `25aad7b`）到 Vue 3 版 `x-markdown`，修复 [antdv-next/x#186](https://github.com/antdv-next/x/issues/186)。

## 变更内容

为 `XMarkdown` 增加按标签名传递额外 props 的 `componentsProps` API：

- `componentsProps` 以标签名为 key，与解析出的 HTML 属性合并后传给 `components` 中的自定义组件，使组件引用保持稳定，避免内联函数导致的重复挂载。
- 合并顺序：HTML 属性 → `componentsProps` → 内部计算属性（`streamStatus`、`domNode`、`children`，以及 `code` 的 `block` / `lang`）最后应用，保证内部属性不可被覆盖。
- `class` / `className` 拼接合并，`componentsProps` 的类名在前（Vue 约定合并结果写入 `class`）。
- 无语言元数据的行内代码和未标注围栏不再继承 `lang`（`data-lang` 或 `language-*` class 均无时删除 `lang`）。
- `index.vue` 增加 `componentsProps` 的 watch，更新时组件正常更新 props 而不重新挂载。

## 文件变更

- `packages/x-markdown/src/XMarkdown/interface.ts` — 新增 `componentsProps` 类型
- `packages/x-markdown/src/XMarkdown/core/VueRenderer.ts` — props 合并逻辑
- `packages/x-markdown/src/XMarkdown/index.vue` — 传递 + watch
- `packages/x-markdown/src/XMarkdown/__tests__/componentsProps.test.ts` — 7 个单元测试
- `packages/x-markdown/README.md` / `README-zh_CN.md` — 文档

## 测试

- `vp test packages/x-markdown` 全部通过（21 tests）
- x-markdown `type-check` 通过

关联：上游 [ant-design/x#1993](https://github.com/ant-design/x/pull/1993) · Issue [antdv-next/x#186](https://github.com/antdv-next/x/issues/186)
