### PR TITLE
fix(x-markdown): avoid extra re-render in AnimationText (#1998)

### DIFF
--- a/packages/x-markdown/src/XMarkdown/components/AnimationText.vue
+++ b/packages/x-markdown/src/XMarkdown/components/AnimationText.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { computed } from "vue";
 
 interface Props {
   text: string;
@@ -12,29 +12,32 @@ const props = withDefaults(defineProps<Props>(), {
   easing: "ease-in-out",
 });
 
-const chunks = ref<string[]>([]);
-const previousText = ref("");
+// Render-phase computation: chunks are derived synchronously while the
+// component renders (no watch/state round-trip), so streaming text updates
+// never trigger an extra reactive update or repeated animation. Mirrors
+// ant-design/x#1998 ("use useRef render-phase computation to eliminate extra
+// re-render in AnimationText").
+let previousText = "";
+let cachedChunks: string[] = [];
 
-function updateChunks(nextText: string) {
-  if (nextText === previousText.value) return;
+const chunks = computed(() => {
+  const text = props.text;
 
-  const isAppend = Boolean(
-    previousText.value && nextText.startsWith(previousText.value),
-  );
-  if (!isAppend) {
-    chunks.value = [nextText];
-    previousText.value = nextText;
-    return;
+  if (text === previousText) return cachedChunks;
+
+  let next: string[];
+  if (!(previousText && text.startsWith(previousText))) {
+    // Not an append: replace everything.
+    next = [text];
+  } else {
+    const delta = text.slice(previousText.length);
+    next = delta ? [...cachedChunks, delta] : cachedChunks;
   }
 
-  const delta = nextText.slice(previousText.value.length);
-  if (!delta) return;
-
-  chunks.value = [...chunks.value, delta];
-  previousText.value = nextText;
-}
-
-watch(() => props.text, updateChunks, { immediate: true });
+  previousText = text;
+  cachedChunks = next;
+  return next;
+});
 
 const animationStyle = computed(() => ({
   animation: `x-markdown-fade-in ${props.fadeDuration}ms ${props.easing} forwards`,

--- a/packages/x-markdown/src/XMarkdown/components/__tests__/AnimationText.test.ts
+++ b/packages/x-markdown/src/XMarkdown/components/__tests__/AnimationText.test.ts
@@ -1,0 +1,62 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+
+import AnimationText from "../AnimationText.vue";
+
+describe("AnimationText", () => {
+  it("renders the initial text as a single animated chunk", () => {
+    const wrapper = mount(AnimationText, { props: { text: "Hello" } });
+    expect(wrapper.findAll("span").map(s => s.element.textContent)).toEqual([
+      "Hello",
+    ]);
+  });
+
+  it("appends streaming deltas as separate chunks", async () => {
+    const wrapper = mount(AnimationText, { props: { text: "Hello" } });
+    await wrapper.setProps({ text: "Hello world" });
+    expect(wrapper.findAll("span").map(s => s.element.textContent)).toEqual([
+      "Hello",
+      " world",
+    ]);
+  });
+
+  it("supports continuous streaming appends", async () => {
+    const wrapper = mount(AnimationText, { props: { text: "Hello" } });
+    await wrapper.setProps({ text: "Hello world" });
+    await wrapper.setProps({ text: "Hello world foo" });
+    expect(wrapper.findAll("span").map(s => s.element.textContent)).toEqual([
+      "Hello",
+      " world",
+      " foo",
+    ]);
+  });
+
+  it("replaces all chunks when the new text is not an append", async () => {
+    const wrapper = mount(AnimationText, { props: { text: "Hello" } });
+    await wrapper.setProps({ text: "World" });
+    expect(wrapper.findAll("span").map(s => s.element.textContent)).toEqual([
+      "World",
+    ]);
+  });
+
+  it("keeps the previous chunks when the text does not change", async () => {
+    const wrapper = mount(AnimationText, { props: { text: "Hello" } });
+    await wrapper.setProps({ text: "Hello" });
+    expect(wrapper.findAll("span").map(s => s.element.textContent)).toEqual([
+      "Hello",
+    ]);
+  });
+
+  it("keeps animation keys stable across appends (no remount)", async () => {
+    const wrapper = mount(AnimationText, { props: { text: "Hello" } });
+    const firstSpan = wrapper.find("span").element;
+    await wrapper.setProps({ text: "Hello world" });
+    expect(wrapper.findAll("span").map(s => s.element.textContent)).toEqual([
+      "Hello",
+      " world",
+    ]);
+    // The first chunk keeps the same DOM node, so its v-for key stayed stable
+    // and no chunk was re-created during the append.
+    expect(wrapper.find("span").element).toBe(firstSpan);
+  });
+});


### PR DESCRIPTION
## 背景

同步上游 [ant-design/x#1998](https://github.com/ant-design/x/pull/1998)（commit `b529d8e`）到 Vue 3 版 `x-markdown`，修复 [antdv-next/x#186](https://github.com/antdv-next/x/issues/186)。

## 变更内容

优化 `AnimationText` 的流式增量分块，消除额外响应式更新和重复动画：

- 将 `watch` + 状态回写改为**渲染阶段计算**（render-phase computation）：chunks 在渲染时同步派生，不再经过 watch/state 往返，流式文本更新不会触发额外一次响应式更新。
- 行为保持不变：追加文本（append）追加新 chunk、非追加更新（replace）整体替换、空增量保留原 chunks。
- 追加场景下 v-for 的 key 保持稳定，chunk 不重建、不重复播放动画。

## 文件变更

- `packages/x-markdown/src/XMarkdown/components/AnimationText.vue` — 渲染阶段计算
- `packages/x-markdown/src/XMarkdown/components/__tests__/AnimationText.test.ts` — 流式更新、非追加更新、key 稳定性测试（6 tests）

## 测试

- `vp test packages/x-markdown` 全部通过（20 tests）
- x-markdown `type-check` 通过

关联：上游 [ant-design/x#1998](https://github.com/ant-design/x/pull/1998) · Issue [antdv-next/x#186](https://github.com/antdv-next/x/issues/186)
