### PR TITLE
fix(x-markdown): correct Latex plugin test import path

### DIFF
--- a/packages/x-markdown/src/plugins/Latex/__tests__/index.test.ts
+++ b/packages/x-markdown/src/plugins/Latex/__tests__/index.test.ts
@@ -1,7 +1,7 @@
 import { mount } from "@vue/test-utils";
 import { describe, expect, it } from "vitest";
 
-import XMarkdown from "../../../XMarkdown/index.vue";
+import { XMarkdown } from "../../../index";
 import latexPlugin from "../index";
 
 function renderHtml(content: string) {


### PR DESCRIPTION
<!--
First of all, thank you for your contribution! 😄
For requesting to pull a new feature or bugfix, please send it from a feature/bugfix branch based on the `main` branch.
Before submitting your pull request, please make sure the checklist below is filled out.
Your pull requests will be merged after one of the collaborators approves.
Thank you!
-->

### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [x] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

> - None

### 💡 Background and Solution

> - The Latex plugin test previously imported `XMarkdown/index.vue` directly via a relative internal path.
> - Change the import to use the package's public index entry (`../../../index`) so the test exercises the public API surface.

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Fix the Latex plugin test to import XMarkdown from the package entry instead of an internal component file. |
| 🇨🇳 Chinese | 修复 Latex 插件测试：改为从包入口导入 XMarkdown，而非内部组件文件。 |