### PR TITLE
fix(docs): optimize playground URL — use ?x=1 param and slim hash payload

### DIFF
--- a/packages/docs/src/components/doc-demo/playground.ts
+++ b/packages/docs/src/components/doc-demo/playground.ts
@@ -1,117 +1,18 @@
-export const baseConfig = {
-  "App.vue": "",
-  "antdv-next-x.js": `import Antdv from "antdv-next";
-import AntdvX from "@antdv-next/x";
-import { getCurrentInstance } from "vue";
+/**
+ * 为 X 文档站生成 Playground 链接。
+ *
+ * 协议与 antdv-next-playground 的 store.ts 对齐:
+ * - hash 负载只含 `src/App.vue` + `_o` 选项(xEnabled: true)
+ * - Playground 端根据 `?x=1` 和 `_o.xEnabled` 自动注册 X 组件 & import map
+ * - 编码使用 `utoa`(encodeURIComponent + btoa),与 Playground 反序列化一致
+ */
 
-let installed = false;
-await loadStyle();
-
-export function setupAntdvNextX() {
-  if (installed) return;
-  const instance = getCurrentInstance();
-  instance.appContext.app.use(Antd);
-  instance.appContext.app.use(AntdvX);
-  installed = true;
+function utoa(data: string): string {
+  return btoa(unescape(encodeURIComponent(data)));
 }
-
-export function loadStyle() {
-  const styles = [
-    "https://cdn.jsdelivr.net/npm/antdv-next@latest/dist/reset.css",
-    "https://cdn.jsdelivr.net/npm/antdv-next@latest/dist/antd.css",
-    "https://cdn.jsdelivr.net/npm/@antdv-next/x@latest/dist/index.css",
-  ].map(style => {
-    return new Promise((resolve, reject) => {
-      const link = document.createElement("link");
-      link.rel = "stylesheet";
-      link.href = style;
-      link.addEventListener("load", resolve);
-      link.addEventListener("error", reject);
-      document.body.append(link);
-    });
-  });
-  return Promise.allSettled(styles);
-}
-`,
-  "tsconfig.json": `{
-  "compilerOptions": {
-    "target": "ESNext",
-    "jsx": "preserve",
-    "module": "ESNext",
-    "moduleResolution": "Bundler",
-    "types": ["antdv-next/global.d.ts"],
-    "allowImportingTsExtensions": true,
-    "allowJs": true,
-    "checkJs": true
-  },
-  "vueCompilerOptions": {
-    "target": 3.3
-  }
-}
-`,
-  "PlaygroundMain.vue": `<script setup>
-import { theme } from "antdv-next";
-import { computed, onMounted, onUnmounted, ref } from "vue";
-import { setupAntdvNextX } from "./antdv-next-x.js";
-import App from "./App.vue";
-setupAntdvNextX();
-
-const { darkAlgorithm, defaultAlgorithm } = theme;
-const isDark = ref(document.documentElement.classList.contains("dark"));
-
-const themeConfig = computed(() => ({
-  algorithm: isDark.value ? darkAlgorithm : defaultAlgorithm,
-}));
-
-let observer;
-onMounted(() => {
-  observer = new MutationObserver(() => {
-    isDark.value = document.documentElement.classList.contains("dark");
-  });
-  observer.observe(document.documentElement, {
-    attributes: true,
-    attributeFilter: ["class"],
-  });
-});
-onUnmounted(() => observer?.disconnect());
-</script>
-
-<template>
-  <a-config-provider :theme="themeConfig">
-    <App />
-  </a-config-provider>
-</template>
-`,
-  "import-map.json": `{
-  "imports": {
-     "vue": "https://cdn.jsdelivr.net/npm/@vue/runtime-dom@latest/dist/runtime-dom.esm-browser.js",
-    "@vue/shared": "https://cdn.jsdelivr.net/npm/@vue/shared@latest/dist/shared.esm-bundler.js",
-    "@antdv-next/x": "https://cdn.jsdelivr.net/npm/@antdv-next/x@latest/es/antdv-next-x.esm.js",
-    "@antdv-next/x/": "https://cdn.jsdelivr.net/npm/@antdv-next/x/@latest/",
-    "@antdv-next/x-markdown": "https://cdn.jsdelivr.net/npm/@antdv-next/x-markdown@latest/dist/index.js",
-    "@antdv-next/x-markdown/themes/": "https://cdn.jsdelivr.net/npm/@antdv-next/x-markdown@latest/themes/",
-    "@antdv-next/x-markdown/": "https://cdn.jsdelivr.net/npm/@antdv-next/x-markdown@latest/",
-    "marked": "https://cdn.jsdelivr.net/npm/marked@12.0.2/lib/marked.esm.js",
-    "dompurify": "https://cdn.jsdelivr.net/npm/dompurify@3.3.3/dist/purify.es.mjs",
-    "antdv-next": "https://cdn.jsdelivr.net/npm/antdv-next@latest/dist/antd.esm.js",
-    "antdv-next/": "https://cdn.jsdelivr.net/npm/antdv-next/@latest/",
-    "@antdv-next/icons": "https://cdn.jsdelivr.net/npm/@antdv-next/icons@latest/dist/antd-icons.esm.js"
-  },
-  "scopes": {}
-}`,
-  _o: {},
-};
-
-function toBase64(str: string) {
-  const bytes = new TextEncoder().encode(str);
-  let binary = "";
-  bytes.forEach(byte => {
-    binary += String.fromCharCode(byte);
-  });
-  return btoa(binary);
-}
-
 export function loadPlaygroundUrl(code: string) {
+  const baseUrl = "https://play.antdv-next.com/";
+
   const defaultCode = `<script setup lang="ts">
 import { version as vueVersion } from "vue";
 
@@ -123,6 +24,11 @@ const message = "Hello Antdv Next X";
 </template>
 `;
 
-  baseConfig["App.vue"] = code || defaultCode;
-  return `https://x-play.antdv-next.com/#${toBase64(JSON.stringify(baseConfig))}`;
+  const state: Record<string, any> = {
+    "src/App.vue": code || defaultCode,
+    _o: { xEnabled: true },
+  };
+
+  const hash = utoa(JSON.stringify(state));
+  return `${baseUrl}?x=1#${hash}`;
 }


### PR DESCRIPTION
### 🤔 This is a ...

- [x] ⚡️ Performance optimization
- [x] 🛠 Refactoring

### 🔗 Related Issues

> 优化 X 文档站"在 Playground 中打开"链接的生成方式，与 antdv-next-playground 的序列化协议对齐。
> 同步改造，参考 antdv-next-pro 侧 PR: https://github.com/antdv-next/antdv-next-pro/pull/13

### 💡 Background and Solution

> **问题：** 当前从 X 文档站点击"在 Playground 中打开"时，生成的 URL hash 中内联了 5 个硬编码文件（`antdv-next-x.js`、`PlaygroundMain.vue`、`import-map.json`、`tsconfig.json`、`App.vue`），导致 URL 非常长（~4KB base64）。同时 `import-map.json` 中所有依赖版本锁死 `@latest`，无法跟随用户在 Playground 中切换的版本。也没有告诉 Playground 需要启用 X 组件。
>
> **方案：** 参考 `antdv-next-playground` 的 `store.ts` 序列化协议进行优化：
>
> 1. **精简 hash 负载** — 只序列化 `src/App.vue` + `_o: { xEnabled: true }`，其余文件由 Playground 端根据 feature flags 自动生成
> 2. **添加 `?x=1` 查询参数** — 让 Playground 自动启用 X 组件注册和 import map（对接 Playground 端已有的 `paramFlag('x', false)` 逻辑）
> 3. **统一编码方式** — 使用与 Playground 一致的 `utoa`（`encodeURIComponent` + `btoa`），解决 Unicode 兼容性问题
>
> | 项目 | 优化前 | 优化后 |
> |------|--------|--------|
> | Hash 负载大小 | ~4KB（5个文件） | ~200B-1KB（仅 App.vue + `_o`） |
> | X 组件支持 | ❌ 硬编码 import map | ✅ `?x=1` + `_o.xEnabled` |
> | 编码方式 | `TextEncoder` + `btoa` | `utoa`（与 Playground 一致） |

### 📝 Change Log

| Language   | Changelog |
| ---------- | --------- |
| 🇺🇸 English | Optimized "Open in Playground" URL generation: slimmed hash payload from ~4KB to <1KB, added `?x=1` query param for automatic X component activation, aligned encoding with Playground protocol. |
| 🇨🇳 Chinese | 优化"在 Playground 中打开"链接生成：hash 负载从 ~4KB 精简至 <1KB，添加 `?x=1` 参数自动启用 X 组件，编码方式与 Playground 对齐。 |