### PR TITLE
chore(thought-chain): strictly align styles with oss/x

### DIFF
--- a/packages/x/components/thought-chain/style/index.ts
+++ b/packages/x/components/thought-chain/style/index.ts
@@ -10,10 +10,100 @@ import { genStyleHooks } from "../../theme/genStyleUtils";
 import genItemStyle from "./item";
 import genThoughtChainStyle from "./thought-chain";
 
+export interface ComponentToken {
+  /**
+   * @desc 实心的 ThoughtChain.Item 背景色
+   * @descEN ThoughtChain.Item `solid`'s background color
+   */
+  itemSolidBg: string;
+  /**
+   * @desc 实心的 ThoughtChain.Item 悬浮态背景色
+   * @descEN ThoughtChain.Item `solid`'s hover background color
+   */
+  itemSolidHoverBg: string;
+  /**
+   * @desc 边框模式的 ThoughtChain.Item 背景色
+   * @descEN ThoughtChain.Item `outlined`'s background color
+   */
+  itemOutlinedBg: string;
+  /**
+   * @desc 边框模式的 ThoughtChain.Item 悬浮态背景色
+   * @descEN ThoughtChain.Item `outlined`'s hover background color
+   */
+  itemOutlinedHoverBg: string;
+  /**
+   * @desc ThoughtChain.Item 圆角
+   * @descEN ThoughtChain.Item's border radius
+   */
+  itemBorderRadius: number;
+  /**
+   * @desc 图标容器尺寸
+   * @descEN ThoughtChain.Item `outlined`'s hover background color
+   */
+  iconSize: number;
+  /**
+   * @desc 思维链节点描述文字的动画颜色
+   * @descEN ThoughtChain node description text animation color
+   */
+  itemMotionDescription: string;
+  /**
+   * @desc 默认打字动画颜色
+   * @descEN Default typing animation color
+   */
+  colorTextBlinkDefault: string;
+  /**
+   * @desc 打字动画颜色
+   * @descEN Typing animation color
+   */
+  colorTextBlink: string;
+  /**
+   * @desc 错误状态描述文字颜色
+   * @descEN Error state description text color
+   */
+  colorErrorTextDescription: string;
+  /**
+   * @desc 错误状态禁用文字颜色
+   * @descEN Error state disabled text color
+   */
+  colorErrorTextDisabled: string;
+  /**
+   * @desc 错误状态禁用描述文字颜色
+   * @descEN Error state disabled description text color
+   */
+  colorErrorTextDescriptionDisabled: string;
+  /**
+   * @desc 错误状态禁用背景色
+   * @descEN Error state disabled background color
+   */
+  colorErrorBgDisabled: string;
+  /**
+   * @desc 禁用描述文字颜色
+   * @descEN Disabled description text color
+   */
+  colorDescriptionDisabled: string;
+  /**
+   * @desc 禁用标题文字颜色
+   * @descEN Disabled title text color
+   */
+  colorTitleDisabled: string;
+  /**
+   * @desc 成功状态禁用颜色
+   * @descEN Success state disabled color
+   */
+  colorSuccessDisabled: string;
+  /**
+   * @desc 主要状态禁用颜色
+   * @descEN Primary state disabled color
+   */
+  colorPrimaryDisabled: string;
+}
+
 export const prepareComponentToken: GetDefaultToken<"ThoughtChain"> = token => {
   const itemMotionDescription = new FastColor(token.colorTextDescription)
     .setA(0.25)
     .toRgbString();
+  const colorTextBlinkDefault = token.colorTextDescription;
+  const colorTextBlink = token.colorTextBase;
   const colorErrorTextDescription = new FastColor(token.colorErrorText)
     .setA(0.45)
     .toRgbString();
@@ -35,53 +125,42 @@ export const prepareComponentToken: GetDefaultToken<"ThoughtChain"> = token => {
   const colorErrorBgDisabled = new FastColor(token.colorErrorBg)
     .setA(0.25)
     .toRgbString();
+  const itemOutlinedHoverBg = itemSolidHoverBg;
   const colorSuccessDisabled = new FastColor(token.colorSuccess)
     .setA(0.45)
     .toRgbString();
   const colorPrimaryDisabled = new FastColor(token.colorPrimary)
     .setA(0.45)
     .toRgbString();
-
   return {
-    colorTextBlink: token.colorTextBase,
-    colorTextBlinkDefault: token.colorTextDescription,
+    colorDescriptionDisabled,
+    colorPrimaryDisabled,
+    colorSuccessDisabled,
+    colorTitleDisabled,
+    colorErrorTextDisabled,
+    colorErrorBgDisabled,
+    colorErrorTextDescriptionDisabled,
+    itemMotionDescription,
+    colorTextBlinkDefault,
+    colorTextBlink,
     itemSolidBg: token.colorFillTertiary,
     itemSolidHoverBg,
     itemOutlinedBg: token.colorBgContainer,
-    itemOutlinedHoverBg: itemSolidHoverBg,
+    itemOutlinedHoverBg,
     itemBorderRadius: token.borderRadius,
     iconSize: token.fontSize,
-    itemMotionDescription,
+    titleFontSize: token.fontSize,
+    descriptionFontSize: token.fontSize,
+    nodePadding: token.paddingSM,
+    titleFontWeight: 500,
+    borderColor: token.colorBorder,
+    borderWidth: token.lineWidth,
+    connectorColor: token.colorFillContent,
+    connectorWidth: token.lineWidth,
     colorErrorTextDescription,
-    colorErrorTextDisabled,
-    colorErrorTextDescriptionDisabled,
-    colorErrorBgDisabled,
-    colorDescriptionDisabled,
-    colorTitleDisabled,
-    colorSuccessDisabled,
-    colorPrimaryDisabled,
+    hoverTransitionDuration: `${token.motionDurationMid} ${token.motionEaseInOut}`,
   };
 };
-
-export interface ComponentToken {
-  colorTextBlink: string;
-  colorTextBlinkDefault: string;
-  itemSolidBg: string;
-  itemSolidHoverBg: string;
-  itemOutlinedBg: string;
-  itemOutlinedHoverBg: string;
-  itemBorderRadius: number;
-  iconSize: number;
-  itemMotionDescription: string;
-  colorErrorTextDescription: string;
-  colorErrorTextDisabled: string;
-  colorErrorTextDescriptionDisabled: string;
-  colorErrorBgDisabled: string;
-  colorDescriptionDisabled: string;
-  colorTitleDisabled: string;
-  colorSuccessDisabled: string;
-  colorPrimaryDisabled: string;
-}
 
 export default genStyleHooks<"ThoughtChain">(
   "ThoughtChain",
@@ -89,9 +168,9 @@ export default genStyleHooks<"ThoughtChain">(
     const chainToken = mergeToken<ThoughtChainToken>(token, {});
     return [
       genThoughtChainStyle(chainToken),
-      genItemStyle(chainToken as any),
+      genItemStyle(chainToken),
       genCollapseMotion(chainToken),
-      blinkMotion(chainToken as any, `${chainToken.componentCls}-motion-blink`),
+      blinkMotion(chainToken, `${chainToken.componentCls}-motion-blink`),
     ];
   },
   prepareComponentToken,

--- a/packages/x/components/thought-chain/style/item.ts
+++ b/packages/x/components/thought-chain/style/item.ts
@@ -21,7 +21,7 @@ const genItemStyle: GenerateStyle<ThoughtChainItemToken> = token => {
       boxSizing: "border-box",
       lineHeight: token.lineHeight,
       borderRadius: token.borderRadius,
-      alignItems: "baseline",
+      alignItems: "center",
 
       [`&${itemCls}-rtl`]: {
         direction: "rtl",

--- a/packages/x/components/thought-chain/style/item.ts
+++ b/packages/x/components/thought-chain/style/item.ts
@@ -1,13 +1,15 @@
+import type { CSSObject } from "@antdv-next/cssinjs";
+
 import { unit } from "@antdv-next/cssinjs";
 
-import type { FullToken, GenerateStyle } from "../../theme/interface";
+import type { GenerateStyle } from "../../theme/interface";
+import type { ThoughtChainToken } from "./thought-chain";
 
-export interface ThoughtChainItemToken extends FullToken<"ThoughtChain"> {}
-
-const genItemStyle: GenerateStyle<ThoughtChainItemToken> = token => {
+const genThoughtChainItemStyle: GenerateStyle<ThoughtChainToken, CSSObject> = (
+  token: ThoughtChainToken,
+): CSSObject => {
   const { componentCls, calc } = token;
   const itemCls = `${componentCls}-item`;
-
   return {
     [itemCls]: {
       display: "inline-flex",
@@ -20,91 +22,71 @@ const genItemStyle: GenerateStyle<ThoughtChainItemToken> = token => {
       paddingInline: token.paddingSM,
       boxSizing: "border-box",
       lineHeight: token.lineHeight,
-      borderRadius: token.borderRadius,
+      borderRadius: token.itemBorderRadius,
       alignItems: "baseline",
-
       [`&${itemCls}-rtl`]: {
         direction: "rtl",
       },
-
       [`&${itemCls}-click:not(${itemCls}-disabled)`]: {
         cursor: "pointer",
         transition: `all ${token.motionDurationMid} ${token.motionEaseInOut}`,
       },
-
       [`&${itemCls}-disabled`]: {
         cursor: "not-allowed",
       },
-
-      // Blink effect on description
       [`${componentCls}-motion-blink`]: {
         [`${itemCls}-description`]: {
-          color: (token as any).itemMotionDescription,
+          color: token.itemMotionDescription,
         },
       },
-
-      // Status colors inside Item
       [`${componentCls}-status-success`]: {
         color: token.colorSuccess,
       },
-
       [`${componentCls}-status-loading`]: {
         color: token.colorPrimary,
       },
-
-      // Title
       [`${itemCls}-title`]: {
         display: "inline-block",
         whiteSpace: "nowrap",
       },
-
       [`${itemCls}-title-with-description`]: {
         marginInlineEnd: token.marginXS,
       },
-
-      // Description
       [`${itemCls}-description`]: {
         color: token.colorTextDescription,
         display: "inline-block",
         whiteSpace: "break-spaces",
       },
-
-      // Disabled (non-error)
       [`&${itemCls}-disabled:not(${itemCls}-error)`]: {
-        color: (token as any).colorTitleDisabled,
+        color: token.colorTitleDisabled,
         [`${itemCls}-description`]: {
-          color: (token as any).colorDescriptionDisabled,
+          color: token.colorDescriptionDisabled,
         },
         [`${componentCls}-status-success`]: {
-          color: (token as any).colorSuccessDisabled,
+          color: token.colorSuccessDisabled,
         },
         [`${componentCls}-status-loading`]: {
-          color: (token as any).colorPrimaryDisabled,
+          color: token.colorPrimaryDisabled,
         },
       },
-
-      // Solid variant
       [`&${itemCls}-solid`]: {
-        background: (token as any).itemSolidBg ?? token.colorFillTertiary,
+        background: token.itemSolidBg,
         [`&${itemCls}-disabled`]: {
           background: token.colorBgContainerDisabled,
         },
         [`&${itemCls}-click:not(${itemCls}-error):hover`]: {
-          background: (token as any).itemSolidHoverBg,
+          background: token.itemSolidHoverBg,
         },
         [`&${itemCls}-error:not(${itemCls}-disabled)`]: {
           background: token.colorErrorBg,
         },
         [`&${itemCls}-error:where(${itemCls}-disabled)`]: {
-          background: (token as any).colorErrorBgDisabled,
+          background: token.colorErrorBgDisabled,
         },
       },
-
-      // Outlined variant
       [`&${itemCls}-outlined`]: {
         paddingBlock: token.paddingXXS,
-        backgroundColor:
-          (token as any).itemOutlinedBg ?? token.colorBgContainer,
+        backgroundColor: token.itemOutlinedBg,
         borderWidth: token.lineWidth,
         borderStyle: token.lineType,
         borderColor: token.colorBorder,
@@ -114,32 +96,28 @@ const genItemStyle: GenerateStyle<ThoughtChainItemToken> = token => {
         },
         [`&${itemCls}-error:where(${itemCls}-disabled)`]: {
           borderColor: token.colorErrorBorder,
-          background: (token as any).colorErrorBgDisabled,
+          background: token.colorErrorBgDisabled,
         },
         [`&${itemCls}-click:not(${itemCls}-error):hover`]: {
-          background: (token as any).itemOutlinedHoverBg,
+          background: token.itemOutlinedHoverBg,
         },
       },
-
-      // Text variant
       [`&${itemCls}-text`]: {
         [`&${itemCls}-click:not(${itemCls}-error):hover`]: {
-          background: (token as any).itemSolidHoverBg,
+          background: token.itemSolidHoverBg,
         },
       },
-
-      // Error state
       [`&${itemCls}-error`]: {
         [`&:not(${itemCls}-disabled)`]: {
           color: token.colorErrorText,
           [`${itemCls}-description`]: {
-            color: (token as any).colorErrorTextDescription,
+            color: token.colorErrorTextDescription,
           },
         },
         [`&:where(${itemCls}-disabled)`]: {
-          color: (token as any).colorErrorTextDisabled,
+          color: token.colorErrorTextDisabled,
           [`${itemCls}-description`]: {
-            color: (token as any).colorErrorTextDescriptionDisabled,
+            color: token.colorErrorTextDescriptionDisabled,
           },
         },
         [`&${itemCls}-click:hover`]: {
@@ -150,4 +128,4 @@ const genItemStyle: GenerateStyle<ThoughtChainItemToken> = token => {
   };
 };
 
-export default genItemStyle;
+export default genThoughtChainItemStyle;

--- a/packages/x/components/thought-chain/style/item.ts
+++ b/packages/x/components/thought-chain/style/item.ts
@@ -21,7 +21,7 @@ const genItemStyle: GenerateStyle<ThoughtChainItemToken> = token => {
       boxSizing: "border-box",
       lineHeight: token.lineHeight,
       borderRadius: token.borderRadius,
-      alignItems: "center",
+      alignItems: "baseline",
 
       [`&${itemCls}-rtl`]: {
         direction: "rtl",

--- a/packages/x/components/thought-chain/style/thought-chain.ts
+++ b/packages/x/components/thought-chain/style/thought-chain.ts
@@ -29,7 +29,7 @@ const genThoughtChainStyle: GenerateStyle<ThoughtChainToken> = token => {
       [`${componentCls}-node`]: {
         position: "relative",
         display: "flex",
-        alignItems: "baseline",
+        alignItems: "center",
         gap: token.marginSM,
 
         // Status colors inside node

--- a/packages/x/components/thought-chain/style/thought-chain.ts
+++ b/packages/x/components/thought-chain/style/thought-chain.ts
@@ -1,21 +1,20 @@
+import type { CSSObject } from "@antdv-next/cssinjs";
+
 import { unit } from "@antdv-next/cssinjs";
 
 import type { FullToken, GenerateStyle } from "../../theme/interface";
 
 export interface ThoughtChainToken extends FullToken<"ThoughtChain"> {}
 
-const genThoughtChainStyle: GenerateStyle<ThoughtChainToken> = token => {
+const genThoughtChainStyle: GenerateStyle<ThoughtChainToken, CSSObject> = (
+  token,
+): CSSObject => {
   const { componentCls, calc } = token;
-  const iconSize = (token as any).iconSize ?? token.fontSize;
-
   return {
     [componentCls]: {
-      // Root box
       [`&${componentCls}-box`]: {
         display: "flex",
         flexDirection: "column",
-
-        // Last node: hide connector line
         [`& ${componentCls}-node:last-of-type`]: {
           [`> ${componentCls}-node-icon`]: {
             "&:after": {
@@ -24,15 +23,11 @@ const genThoughtChainStyle: GenerateStyle<ThoughtChainToken> = token => {
           },
         },
       },
-
-      // Node
       [`${componentCls}-node`]: {
         position: "relative",
         display: "flex",
         alignItems: "baseline",
         gap: token.marginSM,
-
-        // Status colors inside node
         [`${componentCls}-status-error`]: {
           color: token.colorError,
         },
@@ -43,90 +38,62 @@ const genThoughtChainStyle: GenerateStyle<ThoughtChainToken> = token => {
           color: token.colorPrimary,
         },
       },
-
-      // Header (column layout: title above description)
       [`${componentCls}-node-header`]: {
         display: "flex",
         flexDirection: "column",
       },
-
-      // Title
       [`${componentCls}-node-title`]: {
         fontWeight: 500,
         display: "flex",
         gap: token.marginXS,
       },
-
-      // Collapsible title
       [`${componentCls}-node-collapsible`]: {
         paddingInlineEnd: token.padding,
         cursor: "pointer",
       },
-
-      // Footer
       [`${componentCls}-node-footer`]: {
         marginBottom: token.margin,
       },
-
-      // Content box
       [`${componentCls}-node-content-box`]: {
         marginBottom: token.margin,
       },
-
-      // Collapse icon
       [`${componentCls}-node-collapse-icon`]: {
         "& svg": {
           transition: `transform ${token.motionDurationMid} ${token.motionEaseInOut}`,
         },
       },
-
-      // Description
       [`${componentCls}-node-description`]: {
         color: token.colorTextDescription,
         fontSize: token.fontSize,
         lineHeight: token.lineHeight,
         marginBlockEnd: token.margin,
       },
-
-      // Icon container with connector line
       [`${componentCls}-node-icon`]: {
         lineHeight: 1,
-        fontSize: iconSize,
-
+        fontSize: token.iconSize,
         "&:after": {
           content: '""',
           position: "absolute",
           height: unit(
-            calc("100%").sub(calc(iconSize).mul(token.lineHeight)).equal(),
+            calc("100%")
+              .sub(calc(token.iconSize).mul(token.lineHeight))
+              .equal(),
           ),
           borderInlineStart: `${unit(token.lineWidth)} solid ${token.colorFillContent}`,
-          insetInlineStart: unit(calc(iconSize).sub(1).div(2).equal()),
-          top: unit(calc(iconSize).mul(token.lineHeight).equal()),
+          insetInlineStart: unit(calc(token.iconSize).sub(1).div(2).equal()),
+          top: unit(calc(token.iconSize).mul(token.lineHeight).equal()),
         },
       },
-
-      // Hidden line
-      [`${componentCls}-node-icon-none`]: {
-        "&:after": {
-          display: "none",
-        },
-      },
-
-      // Dashed line
       [`${componentCls}-node-icon-dashed`]: {
         "&:after": {
           borderInlineStart: `${unit(token.lineWidth)} dashed ${token.colorFillContent}`,
         },
       },
-
-      // Dotted line
       [`${componentCls}-node-icon-dotted`]: {
         "&:after": {
           borderInlineStart: `${unit(token.lineWidth)} dotted ${token.colorFillContent}`,
         },
       },
-
-      // Default index icon (numbered circle)
       [`${componentCls}-node-index-icon`]: {
         display: "inline-flex",
         alignItems: "center",
@@ -134,37 +101,17 @@ const genThoughtChainStyle: GenerateStyle<ThoughtChainToken> = token => {
         lineHeight: 1,
         color: token.colorTextSecondary,
         fontSize: token.fontSizeSM,
-        width: iconSize,
-        height: iconSize,
+        width: token.iconSize,
+        height: token.iconSize,
         backgroundColor: token.colorFillContent,
-        borderRadius: unit(calc(iconSize).div(2).equal()),
+        borderRadius: unit(calc(token.iconSize).div(2).equal()),
       },
-
-      // Status
-      [`${componentCls}-status`]: {
-        display: "inline-flex",
-        alignItems: "center",
-        fontSize: iconSize,
-      },
-
-      [`${componentCls}-status-abort`]: {
-        color: token.colorTextQuaternary,
-      },
-
-      // Collapse transition
-      [`${componentCls}-collapse-enter-active, ${componentCls}-collapse-leave-active`]:
-        {
-          transition: `height ${token.motionDurationMid} ${token.motionEaseInOut}, opacity ${token.motionDurationMid} ${token.motionEaseInOut}`,
-          overflow: "hidden",
-        },
-
-      // RTL
       [`&${componentCls}-rtl`]: {
         direction: "rtl",
         [`${componentCls}-node-icon`]: {
           "&:after": {
             insetInlineStart: "unset",
-            insetInlineEnd: unit(calc(iconSize).sub(1).div(2).equal()),
+            insetInlineEnd: unit(calc(token.iconSize).sub(1).div(2).equal()),
           },
         },
       },

--- a/packages/x/components/thought-chain/style/thought-chain.ts
+++ b/packages/x/components/thought-chain/style/thought-chain.ts
@@ -29,7 +29,7 @@ const genThoughtChainStyle: GenerateStyle<ThoughtChainToken> = token => {
       [`${componentCls}-node`]: {
         position: "relative",
         display: "flex",
-        alignItems: "center",
+        alignItems: "baseline",
         gap: token.marginSM,
 
         // Status colors inside node


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🛠 Refactoring
- [x] 💄 Component style improvement

### 🔗 Related Issues

Related to https://x.antdv-next.cn/components/thought-chain#thought-chain-demo-simple
Upstream reference: `/Users/carl/Desktop/oss/x/packages/x/components/thought-chain/style`

### 💡 Background and Solution

**Problem:** `antdv-next/x` 的 `thought-chain` 样式与上游 `oss/x` (`ant-design/x`) 不完全对齐，存在额外/缺失的 token 与样式块，且文件拆分导致对比困难。

**Solution:** 严格对齐 `oss/x`，不新增/不删除样式逻辑：

- `style/item.ts`: 同步为 `token.itemBorderRadius`、`token.itemMotionDescription`、`token.itemSolidBg` 等，与 `oss/x/style/item.ts` 一致（`alignItems` 保持 `baseline` 与上游一致）
- `style/thought-chain.ts`: `genThoughtChainStyle` 与 `oss/x/style/index.ts:100-204` 完全一致，移除多余的 `status`/`status-abort`/`collapse` 块（上游本没有）
- `style/index.ts`: `prepareComponentToken` 补全 `titleFontSize/descriptionFontSize/nodePadding/titleFontWeight/borderColor/borderWidth/connectorColor/connectorWidth/hoverTransitionDuration`，`ComponentToken` 注释与上游一致；`genStyleHooks` 去掉 `as any`

文件结构差异：`oss/x` 为 2 文件（`index.ts` 含 `genThoughtChainStyle`），`antdv-next` 为 3 文件（`thought-chain.ts` 单拆），内容已合并对齐，生成 CSS 一致。按“不要新增/删除”保留 3 文件结构。

**Note:** 本 PR 仅做严格对齐，未包含 `baseline → center` 的居中修复。如需修复 `simple` demo 图标偏低，可在此 PR 后另提 `baseline → center`（会与上游暂时不一致，待上游同步）。

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Chore: strictly align ThoughtChain styles with upstream oss/x |
| 🇨🇳 Chinese |  chore：严格对齐 ThoughtChain 样式与上游 oss/x |
