### PR TITLE
chore: record ant-design-x sync status (2.9.0)

### DIFF
--- a/.sync-upstream.json
+++ b/.sync-upstream.json
@@ -45,9 +45,9 @@
       ],
       "last_synced_commit": "25aad7b9c13abeb165466d53b375d0f2ffe81fa0",
       "last_synced_commit_short": "25aad7b9",
-      "last_synced_at": "2026-08-19T02:39:21Z",
+      "last_synced_at": "2026-08-29T03:39:41Z",
       "last_synced_tag": "2.9.0",
-      "sync_count": 2
+      "sync_count": 3
     }
   ]
 }


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [x] ❓ Other (sync status record)

### 🔗 Related Issues

> N/A. Routine ant-design/x synchronization check (see `.sync-upstream.json`).

### 💡 Background and Solution

> - Record the latest ant-design/x synchronization check for tag `2.9.0`.
> - Confirm upstream HEAD remains at `25aad7b9` (tag `2.9.0`): no new commits since the last sync, so no code port is required this cycle; Sender clipboard behavior is already present on `main` (PR #194).
> - Drop the per-cycle `.sync-report.md`; `.sync-upstream.json` remains the single source of sync state.
> - Validation: `vp test packages/x/components/sender/__tests__/index.test.tsx --run` (121 passed); `vp check --fix` (pre-commit).

### 📝 Change Log

> - Read [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)! Track your changes, like a cat tracks a laser pointer.
> - Describe the impact of the changes on developers, not the solution approach.

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Record ant-design/x sync status for `2.9.0`; no upstream code changes to port this cycle. |
| 🇨🇳 Chinese | 记录 ant-design/x `2.9.0` 同步状态；本轮无需要移植的上游代码变更。 |
