### PR TITLE
fix(x-markdown): avoid parsing currency as LaTeX (#1997)

### DIFF
--- a/packages/x-markdown/src/plugins/Latex/__tests__/index.test.ts
+++ b/packages/x-markdown/src/plugins/Latex/__tests__/index.test.ts
@@ -1,0 +1,79 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+
+import XMarkdown from "../../../XMarkdown/index.vue";
+import latexPlugin from "../index";
+
+function renderHtml(content: string) {
+  return mount(XMarkdown, {
+    props: {
+      content,
+      config: { extensions: latexPlugin() },
+    },
+  });
+}
+
+describe("LaTeX Plugin", () => {
+  it("should render inline LaTeX with $..$ syntax", () => {
+    const wrapper = renderHtml("$E=mc^2$");
+    expect(wrapper.find(".katex").exists()).toBe(true);
+  });
+
+  it.each([
+    "Downgrade Max ($100) to Pro ($20)",
+    "把 Max 5x（$100）降级到 Pro（$20）",
+    "The items cost $10, $20, and $30, respectively.",
+  ])("should not interpret currency amounts as LaTeX: %s", content => {
+    const wrapper = renderHtml(`**${content}**`);
+    expect(wrapper.find(".katex").exists()).toBe(false);
+    expect(wrapper.find("strong").text()).toBe(content);
+  });
+
+  // An escaped \$ inside a formula must not be treated as the closing delimiter.
+  it.each(["$\\text{\\$100}$", "$\\text{\\$x}$"])(
+    "should support escaped dollar signs inside formulas: %s",
+    content => {
+      const wrapper = renderHtml(content);
+      expect(wrapper.find(".katex").exists()).toBe(true);
+      expect(wrapper.find(".katex-error").exists()).toBe(false);
+    },
+  );
+
+  it("should still render formulas that start with a number", () => {
+    const wrapper = renderHtml("$2x + 1$");
+    expect(wrapper.find(".katex").exists()).toBe(true);
+  });
+
+  // Behavior change: `$ x $` used to render as math and no longer does. This is
+  // the Pandoc rule that makes currency detection possible at all.
+  it.each(["$ x$", "$x $", "$ x $", "$x$2"])(
+    "should follow single-dollar delimiter rules: %s",
+    content => {
+      const wrapper = renderHtml(content);
+      expect(wrapper.find(".katex").exists()).toBe(false);
+      expect(wrapper.text()).toContain(content);
+    },
+  );
+
+  // The spacing rules apply to `$...$` only; `$$...$$` is unambiguous and keeps
+  // rendering padded content exactly as before.
+  it.each(["$$ x $$", "$$ \\frac{a}{b} $$"])(
+    "should exempt $$ from the single-dollar spacing rules: %s",
+    content => {
+      const wrapper = renderHtml(content);
+      expect(wrapper.find(".katex").exists()).toBe(true);
+    },
+  );
+
+  // Known limitation: the Pandoc rules are positional, not semantic. Prose that
+  // happens to satisfy them is still parsed as math.
+  it("does not catch currency that satisfies the Pandoc rules", () => {
+    const wrapper = renderHtml("价格 $5和$X 的对比");
+    expect(wrapper.find(".katex").exists()).toBe(true);
+  });
+
+  it("should render block LaTeX with $$\n..\n$$ syntax", () => {
+    const wrapper = renderHtml("$$\nE=mc^2\n$$");
+    expect(wrapper.find(".katex").exists()).toBe(true);
+  });
+});

--- a/packages/x-markdown/src/plugins/Latex/index.ts
+++ b/packages/x-markdown/src/plugins/Latex/index.ts
@@ -3,8 +3,9 @@ import type { TokenizerAndRendererExtension } from "marked";
 import katex, { type KatexOptions } from "katex";
 import "katex/dist/katex.min.css";
 
+const inlineDollarRule = /^(\${1,2})((?:\\.|[^\\$]){1,10000}?)\1/;
 const inlineRuleNonStandard =
-  /^(?:\${1,2}([^$]{1,10000}?)\${1,2}|\\\(([\s\S]{1,10000}?)\\\)|\\\[((?:\\.|[^\\]){1,10000}?)\\\])/;
+  /^(?:\\\(([\s\S]{1,10000}?)\\\)|\\\[((?:\\.|[^\\]){1,10000}?)\\\])/;
 const blockRule =
   /^(\${1,2})\n([\s\S]{1,10000}?)\n\1(?:\s*(?:\n|$))|^\\\[((?:\\.|[^\\]){1,10000}?)\\\]/;
 
@@ -25,6 +26,15 @@ type ILevel = "inline" | "block";
 // fix katex not support align*: https://github.com/KaTeX/KaTeX/issues/1007
 function replaceAlign(text: string) {
   return text ? text.replace(/\{align\*\}/g, "{aligned}") : text;
+}
+
+// Follow Pandoc's single-dollar delimiter rules to avoid parsing currency as math.
+// Double-dollar ($$) delimiters are unambiguous and exempt from the spacing rules.
+function isValidInlineDollarMatch(match: RegExpMatchArray, src: string) {
+  const [, delimiter, text] = match;
+  if (delimiter === "$$") return true;
+
+  return !/^\s|\s$/.test(text) && !/^\d/.test(src.slice(match[0].length));
 }
 
 function createRenderer(options: KatexOptions, newlineAfter: boolean) {
@@ -50,11 +60,21 @@ function inlineKatex(renderer: Render, replaceAlignStart: boolean) {
       return indices.length > 0 ? Math.min(...indices) : undefined;
     },
     tokenizer(src: string) {
-      const match = src.match(inlineRuleNonStandard);
+      const dollarMatch = src.match(inlineDollarRule);
+      if (dollarMatch && !isValidInlineDollarMatch(dollarMatch, src)) return;
+
+      const nonStandardMatch = src.match(inlineRuleNonStandard);
+      const match = dollarMatch || nonStandardMatch;
       if (!match) return;
 
-      const rawText = (match[1] || match[2] || match[3] || "").trim();
-      const text = replaceAlignStart ? replaceAlign(rawText) : rawText;
+      const rawText =
+        dollarMatch?.[2] ||
+        nonStandardMatch?.[1] ||
+        nonStandardMatch?.[2] ||
+        "";
+      const text = replaceAlignStart
+        ? replaceAlign(rawText.trim())
+        : rawText.trim();
 
       return {
         type: "inlineKatex",


### PR DESCRIPTION
## 背景

同步上游 [ant-design/x#1997](https://github.com/ant-design/x/pull/1997)（commit `7470e60`）到 Vue 3 版 `x-markdown`，修复 [antdv-next/x#186](https://github.com/antdv-next/x/issues/186)。

## 变更内容

修复 `Latex` 插件把货币金额误解析为 LaTeX 公式的问题：

- 单美元公式遵循 Pandoc 定界符规则：`$...$` 内容首尾不能有空白，且闭合 `$` 后紧跟数字时拒绝解析，避免 `($100)`、`$10, $20` 等金额被识别为公式。
- 双美元 `$$...$$` 不受空白规则限制，行为保持不变。
- 允许公式内的反斜杠转义字符（`\$`），转义美元不再被当作闭合定界符。
- 保留 `\(...\)` / `\[...\]` 语法、数字开头公式等原有行为。

## 文件变更

- `packages/x-markdown/src/plugins/Latex/index.ts` — 定界符规则
- `packages/x-markdown/src/plugins/Latex/__tests__/index.test.ts` — 金额、CJK、边界、转义场景回归测试（15 tests）

## 测试

- `vp test packages/x-markdown` 全部通过（29 tests）
- x-markdown `type-check` 通过

关联：上游 [ant-design/x#1997](https://github.com/ant-design/x/pull/1997) · Issue [antdv-next/x#186](https://github.com/antdv-next/x/issues/186)
