### PR TITLE
fix(docs): resolve escape-carriage named export and avoid scan false-positives

### DIFF
--- a/packages/docs/src/compat/escape-carriage.ts
+++ b/packages/docs/src/compat/escape-carriage.ts
@@ -1,0 +1,65 @@
+/**
+ * ESM compatibility layer for escape-carriage.
+ * The upstream escape-carriage package is CommonJS with `module.exports = fn; module.exports.escapeCarriageReturn = fn;`,
+ * which breaks in Vite when imported with named imports: `import { escapeCarriageReturn } from 'escape-carriage'` (used by ansi-to-vue3).
+ */
+export function escapeCarriageReturn(txt: string): string {
+  if (!txt) return "";
+  if (!/\r/.test(txt)) return txt;
+  let result = txt.replace(/\r+\n/gm, "\n");
+  while (/\r./.test(result)) {
+    result = result.replace(/^([^\r\n]*)\r+([^\r\n]+)/gm, (_, base, insert) => {
+      return insert + base.slice(insert.length);
+    });
+  }
+  return result;
+}
+
+function findLongestString(arr: string[]): number {
+  let longest = 0;
+  for (let i = 0; i < arr.length; i++) {
+    const current = arr[i];
+    const best = arr[longest];
+    if (
+      current !== undefined &&
+      best !== undefined &&
+      best.length <= current.length
+    ) {
+      longest = i;
+    }
+  }
+  return longest;
+}
+
+export function escapeSingleLineSafe(txt: string): string {
+  if (!/\r/.test(txt)) return txt;
+  let arr = txt.split("\r");
+  const res: string[] = [];
+
+  while (arr.length > 0) {
+    const longest = findLongestString(arr);
+    const item = arr[longest];
+    if (item !== undefined) {
+      res.push(item);
+    }
+    arr = arr.slice(longest + 1);
+  }
+
+  return res.join("\r");
+}
+
+export function escapeCarriageReturnSafe(txt: string): string {
+  if (!txt) return "";
+  if (!/\r/.test(txt)) return txt;
+  if (!/\n/.test(txt)) return escapeSingleLineSafe(txt);
+  const normalized = txt.replace(/\r+\n/gm, "\n");
+  const idx = normalized.lastIndexOf("\n");
+
+  return (
+    escapeCarriageReturn(normalized.slice(0, idx)) +
+    "\n" +
+    escapeSingleLineSafe(normalized.slice(idx + 1))
+  );
+}
+
+export default escapeCarriageReturn;

--- a/packages/docs/src/pages/components/code-highlighter/demo/custom-header.vue
+++ b/packages/docs/src/pages/components/code-highlighter/demo/custom-header.vue
@@ -2,10 +2,12 @@
 import { App } from "antdv-next";
 import { ref } from "vue";
 
-const code = `import { createApp } from "vue";
-import App from "./App.vue";
-
-createApp(App).mount("#app");`;
+const code = [
+  'import { createApp } from "vue";',
+  'import App from "./App.vue";',
+  "",
+  'createApp(App).mount("#app");',
+].join("\n");
 
 const theme = ref<"light" | "dark">("light");
 

--- a/packages/docs/src/pages/components/code-highlighter/demo/lazy-language.vue
+++ b/packages/docs/src/pages/components/code-highlighter/demo/lazy-language.vue
@@ -24,7 +24,9 @@ const snippets = {
     label: "Go",
     code: `package main
 
-import "fmt"
+import (
+    "fmt"
+)
 
 func main() {
     names := []string{"Alice", "Bob"}

--- a/packages/docs/src/pages/components/code-highlighter/demo/theme.vue
+++ b/packages/docs/src/pages/components/code-highlighter/demo/theme.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
 import { ref } from "vue";
 
-const code = `import { createApp } from 'vue';
-import App from './App.vue';
-
-const app = createApp(App);
-app.mount('#app');`;
+const code = [
+  "import { createApp } from 'vue';",
+  "import App from './App.vue';",
+  "",
+  "const app = createApp(App);",
+  "app.mount('#app');",
+].join("\n");
 
 const theme = ref<"light" | "dark">("light");
 </script>

--- a/packages/docs/vite.config.ts
+++ b/packages/docs/vite.config.ts
@@ -48,6 +48,12 @@ export default defineConfig({
     manifest: true,
     modulePreload: false,
   },
+  optimizeDeps: {
+    include: [
+      "escape-carriage",
+      "sandpack-vue3 > ansi-to-vue3 > escape-carriage",
+    ],
+  },
   resolve: {
     dedupe: [
       "vue",
@@ -74,6 +80,9 @@ export default defineConfig({
       ),
       "@antdv-next/x-markdown": fileURLToPath(
         new URL("../x-markdown/src", import.meta.url),
+      ),
+      "escape-carriage": fileURLToPath(
+        new URL("./src/compat/escape-carriage.ts", import.meta.url),
       ),
     },
   },


### PR DESCRIPTION
## Description

Fixes browser runtime error:
`Uncaught SyntaxError: The requested module '/@fs/.../escape-carriage/index.js' does not provide an export named 'escapeCarriageReturn'`

### Cause
1. `sandpack-vue3` $\rightarrow$ `ansi-to-vue3` uses named import: `import { escapeCarriageReturn } from 'escape-carriage'`.
2. Upstream `escape-carriage` is CJS (`module.exports = fn; module.exports.escapeCarriageReturn = fn`), which lacks static named exports when loaded in native browser ESM.
3. During Vite dependency scanning, code strings containing `import ... from './App.vue'` and `import "fmt"` in `code-highlighter` demos were matched by Vite's naive scan regex, causing `Failed to run dependency scan. Skipping dependency pre-bundling.` This forced Vite to bypass pre-bundling completely and serve raw CJS to the browser.

### Solution
1. Add an ESM compatibility layer `src/compat/escape-carriage.ts` providing both default and named exports (`escapeCarriageReturn`, `escapeCarriageReturnSafe`), aliased in `vite.config.ts`.
2. Configure `optimizeDeps.include` in `vite.config.ts`.
3. Adjust string templates in `code-highlighter` demos to prevent false-positive static import detection during Vite dependency scan.
