### PR TITLE
fix(x-markdown): exclude tests from build and fix dts type errors

### DIFF
--- a/packages/x-markdown/vite.build.config.ts
+++ b/packages/x-markdown/vite.build.config.ts
@@ -10,6 +10,10 @@ const PLUGINS_DIR = "plugins";
 
 const dtsBaseOptions = {
   tsconfigPath: "./tsconfig.build.json",
+  // unplugin-dts passes `include`/`exclude` to @rollup/pluginutils v5,
+  // where "!" prefixes inside `include` are treated as literal globs and
+  // never negate, so all exclusions must live in `exclude`.
+  exclude: ["**/__tests__/**"],
 };
 
 const buildBaseOptions = {
@@ -19,7 +23,7 @@ const buildBaseOptions = {
 };
 
 const entries = Object.fromEntries(
-  globSync(["./src/**/*.ts", "!./src/plugins/**"])
+  globSync(["./src/**/*.ts", "!./src/plugins/**", "!./src/**/__tests__/**"])
     .sort()
     .map(file => [
       `./${file}`.replace("./src/", "").replace(/\.ts$/, ""),
@@ -70,12 +74,9 @@ export default defineConfig(({ mode }) => {
       dts({
         ...dtsBaseOptions,
         entryRoot: "src",
-        include: [
-          "src/**/*.ts",
-          "!src/plugins/**",
-          "src/**/*.d.ts",
-          "src/**/*.vue",
-        ],
+        include: ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.vue"],
+        // Plugins are built separately (mode: "plugins") into `plugins/`.
+        exclude: ["src/plugins/**", ...dtsBaseOptions.exclude],
         outDirs: DIST_DIR,
         processor: "vue",
       }),


### PR DESCRIPTION
## Summary

Fixes the `x-markdown` build failing with `TS2307: Cannot find module './*.vue'` errors (and stops shipping test files / the entire vitest + @vue/test-utils bundle in the published `dist`).

## Root cause

Two over-broad globs in `packages/x-markdown/vite.build.config.ts`:

1. **dts `include` matched test files.** In `mode: "plugins"`, `include: ["src/plugins/**/*.ts"]` also matched `src/plugins/Latex/__tests__/index.test.ts`. That test imports `XMarkdown` from `"../../../index"`, which pulls the whole non-plugin `src/` graph into the plugins-mode TypeScript program. Because `src/env.d.ts` (the `*.vue` module declaration) is filtered out of the plugins program, every `.vue` import in the main graph failed to resolve → the reported `TS2307` errors.

2. **`src/**/*.ts` globs bundled test files into the published output.** Both the default lib `entries` and the dts `include` matched `src/**/__tests__/**`, so `dist`/`plugins` contained `*.test.js`, `*.test.d.ts`, and the whole vitest/chai/@vue/test-utils dependency tree.

Notably, `@rollup/pluginutils@5.3.0` (used by `unplugin-dts`) treats `!` prefixes inside the `include` array as *literal globs* and never negates them — only the `exclude` option is honored. So exclusions were added via `exclude`.

## Changes

- Add `exclude: ["**/__tests__/**"]` to the shared `dtsBaseOptions`.
- Exclude `!./src/**/__tests__/**` from the default lib `entries` glob.
- For the default dts build, move plugin exclusion from the ineffective `!src/plugins/**` include negation into `exclude: ["src/plugins/**", ...]`.

## Result

- `vp build` (both default and `--mode plugins`) completes with no TS errors.
- `dist` no longer contains `*.test.*` files or vitest/chai/@vue/test-utils bundles (188K vs shipping hundreds of KB of test tooling).
- `plugins/` no longer emits `__tests__/index.test.d.ts`.
- `vue-tsc --project tsconfig.build.json --noEmit` (the `type-check` script) still passes.
- Full test suite still green: 48 files / 494 tests.
