### PR TITLE
fix(docs): add dark mode text and border color tokens for custom blocks

### DIFF
--- a/packages/docs/src/assets/styles/common.css
+++ b/packages/docs/src/assets/styles/common.css
@@ -35,6 +35,7 @@ html.dark {
 html.dark,
 html.dark body {
   background: var(--ant-color-bg-layout, #000);
+  color: var(--ant-color-text, rgba(255, 255, 255, 0.85));
 }
 
 .custom-carousel-item {

--- a/packages/docs/src/assets/styles/markdown/vars.css
+++ b/packages/docs/src/assets/styles/markdown/vars.css
@@ -157,6 +157,12 @@
   --vp-c-gutter: var(--ant-color-split, #e2e2e3);
 }
 
+.dark {
+  --vp-c-border: var(--ant-color-border-secondary, #303030);
+  --vp-c-divider: var(--ant-color-split, rgba(253, 253, 253, 0.12));
+  --vp-c-gutter: var(--ant-color-split, rgba(253, 253, 253, 0.12));
+}
+
 /**
  * Colors: Text
  *
@@ -171,6 +177,12 @@
   --vp-c-text-1: var(--ant-color-text, rgba(0, 0, 0, 0.88));
   --vp-c-text-2: var(--ant-color-text-secondary, rgba(0, 0, 0, 0.65));
   --vp-c-text-3: var(--ant-color-text-tertiary, rgba(0, 0, 0, 0.45));
+}
+
+.dark {
+  --vp-c-text-1: var(--ant-color-text, rgba(255, 255, 255, 0.85));
+  --vp-c-text-2: var(--ant-color-text-secondary, rgba(255, 255, 255, 0.65));
+  --vp-c-text-3: var(--ant-color-text-tertiary, rgba(255, 255, 255, 0.45));
 }
 
 /**


### PR DESCRIPTION
## Description

In dark mode, markdown custom containers (such as `:::info` in contributing doc) did not have dark mode text color tokens defined in `vars.css` (`--vp-c-text-1`, `--vp-c-text-2`, `--vp-c-text-3`), causing them to fallback to `rgba(0, 0, 0, 0.88)` which was illegible on dark backgrounds.

This PR adds:
- `.dark` mode definitions for `--vp-c-text-1`, `--vp-c-text-2`, and `--vp-c-text-3` in `vars.css`
- `.dark` mode definitions for `--vp-c-border`, `--vp-c-divider`, and `--vp-c-gutter` in `vars.css`
- `color: var(--ant-color-text, rgba(255, 255, 255, 0.85));` on `html.dark, html.dark body` in `common.css`

## Related Issue / Links
- https://x.antdv-next.com/docs/contributing
