### PR TITLE
fix(sender): forward icon slots through action buttons (#202)

### DIFF
--- a/packages/docs/src/pages/components/sender/index.en-US.md
+++ b/packages/docs/src/pages/components/sender/index.en-US.md
@@ -97,14 +97,25 @@ type SpeechConfig = {
 };
 ```
 
-```typescript
+````typescript
 type ActionsComponents = {
   SendButton: DefineComponent<ButtonProps>;
   ClearButton: DefineComponent<ButtonProps>;
   LoadingButton: DefineComponent<ButtonProps>;
   SpeechButton: DefineComponent<ButtonProps>;
 };
-```
+
+All four button components above forward both the `icon` slot and the `icon` prop. The slot takes precedence over the prop; either overrides the built-in icon:
+
+```vue
+<template #suffix="{ components }">
+  <component :is="components.SendButton">
+    <template #icon>
+      <SomeOutlined />
+    </template>
+  </component>
+</template>
+````
 
 ### Slots
 

--- a/packages/docs/src/pages/components/sender/index.zh-CN.md
+++ b/packages/docs/src/pages/components/sender/index.zh-CN.md
@@ -106,6 +106,18 @@ type ActionsComponents = {
 };
 ```
 
+以上四个按钮组件均支持透传 `icon` 插槽与 `icon` 属性，插槽优先于属性，均会覆盖内置图标：
+
+```vue
+<template #suffix="{ components }">
+  <component :is="components.SendButton">
+    <template #icon>
+      <SomeOutlined />
+    </template>
+  </component>
+</template>
+```
+
 ### Slots
 
 | 插槽名   | 说明                 | 类型                                         |

--- a/packages/x/components/sender/__tests__/icon-slot.test.tsx
+++ b/packages/x/components/sender/__tests__/icon-slot.test.tsx
@@ -1,0 +1,106 @@
+import { OpenAIOutlined } from "@antdv-next/icons";
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import { defineComponent, h, type VNodeChild } from "vue";
+
+import type { ActionsComponents } from "../interface";
+
+import Sender from "..";
+
+const ARROW_PATH = "M868 545.5L536.1 163";
+
+const Host = defineComponent({
+  name: "Host",
+  setup(_, { slots }) {
+    return () => <Sender>{{ suffix: slots.suffix }}</Sender>;
+  },
+});
+
+type SenderLayoutSlotInfo = {
+  defaultNode: VNodeChild;
+  components: ActionsComponents;
+};
+
+const withIconSlot =
+  (name: keyof ActionsComponents) =>
+  ({ components }: SenderLayoutSlotInfo) => {
+    const Button = components[name];
+    return <Button>{{ icon: () => h(OpenAIOutlined) }}</Button>;
+  };
+
+describe("Sender action button icon customization (#202)", () => {
+  it("SendButton icon slot overrides the default arrow", () => {
+    const wrapper = mount(Host, {
+      slots: { suffix: withIconSlot("SendButton") },
+    });
+
+    const btn = wrapper.find(".antd-sender-actions-btn");
+    expect(btn.exists()).toBe(true);
+    expect(btn.html()).toContain("anticon-open-a-i");
+    expect(btn.html()).not.toContain(ARROW_PATH);
+  });
+  it("SendButton icon prop still overrides the default arrow", () => {
+    const iconPropRender = ({ components }: SenderLayoutSlotInfo) => (
+      <components.SendButton type="primary" icon={h(OpenAIOutlined)} />
+    );
+    const wrapper = mount(Host, { slots: { suffix: iconPropRender } });
+
+    const btn = wrapper.find(".antd-sender-actions-btn");
+    expect(btn.html()).toContain("anticon-open-a-i");
+    expect(btn.html()).not.toContain(ARROW_PATH);
+  });
+
+  it("SendButton without icon slot keeps the default arrow", () => {
+    const plainRender = ({ components }: SenderLayoutSlotInfo) => (
+      <components.SendButton type="primary" />
+    );
+    const wrapper = mount(Host, { slots: { suffix: plainRender } });
+
+    const btn = wrapper.find(".antd-sender-actions-btn");
+    expect(btn.html()).toContain(ARROW_PATH);
+  });
+
+  it("ClearButton icon slot overrides the default clear icon", () => {
+    const wrapper = mount(Host, {
+      slots: { suffix: withIconSlot("ClearButton") },
+    });
+
+    const btn = wrapper.find(".antd-sender-actions-btn");
+    expect(btn.html()).toContain("anticon-open-a-i");
+    expect(btn.html()).not.toContain("anticon-clear");
+  });
+
+  it("LoadingButton icon slot overrides the default stop icon", () => {
+    const wrapper = mount(
+      defineComponent({
+        setup() {
+          return () => (
+            <Sender loading>{{ suffix: withIconSlot("LoadingButton") }}</Sender>
+          );
+        },
+      }),
+    );
+
+    const btn = wrapper.find(".antd-sender-actions-btn-loading-button");
+    expect(btn.exists()).toBe(true);
+    expect(btn.html()).toContain("anticon-open-a-i");
+  });
+
+  it("SpeechButton icon slot overrides the default audio icon", () => {
+    const wrapper = mount(
+      defineComponent({
+        setup() {
+          return () => (
+            <Sender allowSpeech>
+              {{ suffix: withIconSlot("SpeechButton") }}
+            </Sender>
+          );
+        },
+      }),
+    );
+
+    const btn = wrapper.find(".antd-sender-actions-btn");
+    expect(btn.html()).toContain("anticon-open-a-i");
+    expect(btn.html()).not.toContain("anticon-audio");
+  });
+});

--- a/packages/x/components/sender/components/ActionButton.tsx
+++ b/packages/x/components/sender/components/ActionButton.tsx
@@ -66,7 +66,7 @@ const ActionButton = defineComponent({
       default: undefined,
     },
   },
-  setup(props, { attrs }) {
+  setup(props, { attrs, slots }) {
     const context = useActionButtonContext();
 
     const mergedDisabled = computed(() => {
@@ -102,7 +102,9 @@ const ActionButton = defineComponent({
             }
             (attrs.onClick as any)?.(e);
           }}
-        />
+        >
+          {slots}
+        </Button>
       );
     };
   },

--- a/packages/x/components/sender/components/ClearButton.tsx
+++ b/packages/x/components/sender/components/ClearButton.tsx
@@ -6,9 +6,11 @@ import ActionButton from "./ActionButton";
 export default defineComponent({
   name: "ClearButton",
   inheritAttrs: false,
-  setup(_, { attrs }) {
+  setup(_, { attrs, slots }) {
     return () => (
-      <ActionButton icon={<ClearOutlined />} {...attrs} action="onClear" />
+      <ActionButton icon={<ClearOutlined />} {...attrs} action="onClear">
+        {slots}
+      </ActionButton>
     );
   },
 });

--- a/packages/x/components/sender/components/LoadingButton/index.tsx
+++ b/packages/x/components/sender/components/LoadingButton/index.tsx
@@ -7,7 +7,7 @@ import StopLoadingIcon from "./StopLoading";
 export default defineComponent({
   name: "LoadingButton",
   inheritAttrs: false,
-  setup(_, { attrs }) {
+  setup(_, { attrs, slots }) {
     const context = useActionButtonContext();
 
     return () => {
@@ -25,7 +25,9 @@ export default defineComponent({
             `${prefixCls}-loading-button`,
           ])}
           action="onCancel"
-        />
+        >
+          {slots}
+        </ActionButton>
       );
     };
   },

--- a/packages/x/components/sender/components/SendButton.tsx
+++ b/packages/x/components/sender/components/SendButton.tsx
@@ -6,7 +6,7 @@ import ActionButton from "./ActionButton";
 export default defineComponent({
   name: "SendButton",
   inheritAttrs: false,
-  setup(_, { attrs }) {
+  setup(_, { attrs, slots }) {
     return () => (
       <ActionButton
         icon={<ArrowUpOutlined />}
@@ -14,7 +14,9 @@ export default defineComponent({
         shape="circle"
         {...attrs}
         action="onSend"
-      />
+      >
+        {slots}
+      </ActionButton>
     );
   },
 });

--- a/packages/x/components/sender/components/SpeechButton/index.tsx
+++ b/packages/x/components/sender/components/SpeechButton/index.tsx
@@ -9,7 +9,7 @@ import RecordingIcon from "./RecordingIcon";
 export default defineComponent({
   name: "SpeechButton",
   inheritAttrs: false,
-  setup(_, { attrs }) {
+  setup(_, { attrs, slots }) {
     const context = useActionButtonContext();
 
     const mergedDisabled = computed(() => {
@@ -38,7 +38,9 @@ export default defineComponent({
         color="primary"
         {...attrs}
         action="onSpeech"
-      />
+      >
+        {slots}
+      </ActionButton>
     );
   },
 });


### PR DESCRIPTION
## 问题 / Issue

Fixes #202 — Sender 组件调整图标不生效

## 原因分析 / Root cause

`Sender` 暴露的操作按钮组件链存在插槽丢失问题：

1. `SendButton` / `ClearButton` / `LoadingButton` / `SpeechButton` 均为 `inheritAttrs: false`，仅将 `{...attrs}` 展开透传给 `ActionButton`；
2. `ActionButton` 同样只透传 attrs 与自身 `props.icon` 给 antdv-next 的 `Button`；
3. Vue 的插槽不经过 attrs，用户在 `<components.SendButton>` 上写的 `<template #icon>` 在每一层都被静默丢弃；
4. `Button` 最终只能渲染默认 `icon`（如发送按钮内置的 `ArrowUpOutlined`），所以「调整图标不生效」。

传 `icon` prop（`:icon="h(...)"`）之所以生效，是因为各层未声明该 prop，attrs 展开在显式默认 icon 之后，覆盖了默认值。官方文档 suffix.vue demo 使用的 `#icon` 插槽写法同样是坏的，只是视觉上不明显。

## 修复 / Fix

各层将自身 slots 作为 children 透传（与 `BubbleList` 中 `v-slots` 透传模式一致），让 `Button` 内置的「slot 优先于 prop」解析自然生效：

- `SendButton` / `ClearButton` / `LoadingButton` / `SpeechButton` → `ActionButton`：`{slots}` 作为 JSX children
- `ActionButton` → `Button`：同上

用户 `#icon` 插槽优先覆盖内置图标；`icon` prop 路径保持有效；未提供时保持内置图标不变。

## 验证 / Verification

- 新增 `packages/x/components/sender/__tests__/icon-slot.test.tsx`：覆盖四个按钮的插槽覆盖、prop 覆盖、默认图标三条路径（6 个用例）
- `packages/x` 全量测试通过：53 files / 609 tests
- `vp check` 通过（0 errors；剩余 warning 均为 main 上已有的 x-markdown/x-sdk/x-skill 存量问题，与本 PR 无关）
- 文档：zh-CN / en-US 的 `ActionsComponents` 部分补充了插槽透传说明与示例

| 用法 | 修复前 | 修复后 |
|---|---|---|
| `#icon` 插槽 | ❌ 渲染默认箭头 | ✅ 渲染自定义图标 |
| `:icon` prop | ✅ | ✅ |
| 未传 | 默认图标 | 默认图标（不变） |