### PR TITLE
chore: advance upstream sync cursor to 2.9.0

### DIFF
--- a/.sync-upstream.json
+++ b/.sync-upstream.json
@@ -43,11 +43,11 @@
           "description": "Ant Design X Skill -> Antdv X Skill"
         }
       ],
-      "last_synced_commit": "2c3146a5c9148cff86c49979f3293750ece051a9",
-      "last_synced_commit_short": "2c3146a",
-      "last_synced_at": "2026-08-04T17:02:01Z",
+      "last_synced_commit": "25aad7b9c13abeb165466d53b375d0f2ffe81fa0",
+      "last_synced_commit_short": "25aad7b9",
+      "last_synced_at": "2026-08-19T02:39:21Z",
       "last_synced_tag": "2.9.0",
-      "sync_count": 1
+      "sync_count": 2
     }
   ]
 }


### PR DESCRIPTION
Advance the ant-design/x sync cursor to 25aad7b9 after completing issue #186.

- ant-design/x#1993 was merged as downstream PR #187
- ant-design/x#1997 was merged as downstream PR #188
- ant-design/x#1998 was evaluated as not applicable for Vue and downstream PR #189 was closed
- x-markdown tests and type-check passed